### PR TITLE
[WIP] use tailwindcss package to parse class selectors

### DIFF
--- a/__fixtures__/custom.js
+++ b/__fixtures__/custom.js
@@ -6,3 +6,4 @@ tw`content`
 
 tw`font-customFontWeightAsString`
 tw`font-customFontWeightAsNumber`
+tw`form-input`

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,17 @@
         "type-detect": "4.0.8"
       }
     },
+    "@tailwindcss/custom-forms": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz",
+      "integrity": "sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "mini-svg-data-uri": "^1.0.3",
+        "traverse": "^0.6.6"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.5.tgz",
@@ -5102,6 +5113,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
+    },
+    "mini-svg-data-uri": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.1.3.tgz",
+      "integrity": "sha512-EeKOmdzekjdPe53/GdxmUpNgDQFkNeSte6XkJmOBt4BfWL6FQ9G9RtLNh+JMjFS3LhdpSICMIkZdznjiecASHQ==",
       "dev": true
     },
     "minimatch": {
@@ -10749,6 +10766,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "tslib": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -47,10 +47,14 @@
     "chalk": "^3.0.0",
     "dlv": "^1.1.3",
     "dset": "^2.0.1",
+    "postcss": "^7.0.27",
+    "postcss-js": "^2.0.3",
+    "postcss-selector-parser": "^6.0.2",
     "tailwindcss": "^1.2.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.8.3",
+    "@tailwindcss/custom-forms": "^0.2.1",
     "babel-plugin-tester": "^8.0.1",
     "glob-all": "^3.1.0",
     "husky": "^4.2.3",

--- a/plugin.test.js
+++ b/plugin.test.js
@@ -13,7 +13,8 @@ pluginTester({
     babelrc: true
   },
   snapshot: true,
-  tests: glob.sync('__fixtures__/*.js').map(file => ({
+  tests: glob.sync('__fixtures__/custom.js').map(file => ({
+    // tests: glob.sync('__fixtures__/*.js').map(file => ({
     title: path.basename(file),
     code: fs.readFileSync(file, 'utf-8')
   }))

--- a/src/macro.js
+++ b/src/macro.js
@@ -5,14 +5,183 @@ import findIdentifier from './findIdentifier'
 import parseTte from './parseTte'
 import addImport from './addImport'
 import getStyles from './getStyles'
+import { orderByScreens } from './screens'
+import astify from './astify'
 import replaceWithLocation from './replaceWithLocation'
 import resolveConfig from 'tailwindcss/lib/util/resolveConfig'
+import processPlugins from 'tailwindcss/lib/util/processPlugins'
+import prefixSelector from 'tailwindcss/lib/util/prefixSelector'
+import buildMediaQuery from 'tailwindcss/lib/util/buildMediaQuery'
+import cloneNodes from 'tailwindcss/lib/util/cloneNodes'
+import buildSelectorVariant from 'tailwindcss/lib/util/buildSelectorVariant'
+import escapeClassName from 'tailwindcss/lib/util/escapeClassName'
+import corePlugins from 'tailwindcss/lib/corePlugins'
+import substituteTailwindAtRules from 'tailwindcss/lib/lib/substituteTailwindAtRules'
+import evaluateTailwindFunctions from 'tailwindcss/lib/lib/evaluateTailwindFunctions'
+import substituteVariantsAtRules from 'tailwindcss/lib/lib/substituteVariantsAtRules'
 import defaultTailwindConfig from 'tailwindcss/stubs/defaultConfig.stub'
+import postcssJs from 'postcss-js'
+import selectorParser from 'postcss-selector-parser'
+import postcss from 'postcss'
 
 // const UTILS_IMPORT_FILEPATH = 'twin.macro/utils.umd'
 const TW_CONFIG_DEFAULT_FILENAME = 'tailwind.config.js'
 
 export default createMacro(twinMacro, { configName: 'twin' })
+
+function processTailwindPlugins(getConfig) {
+  // TODO: clarify re-evaluation strategy on config change
+  let processedPlugins
+  return function getProcessedPlugins() {
+    if (!processedPlugins) {
+      const config = getConfig()
+      processedPlugins = processPlugins(
+        [...corePlugins(config), ...config.plugins],
+        config
+      )
+    }
+
+    return processedPlugins
+  }
+}
+
+function partiallyProcessTailwindFeatures(getConfig, getProcessedPlugins) {
+  return function(css) {
+    const config = getConfig()
+    const processedPlugins = getProcessedPlugins()
+    // const processedPlugins = processPlugins([...corePlugins({ corePlugins: ['fontWeight', 'fontSize', 'fontStyle', 'textColor', 'backgroundColor'] }), ...config.plugins], config)
+
+    return postcss([
+      substituteTailwindAtRules(config, processedPlugins),
+      evaluateTailwindFunctions(config)
+    ]).process(css)
+  }
+}
+
+// https://github.com/tailwindcss/tailwindcss/blob/af36c6849e3668df0216c3e05bbde3b0921bbac5/src/lib/substituteClassApplyAtRules.js#L30-L32
+function normalizeClassName(className) {
+  return `.${escapeClassName(className.replace(/^\./, ''))}`
+}
+
+function walkToUtilty(css, selector) {
+  let match
+  css.walkRules(rule => {
+    // if (rule.selector.includes('placeholder') && selector.includes('placeholder')) {
+    //   console.log(rule.selector)
+    // }
+    if (
+      !match &&
+      classValueForSelector(rule.selector) === classValueForSelector(selector)
+    ) {
+      match = rule
+      // TODO: we could bail out early here
+      // Unclear whether that indicates error condition
+      // return false
+    }
+  })
+  return match
+}
+
+function parseComposedClassName(config) {
+  return function parseClassName(inputClassName) {
+    const {
+      theme: { screens },
+      separator
+    } = config
+
+    const variants = postcss.list.split(inputClassName, [separator])
+    const utility = variants.pop()
+    const screenName = variants[0]
+
+    const isResponsive = Object.keys(screens).includes(screenName)
+
+    if (isResponsive) {
+      variants.shift()
+    }
+
+    const screen = isResponsive ? screens[screenName] : null
+
+    return {
+      utility,
+      variants,
+      responsive: isResponsive,
+      screen,
+      screenName
+    }
+  }
+}
+
+function variantAtRuleParams(atRule, parsed) {
+  const currentVariantAtRuleParams = postcss.list.comma(atRule.params)
+
+  const hasResponsiveVariant = currentVariantAtRuleParams.includes('responsive')
+  // TODO: this is a fake option, probably should never be used
+  const needsResponsiveWrapper =
+    hasResponsiveVariant &&
+    parsed.responsive &&
+    parsed.useTailwindResponsiveAtRule
+
+  const variantsParams = needsResponsiveWrapper
+    ? currentVariantAtRuleParams
+    : currentVariantAtRuleParams.filter(p => p !== 'responsive')
+
+  if (!hasResponsiveVariant && parsed.responsive) {
+    throw new Error(`Utility ${parsed.utility} is not responsive`)
+  }
+
+  // TODO: can we filter here to be contained in parsed.variants
+  return variantsParams.join(', ')
+}
+
+function classValueForSelector(selector) {
+  return selectorParser(selectors => {
+    return selectors.first.filter(({ type }) => type === 'class').pop().value
+  }).transformSync(selector)
+}
+
+function removeClassNameFromRule(rule, ruleClassName) {
+  // TODO: file issue at https://github.com/postcss/postcss-selector-parser/
+  // processSync does not default `updateSelector` option to `true`
+  return selectorParser(selectors => {
+    selectors.walkClasses(selectorClass => {
+      if (selectorClass.value === ruleClassName) {
+        if (selectorParser.isPseudo(selectorClass.next())) {
+          const pseudoNesting = selectorParser.nesting()
+          selectorClass.parent.insertBefore(selectorClass, pseudoNesting)
+        }
+
+        selectorClass.remove()
+      }
+    })
+  }).processSync(rule, { updateSelector: true })
+}
+
+function getParentForParsedSelector(parsedSelector, root) {
+  if (!parsedSelector.responsive) {
+    return root
+  }
+
+  const screenMediaQueryParams = buildMediaQuery(parsedSelector.screen)
+
+  let parent
+  root.walkAtRules('media', mediaQuery => {
+    if (mediaQuery.params === screenMediaQueryParams) {
+      parent = mediaQuery
+    }
+  })
+
+  if (!parent) {
+    const screenMediaQuery = postcss.atRule({
+      name: 'media',
+      params: screenMediaQueryParams
+    })
+    root.append(screenMediaQuery)
+
+    parent = screenMediaQuery
+  }
+
+  return parent
+}
 
 function twinMacro({ babel: { types: t }, references, state, config }) {
   const sourceRoot = state.file.opts.sourceRoot || '.'
@@ -47,6 +216,127 @@ function twinMacro({ babel: { types: t }, references, state, config }) {
   const tailwindConfig = configExists
     ? resolveConfig([require(configPath), defaultTailwindConfig])
     : resolveConfig([defaultTailwindConfig])
+
+  const getConfig = () => {
+    return tailwindConfig
+  }
+
+  const getProcessedPlugins = processTailwindPlugins(getConfig)
+
+  // TODO: wrap with config HOF
+  function toComposedSelectorVariant(baseClassName, variantPrefixes) {
+    return variantPrefixes.reduce((composedName, variantPrefix) => {
+      return buildSelectorVariant(
+        composedName,
+        variantPrefix,
+        getConfig().separator,
+        console.error
+      )
+    }, baseClassName)
+  }
+
+  const parseClassName = parseComposedClassName(getConfig())
+
+  // Tailwind PostCSS plugins
+  const customTailwindFeaturesPlugin = partiallyProcessTailwindFeatures(
+    getConfig,
+    getProcessedPlugins
+  )
+  const denormalizeVariants = substituteVariantsAtRules(
+    getConfig(),
+    getProcessedPlugins()
+  )
+
+  const template = postcss
+    .root()
+    .append('@tailwind base', '@tailwind components', '@tailwind utilities')
+
+  const sharedTailwindDocument = customTailwindFeaturesPlugin(template)
+  function getUtilityInDocument(document) {
+    return function utilityRuleForSelector(selector) {
+      return walkToUtilty(document.root, selector)
+    }
+  }
+
+  const getSharedUtilityRule = getUtilityInDocument(sharedTailwindDocument)
+
+  function getStylesFromTailwind(tailwindSelectors) {
+    const final = postcss.root()
+
+    for (const selector of tailwindSelectors) {
+      const parsed = parseClassName(selector)
+      const utilityClassName = normalizeClassName(parsed.utility)
+
+      // TODO: might be component?
+      const sharedUtilityRule = getSharedUtilityRule(utilityClassName)
+
+      if (!sharedUtilityRule) {
+        throw new Error(`Unknown utility "${utilityClassName}"`)
+      }
+
+      // TODO: anything else to consider?
+      if (sharedUtilityRule.parent === sharedUtilityRule.root()) {
+        final.append(sharedUtilityRule.clone().nodes)
+        continue
+      }
+
+      const variantsAtRule = sharedUtilityRule.parent
+
+      if (
+        !variantsAtRule ||
+        variantsAtRule.type !== 'atrule' ||
+        variantsAtRule.name !== 'variants'
+      ) {
+        throw new MacroError(
+          `Utility "${utilityClassName}" is not wrapped into "@variant". Please use plugins \`addUtilities\` method.`
+        )
+      }
+
+      const atRuleForUtility = variantsAtRule
+        .clone({
+          params: variantAtRuleParams(variantsAtRule, parsed)
+        })
+        .removeAll()
+
+      // TODO: they are not yet denormalized, only after function call below
+      const denormalizedUtilityVariants = postcss
+        .root()
+        .append(atRuleForUtility.append(sharedUtilityRule.clone()))
+      denormalizeVariants(denormalizedUtilityVariants)
+
+      const denormalizedUtilityVariantSelector = toComposedSelectorVariant(
+        utilityClassName,
+        parsed.variants
+      )
+      const denormalizedUtilityVariantClassName = classValueForSelector(
+        denormalizedUtilityVariantSelector
+      )
+
+      denormalizedUtilityVariants.walkRules(rule => {
+        // TODO: passing whole `rule` should work here, too
+        const ruleClassName = classValueForSelector(rule.selector)
+
+        if (ruleClassName !== denormalizedUtilityVariantClassName) {
+          rule.remove()
+          return
+        }
+
+        const remainingSelector = removeClassNameFromRule(rule, ruleClassName)
+
+        if (remainingSelector) {
+          // This means we keep the nesting
+        } else {
+          rule.replaceWith(rule.nodes)
+        }
+      })
+
+      const parent = getParentForParsedSelector(parsed, final)
+      parent.append(denormalizedUtilityVariants)
+    }
+
+    return final
+  }
+
   state.config = tailwindConfig
 
   if (!tailwindConfig) {
@@ -87,6 +377,16 @@ function twinMacro({ babel: { types: t }, references, state, config }) {
 
   state.debug = config.debug || false
   state.configExists = configExists
+
+  function getStyles(str, t, state) {
+    const order = Object.keys(state.config.theme.screens)
+    const selectors = orderByScreens(postcss.list.space(str), order)
+
+    const styles = postcssJs.objectify(getStylesFromTailwind(selectors))
+
+    const ast = astify(styles, t)
+    return ast
+  }
 
   program.traverse({
     JSXAttribute(path) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,5 +8,21 @@ module.exports = {
         customFontWeightAsNumber: 800
       }
     }
-  }
+  },
+  corePlugins: {
+    preflight: false
+  },
+  plugins: [
+    require('@tailwindcss/custom-forms'),
+    ({ addComponents }) => {
+      addComponents({
+        '.content': {
+          content: '""'
+        },
+        '.clearfix': {
+          '::after': { content: '""', display: 'table', clear: 'both' }
+        }
+      })
+    }
+  ]
 }


### PR DESCRIPTION
This is a draft implementation for #7 

It currently is not rebased on the latest state as I have everything in the `macro.js` file.
I would first need to split up the code into multiple files, and clean up things here and there, but as I promised to already show something towards the weekend I just want to put it out now.

If you tap into the branch and reset the glob for tests you will see a lot of snapshot mismatches, due to `background-something` ➡️ `backgroundSomething`, order of rules (left, right, top, bottom sometimes in different order in `tailwindcss` package). 
How do we want to deal with them? 

## How does it work

1. Prepare the base tailwind style AST'

    Process plugins, inject all the rules into the AST, this is (or should be) shared across multiple `tw` invocations in the same file.

1. Find the utility in use

    Extract the rule and their `@variants` wrappers from the shared AST into its own root.

1. Denormalize copied AST to all available variants

    Variant generators are executed on the utility and the prefixed variant (without responsive prefix) is located.

1. Merge into object

    In a final step the rules from the utility are applied to the root that later is objectified. During this time we either find or create the `@media` rule to append the declarations to.