### PR TITLE
add `clear-node`, `flow-root`, `current` color

### DIFF
--- a/__fixtures__/backgrounds.js
+++ b/__fixtures__/backgrounds.js
@@ -7,6 +7,7 @@ tw`bg-scroll`
 
 // https://tailwindcss.com/docs/background-color
 tw`bg-transparent`
+tw`bg-current`
 tw`bg-black`
 tw`bg-white`
 tw`bg-gray-100`
@@ -126,6 +127,7 @@ tw`bg-contain`
 
 // https://tailwindcss.com/docs/border-color
 tw`border-transparent`
+tw`border-current`
 tw`border-black`
 tw`border-white`
 tw`border-gray-100`

--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -32,6 +32,7 @@ tw`clearfix`
 tw`clear-left`
 tw`clear-right`
 tw`clear-both`
+tw`clear-none`
 
 // https://tailwindcss.com/docs/object-fit
 tw`object-contain`

--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -13,6 +13,7 @@ tw`flow-root`
 tw`flex`
 tw`inline-flex`
 tw`grid`
+tw`inline-grid`
 tw`table`
 tw`table-caption`
 tw`table-cell`

--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -9,6 +9,7 @@ tw`hidden`
 tw`block`
 tw`inline-block`
 tw`inline`
+tw`flow-root`
 tw`flex`
 tw`inline-flex`
 tw`grid`

--- a/__fixtures__/typography.js
+++ b/__fixtures__/typography.js
@@ -71,6 +71,7 @@ tw`list-outside`
 
 // https://tailwindcss.com/docs/placeholder-color
 tw`placeholder-transparent`
+tw`placeholder-current`
 tw`placeholder-black`
 tw`placeholder-white`
 tw`placeholder-gray-100`
@@ -172,6 +173,7 @@ tw`text-justify`
 
 // https://tailwindcss.com/docs/text-color
 tw`text-transparent`
+tw`text-current`
 tw`text-black`
 tw`text-white`
 tw`text-gray-100`
@@ -273,6 +275,7 @@ tw`text-justify`
 
 // https://tailwindcss.com/docs/text-color
 tw`text-transparent`
+tw`text-current`
 tw`text-black`
 tw`text-white`
 tw`text-gray-100`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2740,6 +2740,7 @@ tw\`hidden\`
 tw\`block\`
 tw\`inline-block\`
 tw\`inline\`
+tw\`flow-root\`
 tw\`flex\`
 tw\`inline-flex\`
 tw\`grid\`
@@ -2856,6 +2857,9 @@ tw\`z-auto\`
 })
 ;({
   display: 'inline',
+})
+;({
+  display: 'flow-root',
 })
 ;({
   display: 'flex',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2763,6 +2763,7 @@ tw\`clearfix\`
 tw\`clear-left\`
 tw\`clear-right\`
 tw\`clear-both\`
+tw\`clear-none\`
 
 // https://tailwindcss.com/docs/object-fit
 tw\`object-contain\`
@@ -2918,6 +2919,9 @@ tw\`z-auto\`
 })
 ;({
   clear: 'both',
+})
+;({
+  clear: 'none',
 }) // https://tailwindcss.com/docs/object-fit
 
 ;({

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2752,6 +2752,7 @@ tw\`flow-root\`
 tw\`flex\`
 tw\`inline-flex\`
 tw\`grid\`
+tw\`inline-grid\`
 tw\`table\`
 tw\`table-caption\`
 tw\`table-cell\`
@@ -2877,6 +2878,9 @@ tw\`z-auto\`
 })
 ;({
   display: 'grid',
+})
+;({
+  display: 'inline-grid',
 })
 ;({
   display: 'table',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -444,6 +444,7 @@ tw\`bg-scroll\`
 
 // https://tailwindcss.com/docs/background-color
 tw\`bg-transparent\`
+tw\`bg-current\`
 tw\`bg-black\`
 tw\`bg-white\`
 tw\`bg-gray-100\`
@@ -563,6 +564,7 @@ tw\`bg-contain\`
 
 // https://tailwindcss.com/docs/border-color
 tw\`border-transparent\`
+tw\`border-current\`
 tw\`border-black\`
 tw\`border-white\`
 tw\`border-gray-100\`
@@ -753,6 +755,9 @@ tw\`rounded-bl-full\`
 
 ;({
   backgroundColor: 'transparent',
+})
+;({
+  backgroundColor: 'currentColor',
 })
 ;({
   backgroundColor: '#000',
@@ -1090,6 +1095,9 @@ tw\`rounded-bl-full\`
 
 ;({
   borderColor: 'transparent',
+})
+;({
+  borderColor: 'currentColor',
 })
 ;({
   borderColor: '#000',
@@ -6100,6 +6108,7 @@ tw\`list-outside\`
 
 // https://tailwindcss.com/docs/placeholder-color
 tw\`placeholder-transparent\`
+tw\`placeholder-current\`
 tw\`placeholder-black\`
 tw\`placeholder-white\`
 tw\`placeholder-gray-100\`
@@ -6201,6 +6210,7 @@ tw\`text-justify\`
 
 // https://tailwindcss.com/docs/text-color
 tw\`text-transparent\`
+tw\`text-current\`
 tw\`text-black\`
 tw\`text-white\`
 tw\`text-gray-100\`
@@ -6302,6 +6312,7 @@ tw\`text-justify\`
 
 // https://tailwindcss.com/docs/text-color
 tw\`text-transparent\`
+tw\`text-current\`
 tw\`text-black\`
 tw\`text-white\`
 tw\`text-gray-100\`
@@ -6599,6 +6610,11 @@ tw\`truncate\`
 ;({
   '::placeholder': {
     color: 'transparent',
+  },
+})
+;({
+  '::placeholder': {
+    color: 'currentColor',
   },
 })
 ;({
@@ -7079,6 +7095,9 @@ tw\`truncate\`
   color: 'transparent',
 })
 ;({
+  color: 'currentColor',
+})
+;({
   color: '#000',
 })
 ;({
@@ -7370,6 +7389,9 @@ tw\`truncate\`
 
 ;({
   color: 'transparent',
+})
+;({
+  color: 'currentColor',
 })
 ;({
   color: '#000',

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "chalk": "^3.0.0",
     "dlv": "^1.1.3",
     "dset": "^2.0.1",
-    "tailwindcss": "^1.2.0",
+    "tailwindcss": "^1.3.3",
     "timsort": "^0.3.0"
   },
   "devDependencies": {

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -16,6 +16,7 @@ const staticStyles = {
   block: { output: { display: 'block' } },
   'inline-block': { output: { display: 'inline-block' } },
   inline: { output: { display: 'inline' } },
+  'flow-root': { output: { display: 'flow-root' } },
   flex: { output: { display: 'flex' } },
   'inline-flex': { output: { display: 'inline-flex' } },
   grid: { output: { display: 'grid' } },

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -43,6 +43,7 @@ const staticStyles = {
   'clear-left': { output: { clear: 'left' } },
   'clear-right': { output: { clear: 'right' } },
   'clear-both': { output: { clear: 'both' } },
+  'clear-none': { output: { clear: 'none' } },
 
   // https://tailwindcss.com/docs/object-fit
   'object-contain': { output: { objectFit: 'contain' } },


### PR DESCRIPTION
Hi there, thanks for this great package 👏

#45

- Added `current` to the default color palette
- New `inline-grid` utility
- New `flow-root display` utility
- New `clear-none` utility