### PR TITLE
Bump tailwindcss version ^1.3.0 to ^1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "chalk": "^4.0.0",
     "dlv": "^1.1.3",
     "dset": "^2.0.1",
-    "tailwindcss": "^1.3.4",
+    "tailwindcss": "^1.4.0",
     "timsort": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Desc
[tailwind css v1.4 is out!](https://github.com/tailwindcss/tailwindcss/discussions/1656)

How about updating `twin.macro`'s tailwindcss version to 1.4.0 or higher?
[In version 1.4.0,](https://github.com/tailwindcss/tailwindcss/releases/tag/v1.4.0) many useful functions such as `bg opacity` have been added.