### PR TITLE
Move @types/react to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,7 +1147,8 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.2",
@@ -1159,6 +1160,7 @@
       "version": "16.9.34",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.34.tgz",
       "integrity": "sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -3285,7 +3287,8 @@
     "csstype": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "homepage": "https://github.com/ben-rogerson/twin.macro#readme",
   "dependencies": {
     "@babel/parser": "^7.9.4",
-    "@types/react": "^16.9.34",
     "babel-plugin-macros": "^2.8.0",
     "chalk": "^4.0.0",
     "dlv": "^1.1.3",
@@ -63,11 +62,15 @@
     "tailwindcss": "^1.3.4",
     "timsort": "^0.3.0"
   },
+  "peerDependencies": {
+    "@types/react": "^16.9.34"
+  },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.8.3",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
     "@types/styled-components": "^5.1.0",
+    "@types/react": "^16.9.34",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "babel-plugin-tester": "^9.0.1",


### PR DESCRIPTION
Hey!

There is currently an issue when using Yarn Workspaces where `@types/react` is getting hoisted. This is causing conflict with Typescript finding two different versions of the `@types/react` package.

This PR fixes this by moving the react typings to a peerDependency 