### PR TITLE
Fallback to empty array on default import references

### DIFF
--- a/src/macro.js
+++ b/src/macro.js
@@ -160,8 +160,10 @@ const twinMacro = ({ babel: { types: t }, references, state, config }) => {
       }
     },
   })
+  
+  const defaultImportReferences = references.default || []
 
-  references.default.forEach(path => {
+  defaultImportReferences.forEach(path => {
     const parent = path.findParent(x => x.isTaggedTemplateExpression())
     if (!parent) return
 


### PR DESCRIPTION
Fixes #51.

If you plan to use `tw` solely as a prop, you need to import the macro, but the defined default import is useless and the linter/TS compiler throws an unused identifier error.

This PR makes it possible for the user to nameless import the macro. Example:

```js
import 'twin.macro'

const Component = () => <div tw='flex'>Hello, World</div>
```