### PR TITLE
docs: update yarn command for vanilla react instructions

### DIFF
--- a/docs/styled-components/react.md
+++ b/docs/styled-components/react.md
@@ -23,7 +23,7 @@ npm install --save twin.macro styled-components
 
 ```bash
 # React and Babel
-yarn add react react-dom @babel/core
+yarn add react react-dom @babel/core @babel/plugin-transform-react-jsx
 # Twin and Styled Components
 yarn add twin.macro styled-components
 ```


### PR DESCRIPTION
Add missing `@babel/plugin-transform-react-jsx`