### PR TITLE
Variant/prefix groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ When you use `tw`, Twin converts your classes into css objects, ready for passin
 
 ```js
 import tw from 'twin.macro'
+
 tw`text-sm md:text-lg`
 
 // ↓ ↓ ↓ ↓ ↓ ↓
@@ -124,7 +125,7 @@ ml-8 [2rem] / ml-10 [2.5rem] / ml-12 [3rem] / ml-16 [4rem] / ml-20 [5rem] / ml-2
 ml-40 [10rem] / ml-48 [12rem] / ml-56 [14rem] / ml-64 [16rem] / ml-auto [auto] / ml-px [1px]
 ```
 
-**💥 Go important with a bang** - Add important to any class with a trailing bang!
+**💥 Add important to any class with a trailing bang!**
 
 ```js
 tw`hidden!`
@@ -138,8 +139,27 @@ tw`hidden!`
 - Prefix with `hocus:` to style hover + focus at the same time
 - Style with extra group states like `group-hocus:` and `group-active:`
 - Style form field states with `checked:`, `invalid:` and `required:`
+- Stack variants for nested styles `sm:hover:`
 
 Check out the [full list of variants →](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/variantConfig.js)
+
+**🍱 Apply variants to multiple classes at once with variant groups**
+
+```js
+import 'twin.macro'
+
+const interactionStyles = () => (
+  <div tw="hover:(text-black underline) focus:(text-blue-500 underline)" />
+)
+
+const mediaStyles = () => <div tw="sm:(w-4 mt-3) lg:(w-8 mt-6)" />
+
+const pseudoElementStyles = () => (
+  <div tw="before:(content block w-10 h-10 bg-black)" />
+)
+
+const stackedVariants = () => <div tw="sm:hover:(bg-black text-white)" />
+```
 
 ## Getting started
 

--- a/__fixtures__/!variantGrouping.js
+++ b/__fixtures__/!variantGrouping.js
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import tw from './macro'
+
+const basic = tw`group-hover:(flex m-10)`
+const subMediaQuery = tw`focus-within:(md:flex mt-5)`
+const multipleClasses = tw`hover:(bg-black text-white underline)`
+const pseudoElement = tw`before:(content w-10 h-10 block bg-black)`
+const mediaHover = tw`sm:hover:(bg-black text-white)`
+const sloppySpacing = tw` last:( flex  mt-5)`
+const multipleGroups = tw`focus:(w-10 h-10 block bg-black) focus-within:(md:flex mt-5)`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -822,6 +822,90 @@ const Component3 = () => (
 
 `;
 
+exports[`twin.macro !variantGrouping.js: !variantGrouping.js 1`] = `
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import tw from './macro'
+
+const basic = tw\`group-hover:(flex m-10)\`
+const subMediaQuery = tw\`focus-within:(md:flex mt-5)\`
+const multipleClasses = tw\`hover:(bg-black text-white underline)\`
+const pseudoElement = tw\`before:(content w-10 h-10 block bg-black)\`
+const mediaHover = tw\`sm:hover:(bg-black text-white)\`
+const sloppySpacing = tw\` last:( flex  mt-5)\`
+const multipleGroups = tw\`focus:(w-10 h-10 block bg-black) focus-within:(md:flex mt-5)\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const basic = {
+  '.group:hover &': {
+    display: 'flex',
+    margin: '2.5rem',
+  },
+}
+const subMediaQuery = {
+  ':focus-within': {
+    '@media (min-width: 768px)': {
+      display: 'flex',
+    },
+    marginTop: '1.25rem',
+  },
+}
+const multipleClasses = {
+  ':hover': {
+    '--bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+    '--text-opacity': '1',
+    color: 'rgba(255, 255, 255, var(--text-opacity))',
+    textDecoration: 'underline',
+  },
+}
+const pseudoElement = {
+  ':before': {
+    content: '""',
+    width: '2.5rem',
+    height: '2.5rem',
+    display: 'block',
+    '--bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+  },
+}
+const mediaHover = {
+  '@media (min-width: 640px)': {
+    ':hover': {
+      '--bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+      '--text-opacity': '1',
+      color: 'rgba(255, 255, 255, var(--text-opacity))',
+    },
+  },
+}
+const sloppySpacing = {
+  ':last-child': {
+    display: 'flex',
+    marginTop: '1.25rem',
+  },
+}
+const multipleGroups = {
+  ':focus': {
+    width: '2.5rem',
+    height: '2.5rem',
+    display: 'block',
+    '--bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+  },
+  ':focus-within': {
+    '@media (min-width: 768px)': {
+      display: 'flex',
+    },
+    marginTop: '1.25rem',
+  },
+}
+
+
+`;
+
 exports[`twin.macro !variants.js: !variants.js 1`] = `
 
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/config/variantConfig.js
+++ b/src/config/variantConfig.js
@@ -31,7 +31,7 @@ export default {
    */
 
   // Before/after pseudo elements
-  // Usage: tw`before:content before:bg-black`
+  // Usage: tw`before:(content block w-10 h-10 bg-black)`
   before: ':before',
   after: ':after',
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -142,6 +142,18 @@ const errorSuggestions = properties => {
   return spaced(`${textNotFound}\n\n${suggestionText}`)
 }
 
+const logNotFoundVariant = ({ classNameRaw }) =>
+  spaced(
+    logBadGood(
+      `${classNameRaw}`,
+      [`${classNameRaw}flex`, `${classNameRaw}(flex bg-black)`].join(
+        color.subdued(' / ')
+      )
+    )
+  )
+
+const logNotFoundClass = logGeneralError('That class was not found')
+
 export {
   logNoVariant,
   logNoClass,
@@ -152,4 +164,6 @@ export {
   debugPlugins,
   inOutPlugins,
   errorSuggestions,
+  logNotFoundVariant,
+  logNotFoundClass,
 }

--- a/src/variants.js
+++ b/src/variants.js
@@ -83,4 +83,27 @@ const addVariants = ({ results, style, pieces }) => {
   return styleWithVariants
 }
 
-export { splitVariants, addVariants }
+const handleVariantGroups = classes => {
+  const groupedMatches = classes.match(/(\S*):\(([^\n\r()]*)\)/g)
+  if (!groupedMatches) return classes
+
+  let newClasses = classes.slice()
+
+  groupedMatches.forEach(group => {
+    const match = group.match(/(\S*):\(([^\n\r()]*)\)/)
+    if (!match) return ''
+
+    const [, variant, unwrappedClasses] = match
+    const wrapped = unwrappedClasses
+      .trim()
+      .split(' ')
+      .filter(Boolean) // remove double spaces '  '
+      .map(unwrappedClass => `${variant}:${unwrappedClass}`)
+      .join(' ')
+    newClasses = newClasses.replace(group, wrapped)
+  })
+
+  return newClasses
+}
+
+export { splitVariants, addVariants, handleVariantGroups }


### PR DESCRIPTION
With this feature, we can now group variants together to avoid repetition.

```js
// ✕ Bad
tw`hover:flex hover:bg-black hover:w-10 hover:h-10`

// ✓ Good
tw`hover:(flex bg-black w-10 h-10)`
```

We can use any of the 40+ variants (and screen values) to create these grouped sets.

### Css prop usage

```js
import tw from 'twin.macro'

const HoverBox = () => <div css={tw`hover:(flex bg-black w-10 h-10)`} />
const PseudoElement = () => (
  <div css={tw`before:(content w-10 h-10 block bg-black)`} />
)
```

### Styled components usage

```js
import tw from 'twin.macro'

const HoverBox = tw.div`hover:(flex bg-black w-10 h-10)`
const PseudoElement = tw.div`before:(content w-10 h-10 block bg-black)`
```


### todo

- [ ] Further testing