### PR TITLE
Typescript support for extended Styled Components

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable-next-line import/no-unassigned-import */
-import 'react'
+import { ComponentType } from 'react'
 
 export interface TwStyle {
   [key: string]: string | number | TwStyle
@@ -20,7 +20,12 @@ export type TwComponentMap = {
   [K in keyof JSX.IntrinsicElements]: TemplateFn<TwComponent<K>>
 }
 
-declare const tw: TwFn & TwComponentMap
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type TwComponentWrapper = <T extends ComponentType<any>>(
+  component: T
+) => TemplateFn<T>
+
+declare const tw: TwFn & TwComponentMap & TwComponentWrapper
 export default tw
 
 declare module 'react' {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line import/no-unassigned-import */
 import { ComponentType } from 'react'
 
 export interface TwStyle {

--- a/types/tests/emotion/index.tsx
+++ b/types/tests/emotion/index.tsx
@@ -11,6 +11,7 @@ export const Container = styled.div`
 `
 
 export const Link = tw.a``
-export const ComposedLink = styled(Link)``
+export const ComposedLink = tw(Link)``
+export const ComposedLink2 = styled(Link)``
 
 export const cssProperty = <div css={tw`bg-red-100`} />

--- a/types/tests/styled-components/index.tsx
+++ b/types/tests/styled-components/index.tsx
@@ -11,6 +11,7 @@ export const Container = styled.div`
 `
 
 export const Link = tw.a``
-export const ComposedLink = styled(Link)``
+export const ComposedLink = tw(Link)``
+export const ComposedLink2 = styled(Link)``
 
 export const cssProperty = <div css={tw`bg-red-100`} />


### PR DESCRIPTION
Temporary solution for https://github.com/ben-rogerson/twin.macro/issues/38

```js
const Button = tw.button`text-white`

// tw component wrapping is now a-ok in TypeScript
const PinkButton = tw(Button)`bg-black`
```

Thanks to @A-Shleifman for the code 👍 
