### PR TITLE
add data-tw when using the css prop

### DIFF
--- a/src/macro/debug.js
+++ b/src/macro/debug.js
@@ -24,13 +24,27 @@ const addDebugPropToExistingPath = ({
 }) => {
   if (state.isProd || !state.debugProp) return
 
-  // Remove the existing debug attribute if you happen to have it
-  const debugProperty = attributes.filter(
+  // Append to the existing debug attribute
+  const debugProperty = attributes.find(
+    // TODO: Use @babel/plugin-proposal-optional-chaining
     p => p.node && p.node.name && p.node.name.name === 'data-tw'
   )
-  debugProperty.forEach(path => path.remove())
+  if (debugProperty) {
+    try {
+      // Existing data-tw
+      if (debugProperty.node.value.value) {
+        debugProperty.node.value.value = `${debugProperty.node.value.value} | ${rawClasses}`
+        return
+      }
 
-  // Add the attribute
+      // New data-tw
+      debugProperty.node.value.expression.value = `${debugProperty.node.value.expression.value} | ${rawClasses}`
+    } catch (_) {}
+
+    return
+  }
+
+  // Add a new attribute
   path.pushContainer(
     'attributes',
     t.jSXAttribute(

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -9,7 +9,6 @@ const handleTwProperty = ({ program, t, state }) =>
   program.traverse({
     JSXAttribute(path) {
       if (path.node.name.name === 'css') state.hasCssProp = true
-      // TODO: Add tw-prop for css attributes
 
       if (path.node.name.name !== 'tw') return
       state.hasTwProp = true
@@ -89,6 +88,17 @@ const handleTwFunction = ({ references, state, t }) => {
     if (!parsed) return
 
     const rawClasses = parsed.string
+
+    // Add tw-prop for css attributes
+    const jsxPath = path.findParent(p => p.isJSXOpeningElement())
+    const attributes = jsxPath.get('attributes')
+    addDebugPropToExistingPath({
+      t,
+      attributes,
+      rawClasses,
+      path: jsxPath,
+      state,
+    })
 
     replaceWithLocation(parsed.path, getStyles(rawClasses, t, state))
   })

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -91,14 +91,16 @@ const handleTwFunction = ({ references, state, t }) => {
 
     // Add tw-prop for css attributes
     const jsxPath = path.findParent(p => p.isJSXOpeningElement())
-    const attributes = jsxPath.get('attributes')
-    addDebugPropToExistingPath({
-      t,
-      attributes,
-      rawClasses,
-      path: jsxPath,
-      state,
-    })
+    if (jsxPath) {
+      const attributes = jsxPath.get('attributes')
+      addDebugPropToExistingPath({
+        t,
+        attributes,
+        rawClasses,
+        path: jsxPath,
+        state,
+      })
+    }
 
     replaceWithLocation(parsed.path, getStyles(rawClasses, t, state))
   })


### PR DESCRIPTION
Currently, the "debugProp" only gets added when using the tw prop.

```js
const propDemo = () => <div tw="block mt-5" />

// ↓ ↓ ↓ ↓ ↓ ↓

const propDemo = () => React.createElement('div', {
  "data-tw": "block mt-5",
  css: ...
});
```

This feature adds the `data-tw` prop also when you use the css prop:

```js
const propDemo = () => (
  <div
    tw="block mt-5"
    css={[
      tw`mt-3`,
    ]}
  />
)

// ↓ ↓ ↓ ↓ ↓ ↓

const propDemo = () => React.createElement('div', {
  "data-tw": "block mt-5 | mt-3",
  css: ...
});
```

This should help trace classes back to their definitions and assist debugging from your devtools.