### PR TITLE
Default letter-spacing per font-size

### DIFF
--- a/__fixtures__/typography.js
+++ b/__fixtures__/typography.js
@@ -17,6 +17,11 @@ tw`text-4xl`
 tw`text-5xl`
 tw`text-6xl`
 
+// Extended config
+tw`text-size`
+tw`text-sizeLineHeight`
+tw`text-sizeLineHeightLetterSpacing`
+
 // https://tailwindcss.com/docs/font-smoothing
 tw`antialiased`
 tw`subpixel-antialiased`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -9665,6 +9665,11 @@ tw\`text-4xl\`
 tw\`text-5xl\`
 tw\`text-6xl\`
 
+// Extended config
+tw\`text-size\`
+tw\`text-sizeLineHeight\`
+tw\`text-sizeLineHeightLetterSpacing\`
+
 // https://tailwindcss.com/docs/font-smoothing
 tw\`antialiased\`
 tw\`subpixel-antialiased\`
@@ -10109,6 +10114,19 @@ tw\`truncate\`
 })
 ;({
   fontSize: '4rem',
+}) // Extended config
+
+;({
+  fontSize: '24px',
+})
+;({
+  fontSize: '24px',
+  lineHeight: '15px',
+})
+;({
+  fontSize: '32px',
+  lineHeight: '40px',
+  letterSpacing: '-0.02em',
 }) // https://tailwindcss.com/docs/font-smoothing
 
 ;({

--- a/src/plugins/text.js
+++ b/src/plugins/text.js
@@ -16,11 +16,18 @@ const handleSize = ({ configValue, important }) => {
   const value = configValue('fontSize')
   if (!value) return
 
-  const [fontSize, lineHeight] = Array.isArray(value) ? value : [value]
+  const [fontSize, options] = Array.isArray(value) ? value : [value]
+
+  const lineHeight = options instanceof Object ? options.lineHeight : options
+  const letterSpacing = options && options.letterSpacing
+
   return {
     fontSize: `${fontSize}${important}`,
     ...(lineHeight && {
       lineHeight: `${lineHeight}${important}`,
+    }),
+    ...(letterSpacing && {
+      letterSpacing: `${letterSpacing}${important}`,
     }),
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -141,6 +141,17 @@ module.exports = {
         // https://tailwindcss.com/docs/font-weight#font-weights
         customFontWeightAsNumber: 800,
       },
+      fontSize: {
+        size: '24px',
+        sizeLineHeight: ['24px', '15px'],
+        sizeLineHeightLetterSpacing: [
+          '32px',
+          {
+            lineHeight: '40px',
+            letterSpacing: '-0.02em',
+          },
+        ],
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
This PR adds an alternative fontSize config to specify letterSpacing released in [Tailwind v1.7.0](https://github.com/tailwindlabs/tailwindcss/releases#default-letter-spacing-per-font-size).

Tailwind docs: [Providing a default letter-spacing](https://tailwindcss.com/docs/font-size#providing-a-default-letter-spacing) 

```js
// config
module.exports = {
  theme: {
    extend: {
      fontSize: {
        hero: [
          '7rem',
          {
            lineHeight: '80%',
            letterSpacing: '-0.02em'
          }
        ]
      },
    }
  }
}
```

```js
// usage
<div tw="text-hero text-purple-600">hero text</div>
```

```js
// output
;({
  fontSize: '7rem',
  lineHeight: '80%',
  letterSpacing: '-0.02em',
})
```

![image](https://user-images.githubusercontent.com/21288568/91648757-7c5c8700-eaaa-11ea-99e9-99de91e9c3a2.png)