### PR TITLE
Gap utility aliases

### DIFF
--- a/__fixtures__/grid.js
+++ b/__fixtures__/grid.js
@@ -112,6 +112,50 @@ tw`gap-48`
 tw`gap-56`
 tw`gap-64`
 tw`gap-px`
+
+// https://tailwindcss.com/docs/gap
+tw`gap-x-0`
+tw`gap-x-1`
+tw`gap-x-2`
+tw`gap-x-3`
+tw`gap-x-4`
+tw`gap-x-5`
+tw`gap-x-6`
+tw`gap-x-8`
+tw`gap-x-10`
+tw`gap-x-12`
+tw`gap-x-16`
+tw`gap-x-20`
+tw`gap-x-24`
+tw`gap-x-32`
+tw`gap-x-40`
+tw`gap-x-48`
+tw`gap-x-56`
+tw`gap-x-64`
+tw`gap-x-px`
+
+// https://tailwindcss.com/docs/gap
+tw`gap-y-0`
+tw`gap-y-1`
+tw`gap-y-2`
+tw`gap-y-3`
+tw`gap-y-4`
+tw`gap-y-5`
+tw`gap-y-6`
+tw`gap-y-8`
+tw`gap-y-10`
+tw`gap-y-12`
+tw`gap-y-16`
+tw`gap-y-20`
+tw`gap-y-24`
+tw`gap-y-32`
+tw`gap-y-40`
+tw`gap-y-48`
+tw`gap-y-56`
+tw`gap-y-64`
+tw`gap-y-px`
+
+// Deprecated since tailwindcss v1.7.0
 tw`row-gap-0`
 tw`row-gap-1`
 tw`row-gap-2`
@@ -131,6 +175,8 @@ tw`row-gap-48`
 tw`row-gap-56`
 tw`row-gap-64`
 tw`row-gap-px`
+
+// Deprecated since tailwindcss v1.7.0
 tw`col-gap-0`
 tw`col-gap-1`
 tw`col-gap-2`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -4876,6 +4876,50 @@ tw\`gap-48\`
 tw\`gap-56\`
 tw\`gap-64\`
 tw\`gap-px\`
+
+// https://tailwindcss.com/docs/gap
+tw\`gap-x-0\`
+tw\`gap-x-1\`
+tw\`gap-x-2\`
+tw\`gap-x-3\`
+tw\`gap-x-4\`
+tw\`gap-x-5\`
+tw\`gap-x-6\`
+tw\`gap-x-8\`
+tw\`gap-x-10\`
+tw\`gap-x-12\`
+tw\`gap-x-16\`
+tw\`gap-x-20\`
+tw\`gap-x-24\`
+tw\`gap-x-32\`
+tw\`gap-x-40\`
+tw\`gap-x-48\`
+tw\`gap-x-56\`
+tw\`gap-x-64\`
+tw\`gap-x-px\`
+
+// https://tailwindcss.com/docs/gap
+tw\`gap-y-0\`
+tw\`gap-y-1\`
+tw\`gap-y-2\`
+tw\`gap-y-3\`
+tw\`gap-y-4\`
+tw\`gap-y-5\`
+tw\`gap-y-6\`
+tw\`gap-y-8\`
+tw\`gap-y-10\`
+tw\`gap-y-12\`
+tw\`gap-y-16\`
+tw\`gap-y-20\`
+tw\`gap-y-24\`
+tw\`gap-y-32\`
+tw\`gap-y-40\`
+tw\`gap-y-48\`
+tw\`gap-y-56\`
+tw\`gap-y-64\`
+tw\`gap-y-px\`
+
+// Deprecated since tailwindcss v1.7.0
 tw\`row-gap-0\`
 tw\`row-gap-1\`
 tw\`row-gap-2\`
@@ -4895,6 +4939,8 @@ tw\`row-gap-48\`
 tw\`row-gap-56\`
 tw\`row-gap-64\`
 tw\`row-gap-px\`
+
+// Deprecated since tailwindcss v1.7.0
 tw\`col-gap-0\`
 tw\`col-gap-1\`
 tw\`col-gap-2\`
@@ -5236,7 +5282,66 @@ tw\`grid-flow-col-dense\`
 })
 ;({
   gap: '1px',
+}) // https://tailwindcss.com/docs/gap
+
+;({
+  columnGap: '0',
 })
+;({
+  columnGap: '0.25rem',
+})
+;({
+  columnGap: '0.5rem',
+})
+;({
+  columnGap: '0.75rem',
+})
+;({
+  columnGap: '1rem',
+})
+;({
+  columnGap: '1.25rem',
+})
+;({
+  columnGap: '1.5rem',
+})
+;({
+  columnGap: '2rem',
+})
+;({
+  columnGap: '2.5rem',
+})
+;({
+  columnGap: '3rem',
+})
+;({
+  columnGap: '4rem',
+})
+;({
+  columnGap: '5rem',
+})
+;({
+  columnGap: '6rem',
+})
+;({
+  columnGap: '8rem',
+})
+;({
+  columnGap: '10rem',
+})
+;({
+  columnGap: '12rem',
+})
+;({
+  columnGap: '14rem',
+})
+;({
+  columnGap: '16rem',
+})
+;({
+  columnGap: '1px',
+}) // https://tailwindcss.com/docs/gap
+
 ;({
   rowGap: '0',
 })
@@ -5293,7 +5398,66 @@ tw\`grid-flow-col-dense\`
 })
 ;({
   rowGap: '1px',
+}) // Deprecated since tailwindcss v1.7.0
+
+;({
+  rowGap: '0',
 })
+;({
+  rowGap: '0.25rem',
+})
+;({
+  rowGap: '0.5rem',
+})
+;({
+  rowGap: '0.75rem',
+})
+;({
+  rowGap: '1rem',
+})
+;({
+  rowGap: '1.25rem',
+})
+;({
+  rowGap: '1.5rem',
+})
+;({
+  rowGap: '2rem',
+})
+;({
+  rowGap: '2.5rem',
+})
+;({
+  rowGap: '3rem',
+})
+;({
+  rowGap: '4rem',
+})
+;({
+  rowGap: '5rem',
+})
+;({
+  rowGap: '6rem',
+})
+;({
+  rowGap: '8rem',
+})
+;({
+  rowGap: '10rem',
+})
+;({
+  rowGap: '12rem',
+})
+;({
+  rowGap: '14rem',
+})
+;({
+  rowGap: '16rem',
+})
+;({
+  rowGap: '1px',
+}) // Deprecated since tailwindcss v1.7.0
+
 ;({
   columnGap: '0',
 })

--- a/src/config/dynamicStyles.js
+++ b/src/config/dynamicStyles.js
@@ -98,6 +98,18 @@ export default {
 
   // https://tailwindcss.com/docs/gap
   gap: { prop: 'gap', config: 'gap' },
+  'gap-x': {
+    prop: 'columnGap',
+    config: 'gap',
+    configFallback: 'spacing',
+  },
+  'gap-y': {
+    prop: 'rowGap',
+    config: 'gap',
+    configFallback: 'spacing',
+  },
+
+  // Deprecated since tailwindcss v1.7.0
   'col-gap': { prop: 'columnGap', config: 'gap' },
   'row-gap': { prop: 'rowGap', config: 'gap' },
 


### PR DESCRIPTION
This PR adds the new gap-x gap-y classes released in [Tailwind v1.7.0](https://github.com/tailwindlabs/tailwindcss/releases#new-gap-utility-aliases):

```js

// https://tailwindcss.com/docs/gap
tw`gap-x-0`
tw`gap-x-1`
tw`gap-x-2`
tw`gap-x-3`
tw`gap-x-4`
tw`gap-x-5`
tw`gap-x-6`
tw`gap-x-8`
tw`gap-x-10`
tw`gap-x-12`
tw`gap-x-16`
tw`gap-x-20`
tw`gap-x-24`
tw`gap-x-32`
tw`gap-x-40`
tw`gap-x-48`
tw`gap-x-56`
tw`gap-x-64`
tw`gap-x-px`

// https://tailwindcss.com/docs/gap
tw`gap-y-0`
tw`gap-y-1`
tw`gap-y-2`
tw`gap-y-3`
tw`gap-y-4`
tw`gap-y-5`
tw`gap-y-6`
tw`gap-y-8`
tw`gap-y-10`
tw`gap-y-12`
tw`gap-y-16`
tw`gap-y-20`
tw`gap-y-24`
tw`gap-y-32`
tw`gap-y-40`
tw`gap-y-48`
tw`gap-y-56`
tw`gap-y-64`
tw`gap-y-px`
```