### PR TITLE
Color closures

### DIFF
--- a/__fixtures__/!config.js
+++ b/__fixtures__/!config.js
@@ -11,6 +11,7 @@ tw`text-mycolors-a-purple`
 tw`text-mycolors-a-number`
 tw`text-mycolors-array`
 tw`text-my-blue-100`
+tw`text-color-opacity`
 
 tw`bg-number`
 tw`bg-purple-hyphen`
@@ -19,3 +20,4 @@ tw`bg-mycolors-a-purple`
 tw`bg-mycolors-a-number`
 tw`bg-mycolors-array`
 tw`bg-my-blue-100`
+tw`bg-color-opacity`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -15,6 +15,7 @@ tw\`text-mycolors-a-purple\`
 tw\`text-mycolors-a-number\`
 tw\`text-mycolors-array\`
 tw\`text-my-blue-100\`
+tw\`text-color-opacity\`
 
 tw\`bg-number\`
 tw\`bg-purple-hyphen\`
@@ -23,6 +24,7 @@ tw\`bg-mycolors-a-purple\`
 tw\`bg-mycolors-a-number\`
 tw\`bg-mycolors-array\`
 tw\`bg-my-blue-100\`
+tw\`bg-color-opacity\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -55,6 +57,9 @@ tw\`bg-my-blue-100\`
   color: 'rgba(0, 0, 255, var(--text-opacity))',
 })
 ;({
+  color: 'rgba(var(--color-primary), var(--text-opacity, 1))',
+})
+;({
   backgroundColor: '0',
 })
 ;({
@@ -78,6 +83,9 @@ tw\`bg-my-blue-100\`
 ;({
   '--bg-opacity': '1',
   backgroundColor: 'rgba(0, 0, 255, var(--bg-opacity))',
+})
+;({
+  backgroundColor: 'rgba(var(--color-primary), var(--bg-opacity, 1))',
 })
 
 

--- a/docs/emotion/react.md
+++ b/docs/emotion/react.md
@@ -123,7 +123,7 @@ Then you can import react like normal:
 
 ```js
 import React from 'react'
-import 'twin.macro'
+import tw from 'twin.macro'
 
 const Input = () => <input tw="bg-black" />
 // or

--- a/package-lock.json
+++ b/package-lock.json
@@ -7769,7 +7769,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8544,6 +8545,11 @@
           }
         }
       }
+    },
+    "object-hash": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
+      "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -13966,9 +13972,9 @@
       }
     },
     "tailwindcss": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.6.0.tgz",
-      "integrity": "sha512-UZEex5ebsQlCTIBjI0oZITL67HBjOrzMgA4ceLOf8mrBGquLSn7LsO92do1nBSBZBV2Qqpivz9QUwT3zMSQkMA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.7.5.tgz",
+      "integrity": "sha512-thDHLkRioJh0/62EFcEfQCCBEsZXpluehymrPzn8Hkycy8uI9svvtOqyWtcfkBPB0s5yb6R2tY9zPzh5mIr0Wg==",
       "requires": {
         "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
@@ -13978,17 +13984,26 @@
         "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "node-emoji": "^1.8.1",
         "normalize.css": "^8.0.1",
+        "object-hash": "^2.0.3",
         "postcss": "^7.0.11",
         "postcss-functions": "^3.0.0",
         "postcss-js": "^2.0.0",
         "postcss-nested": "^4.1.1",
         "postcss-selector-parser": "^6.0.0",
+        "postcss-value-parser": "^4.1.0",
         "pretty-hrtime": "^1.0.3",
         "reduce-css-calc": "^2.1.6",
         "resolve": "^1.14.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "tailwindcss-typography": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dset": "^2.0.1",
     "lodash.merge": "^4.6.2",
     "string-similarity": "^4.0.1",
-    "tailwindcss": "^1.6.0",
+    "tailwindcss": "^1.7.5",
     "timsort": "^0.3.0"
   },
   "peerDependencies": {

--- a/src/utils/getConfigValue.js
+++ b/src/utils/getConfigValue.js
@@ -2,7 +2,7 @@ import { isEmpty, assert, stripNegative } from './misc'
 import { logGeneralError } from './../logging'
 
 const normalizeValue = value => {
-  if (typeof value === 'string' || Array.isArray(value)) {
+  if (['string', 'function'].includes(typeof value) || Array.isArray(value)) {
     return value
   }
 
@@ -13,7 +13,7 @@ const normalizeValue = value => {
   logGeneralError(
     `The config value "${Object.stringify(
       value
-    )}" is unsupported - try a string, array or number`
+    )}" is unsupported - try a string, function, array, or number`
   )
 }
 
@@ -65,8 +65,7 @@ const getConfigValue = (from, matcher) => {
 
   const match = from[matcher]
   if (
-    typeof match === 'string' ||
-    typeof match === 'number' ||
+    ['string', 'number', 'function'].includes(typeof match) ||
     Array.isArray(match)
   ) {
     return normalizeValue(match)

--- a/src/utils/withAlpha.js
+++ b/src/utils/withAlpha.js
@@ -15,6 +15,12 @@ function toRgba(color) {
 }
 
 export default ({ color, property, variable, important }) => {
+  if (typeof color === 'function') {
+    return {
+      [property]: `${color({ opacityVariable: variable })}${important}`,
+    }
+  }
+
   const colorValue = `${color}${important}`
   try {
     const [r, g, b, a] = toRgba(color)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -134,6 +134,8 @@ module.exports = {
         'my-blue': {
           100: 'blue',
         },
+        'color-opacity': ({ opacityVariable }) =>
+          `rgba(var(--color-primary), var(${opacityVariable}, 1))`,
       },
       fontWeight: {
         customFontWeightAsString: '700',


### PR DESCRIPTION
This PR adds support for custom colors that work with tailwind opacity classes added in [Tailwind v1.7.0](https://github.com/tailwindlabs/tailwindcss/releases#define-colors-as-closures).
You'll now be able to add custom colors to the tailwind config and then style their opacity with classes like `text-opacity-50` / `bg-opacity-50`.

```js
// tailwind.config.js
module.exports = {
  theme: {
    colors: {
      custom: ({ opacityVariable }) =>
        `rgba(255, 255, 255, var(${opacityVariable}, 1))`,
    },
  },
}

```

```js
// usage
tw`text-custom text-opacity-50`
```

```js
// output
({
  "color": "rgba(255, 255, 255, var(--text-opacity, 1))",
  "--text-opacity": "0.5"
});
```
