### PR TITLE
Divide border style

### DIFF
--- a/__fixtures__/borders.js
+++ b/__fixtures__/borders.js
@@ -295,6 +295,12 @@ tw`divide-pink-700`
 tw`divide-pink-800`
 tw`divide-pink-900`
 
+tw`divide-solid`
+tw`divide-dashed`
+tw`divide-dotted`
+tw`divide-double`
+tw`divide-none`
+
 // https://tailwindcss.com/docs/divide-opacity
 tw`border-opacity-0`
 tw`border-opacity-25`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -3126,6 +3126,12 @@ tw\`divide-pink-700\`
 tw\`divide-pink-800\`
 tw\`divide-pink-900\`
 
+tw\`divide-solid\`
+tw\`divide-dashed\`
+tw\`divide-dotted\`
+tw\`divide-double\`
+tw\`divide-none\`
+
 // https://tailwindcss.com/docs/divide-opacity
 tw\`border-opacity-0\`
 tw\`border-opacity-25\`
@@ -4419,6 +4425,31 @@ tw\`border-opacity-100\`
   '> :not(template) ~ :not(template)': {
     '--divide-opacity': '1',
     borderColor: 'rgba(112, 36, 89, var(--divide-opacity))',
+  },
+})
+;({
+  '> :not(template) ~ :not(template)': {
+    borderStyle: 'solid',
+  },
+})
+;({
+  '> :not(template) ~ :not(template)': {
+    borderStyle: 'dashed',
+  },
+})
+;({
+  '> :not(template) ~ :not(template)': {
+    borderStyle: 'dotted',
+  },
+})
+;({
+  '> :not(template) ~ :not(template)': {
+    borderStyle: 'double',
+  },
+})
+;({
+  '> :not(template) ~ :not(template)': {
+    borderStyle: 'none',
   },
 }) // https://tailwindcss.com/docs/divide-opacity
 

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -135,6 +135,43 @@ export default {
     },
   },
 
+  // https://tailwindcss.com/docs/divide-style
+  'divide-solid': {
+    output: {
+      '> :not(template) ~ :not(template)': {
+        borderStyle: 'solid',
+      },
+    },
+  },
+  'divide-dashed': {
+    output: {
+      '> :not(template) ~ :not(template)': {
+        borderStyle: 'dashed',
+      },
+    },
+  },
+  'divide-dotted': {
+    output: {
+      '> :not(template) ~ :not(template)': {
+        borderStyle: 'dotted',
+      },
+    },
+  },
+  'divide-double': {
+    output: {
+      '> :not(template) ~ :not(template)': {
+        borderStyle: 'double',
+      },
+    },
+  },
+  'divide-none': {
+    output: {
+      '> :not(template) ~ :not(template)': {
+        borderStyle: 'none',
+      },
+    },
+  },
+
   /**
    * ===========================================
    * Flexbox


### PR DESCRIPTION
This PR adds divide styles for your borders added in  [Tailwind v1.7.0](https://github.com/tailwindlabs/tailwindcss/releases#divide-border-styles).

```js
// usage
tw`divide-solid`
tw`divide-dashed`
tw`divide-dotted`
tw`divide-double`
tw`divide-none`
```

```js
// output
({
  "> :not(template) ~ :not(template)": {
    "border-style": "solid"
  }
});
({
  "> :not(template) ~ :not(template)": {
    "border-style": "dashed"
  }
});
({
  "> :not(template) ~ :not(template)": {
    "border-style": "dotted"
  }
});
({
  "> :not(template) ~ :not(template)": {
    "border-style": "double"
  }
});
({
  "> :not(template) ~ :not(template)": {
    "border-style": "none"
  }
});
```

## Example

![image](https://user-images.githubusercontent.com/21288568/91648625-ba58ab80-eaa8-11ea-9cb7-b1b4811f7270.png)

```js
<ul tw="divide-y-8 divide-solid divide-electric">
  <li>item</li>
  <li>item</li>
</ul>
<ul tw="divide-y-8 divide-dashed divide-ribbon">
  <li>item</li>
  <li>item</li>
</ul>
<ul tw="divide-y-8 divide-dotted divide-electric">
  <li>item</li>
  <li>item</li>
</ul>
<ul tw="divide-y-8 divide-double divide-ribbon">
  <li>item</li>
  <li>item</li>
</ul>
```