### PR TITLE
Contents and clips

### DIFF
--- a/__fixtures__/backgrounds.js
+++ b/__fixtures__/backgrounds.js
@@ -5,6 +5,12 @@ tw`bg-fixed`
 tw`bg-local`
 tw`bg-scroll`
 
+// https://tailwindcss.com/docs/background-clip
+tw`bg-clip-border`
+tw`bg-clip-padding`
+tw`bg-clip-content`
+tw`bg-clip-text`
+
 // https://tailwindcss.com/docs/background-color
 tw`bg-transparent`
 tw`bg-current`

--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -10,6 +10,7 @@ tw`box-content`
 // https://tailwindcss.com/docs/display
 tw`hidden`
 tw`block`
+tw`contents`
 tw`inline-block`
 tw`inline`
 tw`flow-root`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2230,6 +2230,12 @@ tw\`bg-fixed\`
 tw\`bg-local\`
 tw\`bg-scroll\`
 
+// https://tailwindcss.com/docs/background-clip
+tw\`bg-clip-border\`
+tw\`bg-clip-padding\`
+tw\`bg-clip-content\`
+tw\`bg-clip-text\`
+
 // https://tailwindcss.com/docs/background-color
 tw\`bg-transparent\`
 tw\`bg-current\`
@@ -2370,6 +2376,19 @@ tw\`bg-contain\`
 })
 ;({
   backgroundAttachment: 'scroll',
+}) // https://tailwindcss.com/docs/background-clip
+
+;({
+  backgroundClip: 'border-box',
+})
+;({
+  backgroundClip: 'padding-box',
+})
+;({
+  backgroundClip: 'content-box',
+})
+;({
+  backgroundClip: 'text',
 }) // https://tailwindcss.com/docs/background-color
 
 ;({
@@ -5486,6 +5505,7 @@ tw\`box-content\`
 // https://tailwindcss.com/docs/display
 tw\`hidden\`
 tw\`block\`
+tw\`contents\`
 tw\`inline-block\`
 tw\`inline\`
 tw\`flow-root\`
@@ -5730,6 +5750,9 @@ tw\`space-y-12 -space-y-reverse\`
 })
 ;({
   display: 'block',
+})
+;({
+  display: 'contents',
 })
 ;({
   display: 'inline-block',

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -14,6 +14,7 @@ export default {
   // https://tailwindcss.com/docs/display
   hidden: { output: { display: 'none' } },
   block: { output: { display: 'block' } },
+  contents: { output: { display: 'contents' } },
   'inline-block': { output: { display: 'inline-block' } },
   inline: { output: { display: 'inline' } },
   'flow-root': { output: { display: 'flow-root' } },
@@ -354,6 +355,12 @@ export default {
   'bg-fixed': { output: { backgroundAttachment: 'fixed' } },
   'bg-local': { output: { backgroundAttachment: 'local' } },
   'bg-scroll': { output: { backgroundAttachment: 'scroll' } },
+
+  // https://tailwindcss.com/docs/background-clip
+  'bg-clip-border': { output: { backgroundClip: 'border-box' } },
+  'bg-clip-padding': { output: { backgroundClip: 'padding-box' } },
+  'bg-clip-content': { output: { backgroundClip: 'content-box' } },
+  'bg-clip-text': { output: { backgroundClip: 'text' } },
 
   // https://tailwindcss.com/docs/background-color
   // https://tailwindcss.com/docs/background-size


### PR DESCRIPTION
This PR adds [new-background-clip-utilities](https://github.com/tailwindlabs/tailwindcss/releases#new-background-clip-utilities) and a [new-contents-display-utility](https://github.com/tailwindlabs/tailwindcss/releases#new-contents-display-utility):

```js
import tw from 'twin.macro'

tw`contents`

tw`bg-clip-border`
tw`bg-clip-padding`
tw`bg-clip-content`
tw`bg-clip-text`
```

```js
// output
({
  "display": "contents"
});

({
  "-webkitBackgroundClip": "border-box",
  "backgroundClip": "border-box"
});
({
  "-webkitBackgroundClip": "padding-box",
  "backgroundClip": "padding-box"
});
({
  "-webkitBackgroundClip": "content-box",
  "backgroundClip": "content-box"
});
({
  "-webkitBackgroundClip": "text",
  "backgroundClip": "text"
});
```

## Example

![image](https://user-images.githubusercontent.com/21288568/91648480-9ba5e500-eaa7-11ea-84bd-1610a5dea3b9.png)

```js
<div tw="bg-clip-text bg-gradient-to-b from-electric to-ribbon text-transparent text-6xl">
  text gradients
</div>
```