### PR TITLE
Style prop check

### DIFF
--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -23,7 +23,7 @@ import {
 export default (classes, t, state) => {
   assert([null, 'null', undefined].includes(classes), () =>
     logGeneralError(
-      'Only plain strings can be used with "tw".\nRead more at https://github.com/ben-rogerson/twin.macro/issues/17'
+      'Only plain strings can be used with "tw".\nRead more at https://twinredirect.page.link/template-literals'
     )
   )
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -43,8 +43,12 @@ const logNoVariant = (variant, validVariants) =>
 const logNotAllowed = ({ className, error }) =>
   spaced(warning(`${color.errorLight(`${className}`)} ${error}`))
 
+// TODO: Wrap this in spaced
 const logBadGood = (bad, good) =>
   `${color.error('✕ Bad:')} ${bad}\n${color.success('✓ Good:')} ${good}`
+
+const logErrorFix = (error, good) =>
+  `${color.error(error)}\n${color.success('Fix:')} ${good}`
 
 const logGeneralError = error => spaced(warning(error))
 
@@ -191,6 +195,13 @@ const logNotFoundVariant = ({ classNameRaw }) =>
 
 const logNotFoundClass = logGeneralError('That class was not found')
 
+const logStylePropertyError = spaced(
+  logErrorFix(
+    'Styles shouldn’t be added within a `style={...}` prop',
+    'Use the tw or css prop instead: <div tw="" /> or <div css={tw``} />\n\nDisable this error by adding this in your twin config: `{ "allowStyleProp": true }`\nRead more at https://twinredirect.page.link/style-prop'
+  )
+)
+
 export {
   logNoVariant,
   logNoClass,
@@ -205,4 +216,5 @@ export {
   themeErrorNotFound,
   logNotFoundVariant,
   logNotFoundClass,
+  logStylePropertyError,
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -31,6 +31,10 @@ const twinMacro = ({ babel: { types: t }, references, state, config }) => {
     typeof config.hasSuggestions === 'undefined'
       ? true
       : Boolean(config.hasSuggestions)
+  state.allowStyleProp =
+    typeof config.allowStyleProp === 'undefined'
+      ? false
+      : Boolean(config.allowStyleProp)
 
   state.tailwindConfigIdentifier = program.scope.generateUidIdentifier(
     'tailwindConfig'


### PR DESCRIPTION
In response to #123, using tw`` within a style prop/attribute works for some styles but not for others (eg: `hover:`, `space-y-xxx`). 

This PR adds a check for that kind of usage and pops an error:
```js
<div style={tw`block`} />
```
Results in:

```bash
Styles shouldn’t be added within a `style={...}` prop
Fix: Use the tw or css prop instead: <div tw="" /> or <div css={tw``} />

Disable this error by adding this in your twin config: `{ "allowStyleProp": true }`
Read more at https://twinredirect.page.link/style-prop
```