### PR TITLE
GlobalStyles import for animate-xxx classes and base styles

### DIFF
--- a/docs/emotion/create-react-app.md
+++ b/docs/emotion/create-react-app.md
@@ -25,15 +25,28 @@ yarn add twin.macro @emotion/core @emotion/styled
 
 </details>
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
 
-Add the following to your `app.js` or `index.js`:
-(the dependency 'tailwindcss' is already in your node_modules)
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `src/App.js`:
 
 ```js
-// In your App.js or index.js entry
-import 'tailwindcss/dist/base.min.css'
+// src/App.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const App = () => (
+  <>
+    <GlobalStyles />
+    <App />
+  </>
+)
+
+export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add the recommended config
 

--- a/docs/emotion/gatsby.md
+++ b/docs/emotion/gatsby.md
@@ -34,15 +34,37 @@ module.exports = {
 }
 ```
 
-### 4. Import the Tailwind base styles
+### 4. Add the global styles
 
-Add the following to your `app.js` or `index.js`:
-(the dependency 'tailwindcss' is already in your node_modules)
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add to a layout file in `src/components/Layout.js`:
 
 ```js
-// In your App.js or index.js entry
-import 'tailwindcss/dist/base.min.css'
+// src/components/Layout.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const Layout = ({ children }) => (
+  <>
+    <GlobalStyles />
+    {children}
+  </>
+)
+
+export default Layout
 ```
+
+Then in your pages, wrap your content with the layout:
+
+```js
+// src/pages/index.js
+import Layout from './../components/Layout'
+
+const App = () => <Layout>{/* ... */}</Layout>
+```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 5. Add the recommended config
 

--- a/docs/emotion/next.md
+++ b/docs/emotion/next.md
@@ -36,18 +36,28 @@ yarn add twin.macro @emotion/core @emotion/styled @emotion/babel-preset-css-prop
 }
 ```
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
 
-In `pages/_app.js`, add the following:
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `pages/_app.js`:
 
 ```js
+// page/_app.js
 import React from 'react'
-import 'tailwindcss/dist/base.min.css'
+import { GlobalStyles } from 'twin.macro'
 
-const App = ({ Component, pageProps }) => <Component {...pageProps} />
+const App = ({ Component, pageProps }) => (
+  <>
+    <GlobalStyles />
+    <Component {...pageProps} />
+  </>
+)
 
 export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add the recommended config
 

--- a/docs/emotion/react.md
+++ b/docs/emotion/react.md
@@ -25,15 +25,28 @@ yarn add twin.macro @emotion/core @emotion/styled
 
 </details>
 
-### 2. Import the Tailwind base styles
+### 2. Add the global styles
 
-Add the following to your `app.js` or `index.js`:
-(the dependency 'tailwindcss' is already in your node_modules)
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `src/App.js`:
 
 ```js
-// In your App.js or index.js entry
-import 'tailwindcss/dist/base.min.css'
+// src/App.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const App = () => (
+  <>
+    <GlobalStyles />
+    {/* ... */}
+  </>
+)
+
+export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 3. Add the recommended config
 

--- a/docs/extra-keyframes.md
+++ b/docs/extra-keyframes.md
@@ -1,0 +1,13 @@
+# Avoid adding the animate-xxx keyframes
+
+If you’re not planning on using Tailwinds `animate-xxx` classes then you won’t need their matching `@keyframes` either.
+
+Twin adds the [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) and also the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to your project with `<GlobalStyles />`, so here’s the alternative:
+
+```js
+import 'tailwindcss/dist/base.min.css'
+```
+
+Add that to the same file you define GlobalStyles within - except if you're using Gatsby in which case you should add it to `gatsby-browser.js`.
+
+You don’t need to install `tailwindcss` yourself as twin installs it automatically as a dependency.

--- a/docs/styled-components/create-react-app.md
+++ b/docs/styled-components/create-react-app.md
@@ -25,15 +25,28 @@ yarn add twin.macro styled-components
 
 </details>
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
 
-Add the following to your `app.js` or `index.js`:
-(the dependency 'tailwindcss' is already in your node_modules)
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `src/App.js`:
 
 ```js
-// In your App.js or index.js entry
-import 'tailwindcss/dist/base.min.css'
+// src/App.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const App = () => (
+  <>
+    <GlobalStyles />
+    {/* ... */}
+  </>
+)
+
+export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add the recommended config
 

--- a/docs/styled-components/gatsby.md
+++ b/docs/styled-components/gatsby.md
@@ -25,12 +25,37 @@ yarn add twin.macro styled-components gatsby-plugin-styled-components
 
 </details>
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
+
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add to a layout file in `src/components/Layout.js`:
 
 ```js
-// gatsby-browser.js
-import 'tailwindcss/dist/base.min.css'
+// src/components/Layout.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const Layout = ({ children }) => (
+  <>
+    <GlobalStyles />
+    {children}
+  </>
+)
+
+export default Layout
 ```
+
+Then in your pages, wrap your content with the layout:
+
+```js
+// src/pages/index.js
+import Layout from './../components/Layout'
+
+const App = () => <Layout>{/* ... */}</Layout>
+```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add gatsby-plugin-styled-components to the gatsby config
 

--- a/docs/styled-components/next.md
+++ b/docs/styled-components/next.md
@@ -41,18 +41,28 @@ yarn add twin.macro styled-components
 }
 ```
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
 
-In `pages/_app.js`, add the following:
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `pages/_app.js`:
 
 ```js
+// page/_app.js
 import React from 'react'
-import 'tailwindcss/dist/base.min.css'
+import { GlobalStyles } from 'twin.macro'
 
-const App = ({ Component, pageProps }) => <Component {...pageProps} />
+const App = ({ Component, pageProps }) => (
+  <>
+    <GlobalStyles />
+    <Component {...pageProps} />
+  </>
+)
 
 export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add the recommended config
 

--- a/docs/styled-components/react.md
+++ b/docs/styled-components/react.md
@@ -37,15 +37,28 @@ yarn add twin.macro styled-components
 }
 ```
 
-### 3. Import the Tailwind base styles
+### 3. Add the global styles
 
-Add the following to your `app.js` or `index.js`:
-(the dependency 'tailwindcss' is already in your node_modules)
+Projects using Twin also use the Tailwind [preflight base styles](https://unpkg.com/tailwindcss/dist/base.css) to smooth over cross-browser inconsistencies.
+
+Twin adds the preflight base styles with the `GlobalStyles` import which you can add in `src/App.js`:
 
 ```js
-// In your App.js or index.js entry
-import 'tailwindcss/dist/base.min.css'
+// src/App.js
+import React from 'react'
+import { GlobalStyles } from 'twin.macro'
+
+const App = () => (
+  <>
+    <GlobalStyles />
+    {/* ... */}
+  </>
+)
+
+export default App
 ```
+
+`GlobalStyles` also includes some [@keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/src/config/globalStyles.js) so the `animate-xxx` classes have animations. But if you’re not using the animate classes then you can [avoid adding the extra keyframes](https://github.com/ben-rogerson/twin.macro/blob/master/docs/extra-keyframes.md).
 
 ### 4. Add the recommended config
 

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -1,0 +1,38 @@
+export default `
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+@keyframes ping {
+    0% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    75%, 100% {
+        transform: scale(2);
+        opacity: 0;
+    }
+}
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+@keyframes bounce {
+    0%, 100% {
+        transform: translateY(-25%);
+        animationTimingFunction: cubic-bezier(0.8, 0, 1,1);
+    }
+    50% {
+        transform: translateY(0);
+        animationTimingFunction: cubic-bezier(0, 0, 0.2, 1);
+    }
+}
+`

--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -4,12 +4,15 @@
  * To use, add the preset in package.json/babel macro config:
  *
  * Styled components
+ * { "babelMacros": { "twin": { "preset": "styled-components" } } }
  * module.exports = { twin: { preset: "styled-components" } }
  *
  * Emotion
+ * { "babelMacros": { "twin": { "preset": "emotion" } } }
  * module.exports = { twin: { preset: "emotion" } }
  *
  * Goober
+ * { "babelMacros": { "twin": { "preset": "goober" } } }
  * module.exports = { twin: { preset: "goober" } }
  */
 
@@ -23,6 +26,10 @@ export default {
       import: 'css',
       from: 'styled-components/macro',
     },
+    global: {
+      import: 'createGlobalStyle',
+      from: 'styled-components',
+    },
   },
   emotion: {
     styled: {
@@ -33,6 +40,10 @@ export default {
       import: 'css',
       from: '@emotion/core',
     },
+    global: {
+      import: 'Global',
+      from: '@emotion/core',
+    },
   },
   goober: {
     styled: {
@@ -41,6 +52,10 @@ export default {
     },
     css: {
       import: 'css',
+      from: 'goober',
+    },
+    global: {
+      import: 'glob',
       from: 'goober',
     },
   },

--- a/src/macro/css.js
+++ b/src/macro/css.js
@@ -1,4 +1,4 @@
-import { addImport } from './../macroHelpers'
+import { addImport, generateUid } from './../macroHelpers'
 import { isEmpty } from './../utils'
 import userPresets from './../config/userPresets'
 
@@ -65,11 +65,7 @@ const maybeAddCssProperty = ({ program, t }) => {
    */
   twinImportPath.insertAfter(
     t.importDeclaration(
-      [
-        t.importDefaultSpecifier(
-          program.scope.generateUidIdentifier('cssPropImport')
-        ),
-      ],
+      [t.importDefaultSpecifier(generateUid('cssPropImport', program))],
       t.stringLiteral(styledComponentsMacroImport)
     )
   )

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -1,0 +1,154 @@
+import { addImport, generateUid } from '../macroHelpers'
+import { assert } from '../utils'
+import { logGeneralError } from './../logging'
+import globalStyles from './../config/globalStyles'
+import userPresets from './../config/userPresets'
+
+const getGlobalStylesConfig = config => {
+  const usedConfig =
+    userPresets[config.preset] ||
+    (config.global && config) ||
+    userPresets.emotion
+  return usedConfig.global
+}
+
+const addGlobalStylesImport = ({ program, t, identifier, config }) => {
+  const globalStyleConfig = getGlobalStylesConfig(config)
+  return addImport({
+    types: t,
+    program,
+    identifier,
+    name: globalStyleConfig.import,
+    mod: globalStyleConfig.from,
+  })
+}
+
+const addGlobalCssImport = ({ identifier, t, program }) =>
+  addImport({
+    types: t,
+    program,
+    mod: 'tailwindcss/dist/base.min.css',
+    identifier,
+  })
+
+const generateTaggedTemplateExpression = ({ identifier, t }) => {
+  const backtickStyles = t.templateElement({
+    raw: `${globalStyles}`,
+    cooked: `${globalStyles}`,
+  })
+  const ttExpression = t.taggedTemplateExpression(
+    identifier,
+    t.templateLiteral([backtickStyles], [])
+  )
+  return ttExpression
+}
+
+const getGlobalDeclarationTte = ({ t, stylesUid, globalUid }) =>
+  t.variableDeclaration('const', [
+    t.variableDeclarator(
+      globalUid,
+      generateTaggedTemplateExpression({ t, identifier: stylesUid })
+    ),
+  ])
+
+const getGlobalTte = ({ t, stylesUid }) =>
+  generateTaggedTemplateExpression({ t, identifier: stylesUid })
+
+const getGlobalDeclarationProperty = ({ t, stylesUid, globalUid, state }) => {
+  const ttExpression = generateTaggedTemplateExpression({
+    t,
+    identifier: state.cssIdentifier,
+  })
+
+  const openingElement = t.jsxOpeningElement(
+    t.jsxIdentifier(stylesUid.name),
+    [
+      t.jsxAttribute(
+        t.jsxIdentifier('styles'),
+        t.jsxExpressionContainer(ttExpression)
+      ),
+    ],
+    true
+  )
+
+  const closingElement = t.jsxClosingElement(t.jsxIdentifier('close'))
+
+  const arrowFunctionExpression = t.arrowFunctionExpression(
+    [],
+    t.jsxElement(openingElement, closingElement, [], true)
+  )
+
+  const code = t.variableDeclaration('const', [
+    t.variableDeclarator(globalUid, arrowFunctionExpression),
+  ])
+
+  return code
+}
+
+const handleGlobalStylesFunction = ({
+  references,
+  program,
+  t,
+  state,
+  config,
+}) => {
+  if (!references.GlobalStyles) return
+  if (references.GlobalStyles.length === 0) return
+
+  assert(references.GlobalStyles.length > 1, () =>
+    logGeneralError('Only one GlobalStyles import can be used')
+  )
+
+  const path = references.GlobalStyles[0]
+  const parentPath = path.findParent(x => x.isJSXElement())
+
+  assert(state.isStyledComponents && !parentPath, () =>
+    logGeneralError(
+      'GlobalStyles must be added as a JSX element, eg: <GlobalStyles />'
+    )
+  )
+
+  const globalUid = generateUid('GlobalStyles', program)
+  const stylesUid = generateUid('globalImport', program)
+
+  if (state.isStyledComponents) {
+    const declaration = getGlobalDeclarationTte({
+      t,
+      globalUid,
+      stylesUid,
+    })
+    program.unshiftContainer('body', declaration)
+    path.replaceWith(t.jSXIdentifier(globalUid.name))
+  }
+
+  if (state.isEmotion) {
+    const declaration = getGlobalDeclarationProperty({
+      t,
+      globalUid,
+      stylesUid,
+      state,
+    })
+    program.unshiftContainer('body', declaration)
+    path.replaceWith(t.jSXIdentifier(globalUid.name))
+    state.isImportingCss = true
+  }
+
+  if (state.isGoober) {
+    const declaration = getGlobalTte({ t, stylesUid })
+    program.unshiftContainer('body', declaration)
+    parentPath.remove()
+  }
+
+  const baseCssIdentifier = generateUid('baseCss', program)
+
+  addGlobalCssImport({ identifier: baseCssIdentifier, t, program })
+
+  addGlobalStylesImport({
+    identifier: stylesUid,
+    t,
+    program,
+    config,
+  })
+}
+
+export { handleGlobalStylesFunction }

--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -6,14 +6,15 @@ const SPREAD_ID = '__spread__'
 const COMPUTED_ID = '__computed__'
 
 function addImport({ types: t, program, mod, name, identifier }) {
+  const importName =
+    name === 'default'
+      ? [t.importDefaultSpecifier(identifier)]
+      : name
+      ? [t.importSpecifier(identifier, t.identifier(name))]
+      : []
   program.unshiftContainer(
     'body',
-    t.importDeclaration(
-      name === 'default'
-        ? [t.importDefaultSpecifier(identifier)]
-        : [t.importSpecifier(identifier, t.identifier(name))],
-      t.stringLiteral(mod)
-    )
+    t.importDeclaration(importName, t.stringLiteral(mod))
   )
 }
 
@@ -198,6 +199,7 @@ const validImports = new Set([
   'theme',
   'TwStyle',
   'ThemeStyle',
+  'GlobalStyles',
 ])
 const validateImports = imports => {
   const unsupportedImport = Object.keys(imports).find(
@@ -218,6 +220,8 @@ const validateImports = imports => {
   )
 }
 
+const generateUid = (name, program) => program.scope.generateUidIdentifier(name)
+
 export {
   SPREAD_ID,
   COMPUTED_ID,
@@ -228,4 +232,5 @@ export {
   parseTte,
   replaceWithLocation,
   validateImports,
+  generateUid,
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,44 +64,9 @@ const textStyles = theme => ({
   },
 })
 
-const animations = {
-  animation: {
-    none: 'none',
-    spin: 'spin 1s linear infinite',
-    ping: 'ping 1s cubic-bezier(0, 0, 0.2, 1) infinite',
-    pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-    bounce: 'bounce 1s infinite',
-  },
-  keyframes: {
-    spin: {
-      from: { transform: 'rotate(0deg)' },
-      to: { transform: 'rotate(360deg)' },
-    },
-    ping: {
-      '0%': { transform: 'scale(1)', opacity: '1' },
-      '75%, 100%': { transform: 'scale(2)', opacity: '0' },
-    },
-    pulse: {
-      '0%, 100%': { opacity: '1' },
-      '50%': { opacity: '.5' },
-    },
-    bounce: {
-      '0%, 100%': {
-        transform: 'translateY(-25%)',
-        animationTimingFunction: 'cubic-bezier(0.8,0,1,1)',
-      },
-      '50%': {
-        transform: 'translateY(0)',
-        animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
-      },
-    },
-  },
-}
-
 module.exports = {
   dark: 'class',
   theme: {
-    ...animations,
     container: {
       padding: {
         default: ['1rem', '2rem'],


### PR DESCRIPTION
In response to #127, this PR adds a `<GlobalStyles />` import which:

1. Replaces the need to add the [base.min.css](https://unpkg.com/tailwindcss/dist/base.css) import yourself, eg: `import 'tailwindcss/dist/base.min.css'`
2. Adds the @keyframes matched with the `animate-xxx` classes so the animations work correctly

General usage is like this:

```js
// src/App.js
import React from 'react'
import { GlobalStyles } from 'twin.macro'

const App = () => (
  <>
    <GlobalStyles />
    <App />
  </>
)

export default App
```

In styled-components, this roughly converts to:

```js
import { createGlobalStyle } from 'styled-components'
import 'tailwindcss/dist/base.min.css'

const GlobalBase = createGlobalStyle`
  // animate-xxx keyframes
`
const App = () => (
  <>
    <GlobalBase />
    <App />
  </>
)

export default App
```

...and this in emotion:

```js
import { css } from "@emotion/core";
import { Global } from "@emotion/core";
import "tailwindcss/dist/base.min.css";

const GlobalBase = () => <Global styles={css`
  // animate-xxx keyframes
`} />

const App = () => (
  <>
    <GlobalBase />
    <App />
  </>
)

export default App;
```

Update:
I've updated the examples above so they reflect the final version of this feature.
Below is a discussion on the original version of this feature.