### PR TITLE
Add justify-evenly

### DIFF
--- a/__fixtures__/flexbox.js
+++ b/__fixtures__/flexbox.js
@@ -38,6 +38,7 @@ tw`justify-center`
 tw`justify-end`
 tw`justify-between`
 tw`justify-around`
+tw`justify-evenly`
 
 // https://tailwindcss.com/docs/flex
 tw`flex-initial`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -4624,6 +4624,7 @@ tw\`justify-center\`
 tw\`justify-end\`
 tw\`justify-between\`
 tw\`justify-around\`
+tw\`justify-evenly\`
 
 // https://tailwindcss.com/docs/flex
 tw\`flex-initial\`
@@ -4744,6 +4745,9 @@ tw\`order-12\`
 })
 ;({
   justifyContent: 'space-around',
+})
+;({
+  justifyContent: 'space-evenly',
 }) // https://tailwindcss.com/docs/flex
 
 ;({

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -238,6 +238,9 @@ export default {
   'justify-around': {
     output: { justifyContent: 'space-around' },
   },
+  'justify-evenly': {
+    output: { justifyContent: 'space-evenly' },
+  },
 
   // https://tailwindcss.com/docs/flex
   // https://tailwindcss.com/docs/flex-grow


### PR DESCRIPTION
This PR adds the missing `justify-evenly` class:

```js
import tw from 'twin.macro'

tw`justify-evenly`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "justifyContent": "space-evenly"
});
```