### PR TITLE
Add dark and light mode variants

### DIFF
--- a/__fixtures__/!variants.js
+++ b/__fixtures__/!variants.js
@@ -60,4 +60,12 @@ tw`focus-within:flex`
 tw`motion-safe:flex`
 tw`motion-reduce:flex`
 
+// Dark/Light themes
+tw`dark:bg-black`
+tw`light:bg-black`
+tw`dark:sm:bg-black`
+tw`light:sm:bg-black`
+tw`dark:group-hover:sm:bg-black`
+tw`light:group-hocus:sm:bg-black`
+
 const multiVariants = tw`xl:placeholder-red-500! first:md:block sm:disabled:flex`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1892,6 +1892,14 @@ tw\`focus-within:flex\`
 tw\`motion-safe:flex\`
 tw\`motion-reduce:flex\`
 
+// Dark/Light themes
+tw\`dark:bg-black\`
+tw\`light:bg-black\`
+tw\`dark:sm:bg-black\`
+tw\`light:sm:bg-black\`
+tw\`dark:group-hover:sm:bg-black\`
+tw\`light:group-hocus:sm:bg-black\`
+
 const multiVariants = tw\`xl:placeholder-red-500! first:md:block sm:disabled:flex\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -2136,6 +2144,51 @@ const multiVariants = tw\`xl:placeholder-red-500! first:md:block sm:disabled:fle
 ;({
   '@media (prefers-reduced-motion: reduce)': {
     display: 'flex',
+  },
+}) // Dark/Light themes
+
+;({
+  '.dark &': {
+    '--bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+  },
+})
+;({
+  '.light &': {
+    '--bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+  },
+})
+;({
+  '.dark &': {
+    '@media (min-width: 640px)': {
+      '--bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+    },
+  },
+})
+;({
+  '.light &': {
+    '@media (min-width: 640px)': {
+      '--bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+    },
+  },
+})
+;({
+  '.dark .group:hover &, .dark.group:hover &': {
+    '@media (min-width: 640px)': {
+      '--bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+    },
+  },
+})
+;({
+  '.light .group:hover &, .light .group:focus &, .light.group:hover &, .light.group:focus &': {
+    '@media (min-width: 640px)': {
+      '--bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--bg-opacity))',
+    },
   },
 })
 const multiVariants = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5202,6 +5202,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -13972,9 +13977,9 @@
       }
     },
     "tailwindcss": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.7.5.tgz",
-      "integrity": "sha512-thDHLkRioJh0/62EFcEfQCCBEsZXpluehymrPzn8Hkycy8uI9svvtOqyWtcfkBPB0s5yb6R2tY9zPzh5mIr0Wg==",
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.8.8.tgz",
+      "integrity": "sha512-MCaTFA+ae278rYeB0UTJAkWJMW5eYMMO6/XXBL0oo+SKuZCM4uCFskroHbMFvQSoA96sslFX2+tCPDOv1T7Tbw==",
       "requires": {
         "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
@@ -13984,6 +13989,7 @@
         "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
+        "html-tags": "^3.1.0",
         "lodash": "^4.17.20",
         "node-emoji": "^1.8.1",
         "normalize.css": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dset": "^2.0.1",
     "lodash.merge": "^4.6.2",
     "string-similarity": "^4.0.1",
-    "tailwindcss": "^1.7.5",
+    "tailwindcss": "^1.8.8",
     "timsort": "^0.3.0"
   },
   "peerDependencies": {

--- a/src/config/variantConfig.js
+++ b/src/config/variantConfig.js
@@ -57,16 +57,90 @@ export default {
   'odd-of-type': ':nth-of-type(odd)',
 
   // Group states
-  // Add className="group" to an ancestor and add these on the children
+  // You'll need to add className="group" to an ancestor to make these work
   // https://github.com/ben-rogerson/twin.macro/blob/master/docs/group.md
-  'group-hover': '.group:hover &', // Tailwind
-  'group-focus': '.group:focus &', // Tailwind
-  'group-hocus': '.group:hover &, .group:focus &',
-  'group-active': '.group:active &',
-  'group-visited': '.group:visited &',
+  'group-hover': variantData =>
+    generateGroupSelector('.group:hover &', variantData), // Tailwind
+  'group-focus': variantData =>
+    generateGroupSelector('.group:focus &', variantData), // Tailwind
+  'group-hocus': variantData =>
+    generateGroupSelector('.group:hover &, .group:focus &', variantData),
+  'group-active': variantData =>
+    generateGroupSelector('.group:active &', variantData),
+  'group-visited': variantData =>
+    generateGroupSelector('.group:visited &', variantData),
 
   // Motion control
   // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
   'motion-safe': '@media (prefers-reduced-motion: no-preference)',
   'motion-reduce': '@media (prefers-reduced-motion: reduce)',
+
+  // Dark theme
+  dark: ({ hasGroupVariant, config, errorCustom }) => {
+    const styles =
+      {
+        // Media strategy: The default when you prepend with dark, tw`dark:block`
+        media: '@media (prefers-color-scheme: dark)',
+        // Class strategy: In your tailwind.config.js, add `{ dark: 'class' }
+        // then add a `className="dark"` on a parent element.
+        class: !hasGroupVariant && '.dark &',
+      }[config('dark') || 'media'] || null
+
+    if (!styles && !hasGroupVariant) {
+      errorCustom(
+        "The `dark` config option must be either `{ dark: 'media' }` (default) or `{ dark: 'class' }`"
+      )
+    }
+
+    return styles
+  },
+
+  // Light theme
+  light: ({ hasGroupVariant, config, errorCustom }) => {
+    const styles =
+      {
+        // Media strategy: The default when you prepend with light, tw`light:block`
+        media: '@media (prefers-color-scheme: light)',
+        // Class strategy: In your tailwind.config.js, add `{ light: 'class' }
+        // then add a `className="light"` on a parent element.
+        class: !hasGroupVariant && '.light &',
+      }[config('light') || config('dark') || 'media'] || null
+
+    if (!styles && !hasGroupVariant) {
+      if (config('light')) {
+        errorCustom(
+          "The `light` config option must be either `{ light: 'media' }` (default) or `{ light: 'class' }`"
+        )
+      }
+
+      errorCustom(
+        "The `dark` config option must be either `{ dark: 'media' }` (default) or `{ dark: 'class' }`"
+      )
+    }
+
+    return styles
+  },
+}
+
+const generateGroupSelector = (
+  className,
+  { hasDarkVariant, hasLightVariant, config }
+) => {
+  const themeVariant =
+    (hasDarkVariant && config('dark') === 'class' && ['dark ', 'dark']) ||
+    (hasLightVariant &&
+      (config('light') === 'class' || config('dark') === 'class') && [
+        'light ',
+        'light',
+      ])
+  return themeVariant
+    ? themeVariant
+        .map(v =>
+          className
+            .split(', ')
+            .map(cn => `.${v}${cn}`)
+            .join(', ')
+        )
+        .join(', ')
+    : className
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -99,6 +99,7 @@ const animations = {
 }
 
 module.exports = {
+  dark: 'class',
   theme: {
     ...animations,
     container: {


### PR DESCRIPTION
Following [the new tailwind darkmode feature](https://github.com/tailwindlabs/tailwindcss/pull/2279), twin has also added the dark mode variant:

#### Darkmode: Default

```js
tw`dark:bg-black`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "@media (prefers-color-scheme: dark)": {
    "--bg-opacity": "1",
    "backgroundColor": "rgba(0, 0, 0, var(--bg-opacity))"
  }
});
```

#### Darkmode: Class strategy

If you add `{ dark: 'class' }` to your config:

```js
tw`dark:bg-black`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  ".dark &": {
    "--bg-opacity": "1",
    "backgroundColor": "rgba(0, 0, 0, var(--bg-opacity))"
  }
});
```

With the class strategy, you'll need to add a className of `dark` on a parent element to make this strategy work (it can be dynamic too):

```js
<div className="dark"><button tw="dark:bg-black">Hi</button></div>
```

## Extra: Light mode

I've also added a light mode variant that works similarly:

#### Lightmode: Default

```js
tw`light:bg-white`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "@media (prefers-color-scheme: light)": {
    "--bg-opacity": "1",
    "backgroundColor": "rgba(0, 0, 0, var(--bg-opacity))"
  }
});
```

#### Lightmode: Class strategy

If you add `{ dark: 'class' }` (or `{ light: 'class' }`) to your config:

```js
tw`light:bg-white`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  ".light &": {
    "--bg-opacity": "1",
    "backgroundColor": "rgba(255, 255, 255, var(--bg-opacity))"
  }
});
```


With the class strategy, you'll need to add a className of `light` on a parent element to make this strategy work (it can be dynamic too):

```js
<div className="light"><button tw="light:bg-white">Hi</button></div>
```