### PR TITLE
Add font variant numeric utilities

### DIFF
--- a/__fixtures__/typography.js
+++ b/__fixtures__/typography.js
@@ -421,3 +421,14 @@ tw`break-normal`
 tw`break-words`
 tw`break-all`
 tw`truncate`
+
+// font-variant-numeric
+tw`ordinal`
+tw`slashed-zero`
+tw`lining-nums`
+tw`oldstyle-nums`
+tw`proportional-nums`
+tw`tabular-nums`
+tw`diagonal-fractions`
+tw`stacked-fractions`
+tw`normal-nums`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -11951,6 +11951,17 @@ tw\`break-words\`
 tw\`break-all\`
 tw\`truncate\`
 
+// font-variant-numeric
+tw\`ordinal\`
+tw\`slashed-zero\`
+tw\`lining-nums\`
+tw\`oldstyle-nums\`
+tw\`proportional-nums\`
+tw\`tabular-nums\`
+tw\`diagonal-fractions\`
+tw\`stacked-fractions\`
+tw\`normal-nums\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 // https://tailwindcss.com/docs/font-family
@@ -13590,6 +13601,82 @@ tw\`truncate\`
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+}) // font-variant-numeric
+
+;({
+  '--font-variant-numeric-ordinal': 'ordinal',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'slashed-zero',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'lining-nums',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'oldstyle-nums',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'proportional-nums',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'tabular-nums',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'diagonal-fractions',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'stacked-fractions',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+})
+;({
+  fontVariantNumeric: 'normal',
 })
 
 

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -1,3 +1,16 @@
+// https://tailwindcss.com/docs/font-variant-numeric
+// This feature uses var+comment hacks to get around property stripping:
+// https://github.com/tailwindlabs/tailwindcss.com/issues/522#issuecomment-687667238
+const fontVariants = {
+  '--font-variant-numeric-ordinal': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-slashed-zero': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-figure': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-spacing': 'var(--twin-empty,/*!*/ /*!*/)',
+  '--font-variant-numeric-fraction': 'var(--twin-empty,/*!*/ /*!*/)',
+  fontVariantNumeric:
+    'var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)',
+}
+
 export default {
   /**
    * ===========================================
@@ -318,6 +331,57 @@ export default {
   'not-italic': { output: { fontStyle: 'normal' } },
 
   // https://tailwindcss.com/docs/font-weight
+  // See dynamicStyles.js
+
+  // https://tailwindcss.com/docs/font-variant-numeric
+  ordinal: {
+    output: { ...fontVariants, '--font-variant-numeric-ordinal': 'ordinal' },
+  },
+  'slashed-zero': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-slashed-zero': 'slashed-zero',
+    },
+  },
+  'lining-nums': {
+    output: { ...fontVariants, '--font-variant-numeric-figure': 'lining-nums' },
+  },
+  'oldstyle-nums': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-figure': 'oldstyle-nums',
+    },
+  },
+  'proportional-nums': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-spacing': 'proportional-nums',
+    },
+  },
+  'tabular-nums': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-spacing': 'tabular-nums',
+    },
+  },
+  'diagonal-fractions': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-fraction': 'diagonal-fractions',
+    },
+  },
+  'stacked-fractions': {
+    output: {
+      ...fontVariants,
+      '--font-variant-numeric-fraction': 'stacked-fractions',
+    },
+  },
+  'normal-nums': {
+    output: {
+      fontVariantNumeric: 'normal',
+    },
+  },
+
   // https://tailwindcss.com/docs/letter-spacing
   // https://tailwindcss.com/docs/line-height
   // https://tailwindcss.com/docs/list-style-type


### PR DESCRIPTION
This PR adds the new font-variant-numeric classes.

This feature uses the "empty comment variable fallback hack" to avoid [@emotion/stylis](https://github.com/emotion-js/emotion/tree/master/packages/stylis) stripping out the properties. This is the same technique [Adam has used in Tailwind](https://github.com/tailwindlabs/tailwindcss.com/issues/522#issuecomment-687667238):

```js
import tw from 'twin.macro'

tw`ordinal`
tw`slashed-zero`
tw`lining-nums`
tw`oldstyle-nums`
tw`proportional-nums`
tw`tabular-nums`
tw`diagonal-fractions`
tw`stacked-fractions`
tw`normal-nums`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "--font-variant-numeric-ordinal": "ordinal",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "slashed-zero",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "lining-nums",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "oldstyle-nums",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "proportional-nums",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "tabular-nums",
  "--font-variant-numeric-fraction": "var(--twin-empty,/*!*/ /*!*/)",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "diagonal-fractions",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "--font-variant-numeric-ordinal": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-slashed-zero": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-figure": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-spacing": "var(--twin-empty,/*!*/ /*!*/)",
  "--font-variant-numeric-fraction": "stacked-fractions",
  "fontVariantNumeric": "var(--font-variant-numeric-ordinal) var(--font-variant-numeric-slashed-zero) var(--font-variant-numeric-figure) var(--font-variant-numeric-spacing) var(--font-variant-numeric-fraction)"
});
({
  "fontVariantNumeric": "normal"
});
```