### PR TITLE
Container updates

### DIFF
--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -7594,6 +7594,21 @@ tw\`space-y-12 -space-y-reverse\`
     marginLeft: '7rem',
     marginRight: '7rem',
   },
+  '@media (min-width: 968px)': {
+    maxWidth: '968px',
+    paddingLeft: '8rem',
+    paddingRight: '8rem',
+  },
+  '@media (min-width: 992px)': {
+    maxWidth: '992px',
+    paddingLeft: '10rem',
+    paddingRight: '10rem',
+  },
+  '@media (min-width: 1200px)': {
+    maxWidth: '1200px',
+    paddingLeft: '12rem',
+    paddingRight: '12rem',
+  },
 }) // https://tailwindcss.com/docs/box-sizing
 
 ;({

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -38,18 +38,26 @@ export default ({
   hasImportant && errorNoImportant()
   hasNegative && errorNoNegatives()
 
-  const { container, screens } = theme()
+  const { container, screens: screensRaw } = theme()
   const { padding, margin, center } = container
 
+  const screens = container.screens || screensRaw
+
   const mediaScreens = Object.entries(screens).reduce(
-    (accumulator, [key, value]) => ({
-      ...accumulator,
-      [`@media (min-width: ${value})`]: {
-        maxWidth: value,
-        ...getSpacingStyle('padding', padding, key),
-        ...(!center && getSpacingStyle('margin', margin, key)),
-      },
-    }),
+    (accumulator, [key, rawValue]) => {
+      const value =
+        typeof rawValue === 'object'
+          ? rawValue.min || rawValue['min-width']
+          : rawValue
+      return {
+        ...accumulator,
+        [`@media (min-width: ${value})`]: {
+          maxWidth: value,
+          ...(padding && getSpacingStyle('padding', padding, key)),
+          ...(!center && margin && getSpacingStyle('margin', margin, key)),
+        },
+      }
+    },
     {}
   )
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -107,6 +107,9 @@ module.exports = {
         sm: ['2rem'],
         lg: '4rem',
         xl: '6rem',
+        object: '8rem',
+        'object-width': '10rem',
+        'object-min-max': '12rem',
       },
       margin: {
         default: ['2rem', '3rem'],
@@ -122,6 +125,11 @@ module.exports = {
     },
     textStyles,
     extend: {
+      screens: {
+        object: { min: '968px' },
+        'object-width': { 'min-width': '992px' },
+        'object-min-max': { min: '1200px', max: '1600px' },
+      },
       colors: {
         number: 0,
         'purple-hyphen': 'purple',


### PR DESCRIPTION
This PR adds some missing features with the container class such as reading from the container.screens key if specified and supporting screens when defined like this:

```js
screens: {
  sm: '576px',
  md: { min: '768px' },
  lg: { 'min-width': '992px' },
  xl: { min: '1200px', max: '1600px' },
},
```