### PR TITLE
Fix JSX pragma setup instruction order

### DIFF
--- a/docs/emotion/react.md
+++ b/docs/emotion/react.md
@@ -95,6 +95,18 @@ You can avoid adding the pragma yourself with the following babel config:
 }
 ```
 
+Then you can import react like normal:
+
+```js
+import React from 'react'
+import tw from 'twin.macro'
+
+const Input = () => <input tw="bg-black" />
+// or
+const Input = () => <input css={tw`bg-black`} />
+```
+
+
 **b) Or add the jsx pragma manually:**
 
 ```js
@@ -112,17 +124,6 @@ Then when styling with the tw/css prop, add the two lines for the pragma at the 
 ```js
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
-import tw from 'twin.macro'
-
-const Input = () => <input tw="bg-black" />
-// or
-const Input = () => <input css={tw`bg-black`} />
-```
-
-Then you can import react like normal:
-
-```js
-import React from 'react'
 import tw from 'twin.macro'
 
 const Input = () => <input tw="bg-black" />


### PR DESCRIPTION
It looks like the component imports for a) automatical and b) manual JSX pragma insertion are mixed.

By the way, automatic insertion still doesn't work in my project for production builds, so I'm a bit uncertain if this is the required doc change or that I just don't understand the instructions.

*PS: Feel free to rebase, because the commit message is the same as PR description when creating this PR via GitHub website*