### PR TITLE
Add the 'css' to ts definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -56,4 +56,5 @@ declare global {
 }
 
 declare const theme: ThemeFn
-export { theme }
+declare const css;
+export { theme, css }


### PR DESCRIPTION
I noticed that when working with typescript, I got an error when trying to import `css` object from `twin.macro`
```
import tw, { css, theme } from 'twin.macro';
```

![imagen](https://user-images.githubusercontent.com/2032683/95843786-65b37c00-0d48-11eb-87af-01ed041babcd.png)
