### PR TITLE
Add tests for `row-span-full` and `col-span-full` classes

### DIFF
--- a/__fixtures__/grid.js
+++ b/__fixtures__/grid.js
@@ -29,6 +29,7 @@ tw`col-span-9`
 tw`col-span-10`
 tw`col-span-11`
 tw`col-span-12`
+tw`col-span-full`
 tw`col-start-1`
 tw`col-start-2`
 tw`col-start-3`
@@ -75,6 +76,7 @@ tw`row-span-3`
 tw`row-span-4`
 tw`row-span-5`
 tw`row-span-6`
+tw`row-span-full`
 tw`row-start-1`
 tw`row-start-2`
 tw`row-start-3`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -6559,6 +6559,7 @@ tw\`col-span-9\`
 tw\`col-span-10\`
 tw\`col-span-11\`
 tw\`col-span-12\`
+tw\`col-span-full\`
 tw\`col-start-1\`
 tw\`col-start-2\`
 tw\`col-start-3\`
@@ -6605,6 +6606,7 @@ tw\`row-span-3\`
 tw\`row-span-4\`
 tw\`row-span-5\`
 tw\`row-span-6\`
+tw\`row-span-full\`
 tw\`row-start-1\`
 tw\`row-start-2\`
 tw\`row-start-3\`
@@ -6851,6 +6853,9 @@ tw\`place-self-stretch\`
   gridColumn: 'span 12 / span 12',
 })
 ;({
+  gridColumn: '1 / -1',
+})
+;({
   gridColumnStart: '1',
 })
 ;({
@@ -6977,6 +6982,9 @@ tw\`place-self-stretch\`
 })
 ;({
   gridRow: 'span 6 / span 6',
+})
+;({
+  gridRow: '1 / -1',
 })
 ;({
   gridRowStart: '1',


### PR DESCRIPTION
This PR adds tests for the [new col and row span classes in Tailwindcss@1.9.0](https://github.com/tailwindlabs/tailwindcss/pull/2471). Further work isn't required as the updates come down the stream in the default config change from tailwindcss.

```js
import tw from 'twin.macro'

tw`row-span-full`
tw`col-span-full`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "gridRow": "1 / -1"
});
({
  "gridColumn": "1 / -1"
});
```