### PR TITLE
Add tests for smaller rotate and skew values

### DIFF
--- a/__fixtures__/transforms.js
+++ b/__fixtures__/transforms.js
@@ -34,12 +34,22 @@ tw`scale-y-150`
 
 // https://tailwindcss.com/docs/rotate
 tw`rotate-0`
+tw`rotate-1`
+tw`rotate-2`
+tw`rotate-3`
+tw`rotate-6`
+tw`rotate-12`
 tw`rotate-45`
 tw`rotate-90`
 tw`rotate-180`
-tw`-rotate-180`
-tw`-rotate-90`
+tw`-rotate-1`
+tw`-rotate-2`
+tw`-rotate-3`
+tw`-rotate-6`
+tw`-rotate-12`
 tw`-rotate-45`
+tw`-rotate-90`
+tw`-rotate-180`
 
 // https://tailwindcss.com/docs/translate
 tw`translate-x-0`
@@ -127,19 +137,27 @@ tw`translate-y-full`
 
 // https://tailwindcss.com/docs/skew
 tw`skew-x-0`
+tw`skew-x-1`
+tw`skew-x-2`
 tw`skew-x-3`
 tw`skew-x-6`
 tw`skew-x-12`
-tw`-skew-x-12`
-tw`-skew-x-6`
+tw`-skew-x-1`
+tw`-skew-x-2`
 tw`-skew-x-3`
+tw`-skew-x-6`
+tw`-skew-x-12`
 tw`skew-y-0`
+tw`skew-y-1`
+tw`skew-y-2`
 tw`skew-y-3`
 tw`skew-y-6`
 tw`skew-y-12`
-tw`-skew-y-12`
-tw`-skew-y-6`
+tw`-skew-y-1`
+tw`-skew-y-2`
 tw`-skew-y-3`
+tw`-skew-y-6`
+tw`-skew-y-12`
 
 // https://tailwindcss.com/docs/transform-origin
 tw`origin-center`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -11002,12 +11002,22 @@ tw\`scale-y-150\`
 
 // https://tailwindcss.com/docs/rotate
 tw\`rotate-0\`
+tw\`rotate-1\`
+tw\`rotate-2\`
+tw\`rotate-3\`
+tw\`rotate-6\`
+tw\`rotate-12\`
 tw\`rotate-45\`
 tw\`rotate-90\`
 tw\`rotate-180\`
-tw\`-rotate-180\`
-tw\`-rotate-90\`
+tw\`-rotate-1\`
+tw\`-rotate-2\`
+tw\`-rotate-3\`
+tw\`-rotate-6\`
+tw\`-rotate-12\`
 tw\`-rotate-45\`
+tw\`-rotate-90\`
+tw\`-rotate-180\`
 
 // https://tailwindcss.com/docs/translate
 tw\`translate-x-0\`
@@ -11095,19 +11105,27 @@ tw\`translate-y-full\`
 
 // https://tailwindcss.com/docs/skew
 tw\`skew-x-0\`
+tw\`skew-x-1\`
+tw\`skew-x-2\`
 tw\`skew-x-3\`
 tw\`skew-x-6\`
 tw\`skew-x-12\`
-tw\`-skew-x-12\`
-tw\`-skew-x-6\`
+tw\`-skew-x-1\`
+tw\`-skew-x-2\`
 tw\`-skew-x-3\`
+tw\`-skew-x-6\`
+tw\`-skew-x-12\`
 tw\`skew-y-0\`
+tw\`skew-y-1\`
+tw\`skew-y-2\`
 tw\`skew-y-3\`
 tw\`skew-y-6\`
 tw\`skew-y-12\`
-tw\`-skew-y-12\`
-tw\`-skew-y-6\`
+tw\`-skew-y-1\`
+tw\`-skew-y-2\`
 tw\`-skew-y-3\`
+tw\`-skew-y-6\`
+tw\`-skew-y-12\`
 
 // https://tailwindcss.com/docs/transform-origin
 tw\`origin-center\`
@@ -11230,6 +11248,21 @@ tw\`transform\`
   '--transform-rotate': '0',
 })
 ;({
+  '--transform-rotate': '1deg',
+})
+;({
+  '--transform-rotate': '2deg',
+})
+;({
+  '--transform-rotate': '3deg',
+})
+;({
+  '--transform-rotate': '6deg',
+})
+;({
+  '--transform-rotate': '12deg',
+})
+;({
   '--transform-rotate': '45deg',
 })
 ;({
@@ -11239,13 +11272,28 @@ tw\`transform\`
   '--transform-rotate': '180deg',
 })
 ;({
-  '--transform-rotate': '-180deg',
+  '--transform-rotate': '-1deg',
+})
+;({
+  '--transform-rotate': '-2deg',
+})
+;({
+  '--transform-rotate': '-3deg',
+})
+;({
+  '--transform-rotate': '-6deg',
+})
+;({
+  '--transform-rotate': '-12deg',
+})
+;({
+  '--transform-rotate': '-45deg',
 })
 ;({
   '--transform-rotate': '-90deg',
 })
 ;({
-  '--transform-rotate': '-45deg',
+  '--transform-rotate': '-180deg',
 }) // https://tailwindcss.com/docs/translate
 
 ;({
@@ -11499,6 +11547,12 @@ tw\`transform\`
   '--transform-skew-x': '0',
 })
 ;({
+  '--transform-skew-x': '1deg',
+})
+;({
+  '--transform-skew-x': '2deg',
+})
+;({
   '--transform-skew-x': '3deg',
 })
 ;({
@@ -11508,16 +11562,28 @@ tw\`transform\`
   '--transform-skew-x': '12deg',
 })
 ;({
-  '--transform-skew-x': '-12deg',
+  '--transform-skew-x': '-1deg',
 })
 ;({
-  '--transform-skew-x': '-6deg',
+  '--transform-skew-x': '-2deg',
 })
 ;({
   '--transform-skew-x': '-3deg',
 })
 ;({
+  '--transform-skew-x': '-6deg',
+})
+;({
+  '--transform-skew-x': '-12deg',
+})
+;({
   '--transform-skew-y': '0',
+})
+;({
+  '--transform-skew-y': '1deg',
+})
+;({
+  '--transform-skew-y': '2deg',
 })
 ;({
   '--transform-skew-y': '3deg',
@@ -11529,13 +11595,19 @@ tw\`transform\`
   '--transform-skew-y': '12deg',
 })
 ;({
-  '--transform-skew-y': '-12deg',
+  '--transform-skew-y': '-1deg',
+})
+;({
+  '--transform-skew-y': '-2deg',
+})
+;({
+  '--transform-skew-y': '-3deg',
 })
 ;({
   '--transform-skew-y': '-6deg',
 })
 ;({
-  '--transform-skew-y': '-3deg',
+  '--transform-skew-y': '-12deg',
 }) // https://tailwindcss.com/docs/transform-origin
 
 ;({


### PR DESCRIPTION
This PR adds tests for the [new smaller rotate and skew classes in Tailwindcss@1.9.0](https://github.com/tailwindlabs/tailwindcss/pull/2528). Further work isn't required as the updates come down the stream in the default config change from tailwindcss.

```js
import tw from 'twin.macro'

tw`rotate-1`
tw`rotate-2`
tw`rotate-3`
tw`rotate-6`
tw`rotate-12`

tw`-rotate-1`
tw`-rotate-2`
tw`-rotate-3`
tw`-rotate-6`
tw`-rotate-12`

tw`skew-x-1`
tw`skew-x-2`

tw`-skew-x-1`
tw`-skew-x-2`

tw`skew-y-1`
tw`skew-y-2`

tw`-skew-y-1`
tw`-skew-y-2`


// ↓ ↓ ↓ ↓ ↓ ↓

({
  "--transform-rotate": "1deg"
});
({
  "--transform-rotate": "2deg"
});
({
  "--transform-rotate": "3deg"
});
({
  "--transform-rotate": "6deg"
});
({
  "--transform-rotate": "12deg"
});
({
  "--transform-rotate": "-1deg"
});
({
  "--transform-rotate": "-2deg"
});
({
  "--transform-rotate": "-3deg"
});
({
  "--transform-rotate": "-6deg"
});
({
  "--transform-rotate": "-12deg"
});
({
  "--transform-skew-x": "1deg"
});
({
  "--transform-skew-x": "2deg"
});
({
  "--transform-skew-x": "-1deg"
});
({
  "--transform-skew-x": "-2deg"
});
({
  "--transform-skew-y": "1deg"
});
({
  "--transform-skew-y": "2deg"
});
({
  "--transform-skew-y": "-1deg"
});
({
  "--transform-skew-y": "-2deg"
});
```