### PR TITLE
Add new classes for `grid-auto-columns` and `grid-auto-rows`

### DIFF
--- a/__fixtures__/grid.js
+++ b/__fixtures__/grid.js
@@ -203,6 +203,18 @@ tw`grid-flow-col`
 tw`grid-flow-row-dense`
 tw`grid-flow-col-dense`
 
+// https://tailwindcss.com/docs/grid-auto-columns
+tw`auto-cols-auto`
+tw`auto-cols-min`
+tw`auto-cols-max`
+tw`auto-cols-fr`
+
+// https://tailwindcss.com/docs/grid-auto-rows
+tw`auto-rows-auto`
+tw`auto-rows-min`
+tw`auto-rows-max`
+tw`auto-rows-fr`
+
 // Grid alignment utilities
 // https://github.com/tailwindlabs/tailwindcss/pull/2306
 

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -6733,6 +6733,18 @@ tw\`grid-flow-col\`
 tw\`grid-flow-row-dense\`
 tw\`grid-flow-col-dense\`
 
+// https://tailwindcss.com/docs/grid-auto-columns
+tw\`auto-cols-auto\`
+tw\`auto-cols-min\`
+tw\`auto-cols-max\`
+tw\`auto-cols-fr\`
+
+// https://tailwindcss.com/docs/grid-auto-rows
+tw\`auto-rows-auto\`
+tw\`auto-rows-min\`
+tw\`auto-rows-max\`
+tw\`auto-rows-fr\`
+
 // Grid alignment utilities
 // https://github.com/tailwindlabs/tailwindcss/pull/2306
 
@@ -7328,6 +7340,32 @@ tw\`place-self-stretch\`
 })
 ;({
   gridAutoFlow: 'col dense',
+}) // https://tailwindcss.com/docs/grid-auto-columns
+
+;({
+  gridAutoColumns: 'auto',
+})
+;({
+  gridAutoColumns: 'min-content',
+})
+;({
+  gridAutoColumns: 'max-content',
+})
+;({
+  gridAutoColumns: 'minmax(0, 1fr)',
+}) // https://tailwindcss.com/docs/grid-auto-rows
+
+;({
+  gridAutoRows: 'auto',
+})
+;({
+  gridAutoRows: 'min-content',
+})
+;({
+  gridAutoRows: 'max-content',
+})
+;({
+  gridAutoRows: 'minmax(0, 1fr)',
 }) // Grid alignment utilities
 // https://github.com/tailwindlabs/tailwindcss/pull/2306
 

--- a/src/config/dynamicStyles.js
+++ b/src/config/dynamicStyles.js
@@ -96,6 +96,12 @@ export default {
   'row-start': { prop: 'gridRowStart', config: 'gridRowStart' },
   'row-end': { prop: 'gridRowEnd', config: 'gridRowEnd' },
 
+  // https://tailwindcss.com/docs/grid-auto-columns
+  'auto-cols': { prop: 'gridAutoColumns', config: 'gridAutoColumns' },
+
+  // https://tailwindcss.com/docs/grid-auto-rows
+  'auto-rows': { prop: 'gridAutoRows', config: 'gridAutoRows' },
+
   // https://tailwindcss.com/docs/gap
   gap: { prop: 'gap', config: 'gap' },
   'gap-x': {

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -279,6 +279,10 @@ export default {
   'grid-flow-row-dense': { output: { gridAutoFlow: 'row dense' } },
   'grid-flow-col-dense': { output: { gridAutoFlow: 'col dense' } },
 
+  // https://tailwindcss.com/docs/grid-auto-columns
+  // https://tailwindcss.com/docs/grid-auto-rows#app
+  // See dynamicStyles.js
+
   /**
    * ===========================================
    * Spacing


### PR DESCRIPTION
This PR adds support for the new [auto-cols-xxx and auto-rows-xxx classes in Tailwindcss@1.9.0](https://github.com/tailwindlabs/tailwindcss/pull/2531):

```js
import tw from 'twin.macro'

tw`auto-cols-auto`
tw`auto-cols-min`
tw`auto-cols-max`
tw`auto-cols-fr`

tw`auto-rows-auto`
tw`auto-rows-min`
tw`auto-rows-max`
tw`auto-rows-fr`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "gridAutoColumns": "auto"
});
({
  "gridAutoColumns": "min-content"
});
({
  "gridAutoColumns": "max-content"
});
({
  "gridAutoColumns": "minmax(0, 1fr)"
});
({
  "gridAutoRows": "auto"
});
({
  "gridAutoRows": "min-content"
});
({
  "gridAutoRows": "max-content"
});
({
  "gridAutoRows": "minmax(0, 1fr)"
});
```