### PR TITLE
Give theme import access to the whole theme

### DIFF
--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -1,0 +1,34 @@
+const configGooberDefaults = { sassyPseudo: true }
+
+const configTwinDefaults = state => ({
+  allowStyleProp: false, // Allows styles within style="blah" without throwing an error
+  autoCssProp: false, // Automates the import of styled-components so you can use their css prop
+  hasSuggestions: true, // Switch suggestions on/off when you use a tailwind class that's not found
+  sassyPseudo: false, // Sets selectors like hover to &:hover
+  // ...
+  // TODO: Add the rest of the twin config items here (ongoing migration)
+  ...(state.isGoober && configGooberDefaults),
+})
+
+const isBoolean = value => typeof value === 'boolean'
+
+const configTwinValidators = {
+  allowStyleProp: [
+    isBoolean,
+    'The config “allowStyleProp” can only be true or false',
+  ],
+  autoCssProp: [
+    isBoolean,
+    'The config “autoCssProp” can only be true or false',
+  ],
+  hasSuggestions: [
+    isBoolean,
+    'The config “hasSuggestions” can only be true or false',
+  ],
+  sassyPseudo: [
+    isBoolean,
+    'The config “sassyPseudo” can only be true or false',
+  ],
+}
+
+export { configTwinDefaults, configTwinValidators }

--- a/src/configHelpers.js
+++ b/src/configHelpers.js
@@ -3,25 +3,54 @@ import { resolve } from 'path'
 import { existsSync } from 'fs'
 import resolveTailwindConfig from 'tailwindcss/lib/util/resolveConfig'
 import defaultTailwindConfig from 'tailwindcss/stubs/defaultConfig.stub'
+import { configTwinValidators, configTwinDefaults } from './config/twinConfig'
+import { logGeneralError } from './logging'
+import { assert } from './utils'
 
-const getConfigProperties = (state, config) => {
+const getConfigTailwindProperties = (state, config) => {
   const sourceRoot = state.file.opts.sourceRoot || '.'
   const configFile = config && config.config
 
   const configPath = resolve(sourceRoot, configFile || `./tailwind.config.js`)
   const configExists = existsSync(configPath)
-  const tailwindConfig = configExists
+  const configTailwind = configExists
     ? resolveTailwindConfig([require(configPath), defaultTailwindConfig])
     : resolveTailwindConfig([defaultTailwindConfig])
-  if (!tailwindConfig) {
+  if (!configTailwind) {
     throw new MacroError(`Couldn’t find the Tailwind config`)
   }
 
-  return {
-    configPath,
-    configExists,
-    tailwindConfig,
-  }
+  return { configPath, configExists, configTailwind }
 }
 
-export { getConfigProperties, resolveTailwindConfig, defaultTailwindConfig }
+const runConfigValidator = ([item, value]) => {
+  const validatorConfig = configTwinValidators[item]
+  if (!validatorConfig) return true
+
+  const [validator, errorMessage] = validatorConfig
+
+  assert(validator(value) !== true, () => logGeneralError(errorMessage))
+
+  return true
+}
+
+const getConfigTwin = (config, state) => ({
+  ...configTwinDefaults(state),
+  ...config,
+})
+
+const getConfigTwinValidated = (config, state) =>
+  Object.entries(getConfigTwin(config, state)).reduce(
+    (result, item) => ({
+      ...result,
+      ...(runConfigValidator(item) && { [item[0]]: item[1] }),
+    }),
+    {}
+  )
+
+export {
+  getConfigTailwindProperties,
+  resolveTailwindConfig,
+  defaultTailwindConfig,
+  getConfigTwinValidated,
+}

--- a/src/configHelpers.js
+++ b/src/configHelpers.js
@@ -5,7 +5,7 @@ import resolveTailwindConfig from 'tailwindcss/lib/util/resolveConfig'
 import defaultTailwindConfig from 'tailwindcss/stubs/defaultConfig.stub'
 import { configTwinValidators, configTwinDefaults } from './config/twinConfig'
 import { logGeneralError } from './logging'
-import { assert } from './utils'
+import { throwIf } from './utils'
 
 const getConfigTailwindProperties = (state, config) => {
   const sourceRoot = state.file.opts.sourceRoot || '.'
@@ -29,7 +29,7 @@ const runConfigValidator = ([item, value]) => {
 
   const [validator, errorMessage] = validatorConfig
 
-  assert(validator(value) !== true, () => logGeneralError(errorMessage))
+  throwIf(validator(value) !== true, () => logGeneralError(errorMessage))
 
   return true
 }

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -1,5 +1,5 @@
 import deepMerge from 'lodash.merge'
-import { assert, isEmpty, getProperties, getTheme } from './utils'
+import { throwIf, isEmpty, getProperties, getTheme } from './utils'
 import getPieces from './utils/getPieces'
 import { astify } from './macroHelpers'
 import doPrechecks, { precheckGroup } from './prechecks'
@@ -21,7 +21,7 @@ import {
 } from './handlers'
 
 export default (classes, t, state) => {
-  assert([null, 'null', undefined].includes(classes), () =>
+  throwIf([null, 'null', undefined].includes(classes), () =>
     logGeneralError(
       'Only plain strings can be used with "tw".\nRead more at https://twinredirect.page.link/template-literals'
     )
@@ -45,7 +45,7 @@ export default (classes, t, state) => {
     const pieces = getPieces({ classNameRaw, state })
     const { className, hasVariants } = pieces
 
-    assert(!className, () =>
+    throwIf(!className, () =>
       hasVariants ? logNotFoundVariant({ classNameRaw }) : logNotFoundClass
     )
 
@@ -59,7 +59,7 @@ export default (classes, t, state) => {
     } = getProperties(className, state)
 
     // Kick off suggestions when no class matches
-    assert(!hasMatches && !hasUserPlugins, () =>
+    throwIf(!hasMatches && !hasUserPlugins, () =>
       errorSuggestions({ pieces, state })
     )
 
@@ -90,7 +90,7 @@ export default (classes, t, state) => {
     }
 
     // Check again there are no userPlugin matches
-    assert(!hasMatches && !style, () => errorSuggestions({ pieces, state }))
+    throwIf(!hasMatches && !style, () => errorSuggestions({ pieces, state }))
 
     style =
       style || applyTransforms({ type, pieces, style: styleHandler[type]() })

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -1,5 +1,5 @@
 import getConfigValue from './../utils/getConfigValue'
-import { assert, stripNegative } from './../utils'
+import { throwIf, stripNegative } from './../utils'
 import { errorSuggestions } from './../logging'
 
 // Convert an array of objects into a single object
@@ -36,7 +36,7 @@ export default ({ theme, pieces, state, dynamicKey, dynamicConfig }) => {
     }))
     .filter(item => item.value)[0]
 
-  assert(!results || className.endsWith('-'), () =>
+  throwIf(!results || className.endsWith('-'), () =>
     errorSuggestions({
       pieces,
       state,

--- a/src/handlers/userPlugins.js
+++ b/src/handlers/userPlugins.js
@@ -60,7 +60,7 @@ const formatKey = (selector, className, sassyPseudo) => {
 
 export default ({
   state: {
-    sassyPseudo,
+    configTwin: { sassyPseudo },
     userPluginData: { components, utilities },
   },
   className,

--- a/src/logging.js
+++ b/src/logging.js
@@ -148,20 +148,6 @@ const errorSuggestions = properties => {
   return spaced(`${textNotFound}\n\n${suggestionText}`)
 }
 
-const themeErrorNotString = ({ themeValue, input }) => {
-  const textNotFound = warning(
-    `${color.errorLight(input)} didn’t bring back a string theme value`
-  )
-  const suggestionText = `Try adding one of these values after a dot:\n${formatSuggestions(
-    Object.entries(themeValue).map(([k, v]) => ({
-      target: k,
-      value: typeof v === 'string' ? v : '...',
-    }))
-  )}`
-
-  return spaced(`${textNotFound}\n\n${suggestionText}`)
-}
-
 const themeErrorNotFound = ({ theme, input, trimInput }) => {
   if (typeof theme === 'string') {
     return spaced(logBadGood(input, trimInput))
@@ -214,7 +200,6 @@ export {
   debugPlugins,
   inOutPlugins,
   errorSuggestions,
-  themeErrorNotString,
   themeErrorNotFound,
   logNotFoundVariant,
   logNotFoundClass,

--- a/src/logging.js
+++ b/src/logging.js
@@ -117,7 +117,9 @@ const logDeeplyNestedClass = properties => {
 
 const errorSuggestions = properties => {
   const {
-    state: { hasSuggestions },
+    state: {
+      configTwin: { hasSuggestions },
+    },
     pieces: { className },
   } = properties
 

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -1,5 +1,5 @@
 import { addImport, generateUid } from '../macroHelpers'
-import { assert } from '../utils'
+import { throwIf } from '../utils'
 import { logGeneralError } from './../logging'
 import globalStyles from './../config/globalStyles'
 import userPresets from './../config/userPresets'
@@ -95,14 +95,14 @@ const handleGlobalStylesFunction = ({
   if (!references.GlobalStyles) return
   if (references.GlobalStyles.length === 0) return
 
-  assert(references.GlobalStyles.length > 1, () =>
+  throwIf(references.GlobalStyles.length > 1, () =>
     logGeneralError('Only one GlobalStyles import can be used')
   )
 
   const path = references.GlobalStyles[0]
   const parentPath = path.findParent(x => x.isJSXElement())
 
-  assert(state.isStyledComponents && !parentPath, () =>
+  throwIf(state.isStyledComponents && !parentPath, () =>
     logGeneralError(
       'GlobalStyles must be added as a JSX element, eg: <GlobalStyles />'
     )

--- a/src/macro/theme.js
+++ b/src/macro/theme.js
@@ -1,6 +1,6 @@
 import dlv from 'dlv'
 import { replaceWithLocation, astify } from './../macroHelpers'
-import { getTheme, assert } from './../utils'
+import { getTheme, throwIf } from './../utils'
 import {
   logGeneralError,
   themeErrorNotString,
@@ -56,14 +56,14 @@ const handleThemeFunction = ({ references, t, state }) => {
       return replaceWithLocation(parent, astify('', t))
     }
 
-    assert(!parent || !input, () =>
+    throwIf(!parent || !input, () =>
       logGeneralError(
         "The theme value doesn’t look right\n\nTry using it like this: theme`colors.black` or theme('colors.black')"
       )
     )
 
     const themeValue = dlv(theme(), input)
-    assert(!themeValue, () =>
+    throwIf(!themeValue, () =>
       themeErrorNotFound({
         theme: input.includes('.') ? dlv(theme(), trimInput(input)) : theme(),
         input,
@@ -72,7 +72,7 @@ const handleThemeFunction = ({ references, t, state }) => {
     )
 
     const normalizedValue = normalizeThemeValue(themeValue)
-    assert(typeof normalizedValue !== 'string', () =>
+    throwIf(typeof normalizedValue !== 'string', () =>
       themeErrorNotString({ themeValue, input })
     )
 

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -75,7 +75,7 @@ const handleTwFunction = ({ references, state, t }) => {
     if (!parent) return
 
     // Check if the style attribute is being used
-    if (!state.allowStyleProp) {
+    if (!state.configTwin.allowStyleProp) {
       const jsxAttribute = parent.findParent(x => x.isJSXAttribute())
       const attributeName =
         jsxAttribute && jsxAttribute.get('name').get('name').node

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -1,5 +1,5 @@
 import { parseTte, replaceWithLocation } from './../macroHelpers'
-import { assert } from './../utils'
+import { throwIf } from './../utils'
 import { logGeneralError, logStylePropertyError } from './../logging'
 /* eslint-disable-next-line unicorn/prevent-abbreviations */
 import { addDebugPropToPath, addDebugPropToExistingPath } from './debug'
@@ -21,7 +21,7 @@ const handleTwProperty = ({ path, t, state }) => {
     nodeValue.expression.value
 
   // Feedback for unsupported usage
-  assert(nodeValue.expression && !expressionValue, () =>
+  throwIf(nodeValue.expression && !expressionValue, () =>
     logGeneralError(
       `Only plain strings can be used with the "tw" prop.\nEg: <div tw="text-black" /> or <div tw={"text-black"} />`
     )
@@ -45,7 +45,7 @@ const handleTwProperty = ({ path, t, state }) => {
       // But it would break the specificity of existing css+tw combinations.
       expr.pushContainer('elements', styles)
     } else {
-      assert(!expr.node, () =>
+      throwIf(!expr.node, () =>
         logGeneralError(
           `An empty css prop (css="") isn’t supported alongside the tw prop (tw="...")`
         )
@@ -79,7 +79,7 @@ const handleTwFunction = ({ references, state, t }) => {
       const jsxAttribute = parent.findParent(x => x.isJSXAttribute())
       const attributeName =
         jsxAttribute && jsxAttribute.get('name').get('name').node
-      assert(attributeName === 'style', () => logStylePropertyError)
+      throwIf(attributeName === 'style', () => logStylePropertyError)
     }
 
     const parsed = parseTte({

--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -1,5 +1,5 @@
 import babylon from '@babel/parser'
-import { assert } from './utils'
+import { throwIf } from './utils'
 import { logGeneralError } from './logging'
 
 const SPREAD_ID = '__spread__'
@@ -229,12 +229,12 @@ const validateImports = imports => {
   const importTwAsNamedNotDefault = Object.keys(imports).find(
     reference => reference === 'tw'
   )
-  assert(importTwAsNamedNotDefault, () => {
+  throwIf(importTwAsNamedNotDefault, () => {
     logGeneralError(
       `Please use the default export for twin.macro, i.e:\nimport tw from 'twin.macro'\nNOT import { tw } from 'twin.macro'`
     )
   })
-  assert(unsupportedImport, () =>
+  throwIf(unsupportedImport, () =>
     logGeneralError(
       `Twin doesn't recognize { ${unsupportedImport} }\n\nTry one of these imports:\nimport tw, { styled, css, theme } from 'twin.macro'`
     )

--- a/src/prechecks.js
+++ b/src/prechecks.js
@@ -1,8 +1,8 @@
-import { assert } from './utils'
+import { throwIf } from './utils'
 import { logBadGood } from './logging'
 
 const precheckGroup = ({ classNameRaw }) =>
-  assert(
+  throwIf(
     classNameRaw === 'group',
     () =>
       `"group" must be added as className:\n\n${logBadGood(

--- a/src/utils/getConfigValue.js
+++ b/src/utils/getConfigValue.js
@@ -1,4 +1,4 @@
-import { isEmpty, assert, stripNegative } from './misc'
+import { isEmpty, throwIf, stripNegative } from './misc'
 import { logGeneralError } from './../logging'
 
 const normalizeValue = value => {
@@ -39,7 +39,7 @@ const matchChildKey = (from, matcher) => {
       typeof objectMatch === 'number' ||
       Array.isArray(objectMatch)
 
-    assert(!isValueReturnable, () =>
+    throwIf(!isValueReturnable, () =>
       logGeneralError(
         `The tailwind config is nested too deep\nReplace this with a string, number or array:\n${JSON.stringify(
           objectMatch

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-export { assert, isEmpty, addPxTo0, getTheme, stripNegative } from './misc'
+export { throwIf, isEmpty, addPxTo0, getTheme, stripNegative } from './misc'
 export { default as resolveConfig } from './resolveConfig'
 export { default as getProperties } from './getProperties'
 export { default as withAlpha } from './withAlpha'

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,7 +1,7 @@
 import dlv from 'dlv'
 import { MacroError } from 'babel-plugin-macros'
 
-const assert = (expression, callBack) => {
+const throwIf = (expression, callBack) => {
   if (!expression) return
   throw new MacroError(callBack())
 }
@@ -22,4 +22,4 @@ const stripNegative = string =>
     ? string.slice(1, string.length)
     : string
 
-export { assert, isEmpty, addPxTo0, getTheme, stripNegative }
+export { throwIf, isEmpty, addPxTo0, getTheme, stripNegative }

--- a/src/variants.js
+++ b/src/variants.js
@@ -35,7 +35,7 @@ const validateVariants = ({ variants, state, ...rest }) => {
           foundVariant = foundVariant(context)
         }
 
-        if (state.sassyPseudo) {
+        if (state.configTwin.sassyPseudo) {
           return foundVariant.replace(/(?<= ):|^:/g, '&:')
         }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,10 +4,6 @@ export interface TwStyle {
   [key: string]: string | number | TwStyle
 }
 
-export interface ThemeStyle {
-  [key: string]: string | number | ThemeStyle
-}
-
 export const GlobalStyles: string
 
 export type TemplateFn<R> = (
@@ -22,8 +18,7 @@ export type ThemeSearchTaggedFn<R> = (
   strings: Readonly<TemplateStringsArray>
 ) => R
 
-export type ThemeFn = ThemeSearchFn<ThemeStyle> &
-  ThemeSearchTaggedFn<ThemeStyle>
+export type ThemeFn = <T = string>(arg?: string | TemplateStringsArray) => T
 
 export type TwComponent<K extends keyof JSX.IntrinsicElements> = (
   props: JSX.IntrinsicElements[K]


### PR DESCRIPTION
Previously the `theme` import could only grab string values from your merged tailwind config.
This PR beefs up the theme import so you can now grab anything from the theme key of the merged tailwind.config.js

Some usage examples:

## Grab the breakpoints

Once you've got the breakpoints, you could use them to create breakpoint helpers of your own.

```js
import { theme } from 'twin.macro'

const breakpoints = theme`screens`

// ↓ ↓ ↓ ↓ ↓ ↓

const breakpoints = {
  "sm": "640px",
  "md": "768px",
  "lg": "1024px",
  "xl": "1280px",
};
```

## Grab a set of colors

This is most likely to help you create custom themes on your site or app. 

```js
import { theme } from 'twin.macro'

const grayColors = theme`colors.gray`

// ↓ ↓ ↓ ↓ ↓ ↓

const grayColors = {
  "100": "#f7fafc",
  "200": "#edf2f7",
  "300": "#e2e8f0",
  "400": "#cbd5e0",
  "500": "#a0aec0",
  "600": "#718096",
  "700": "#4a5568",
  "800": "#2d3748",
  "900": "#1a202c"
};
```

## Grab the whole merged config

You can also grab the whole merged config with an empty theme call.
The theme call will be replaced with the entire merged config so **beware of the bloat this will add to your file**:

```js
import { theme } from 'twin.macro'

const wholeCombinedConfig = theme() // or theme``

// ↓ ↓ ↓ ↓ ↓ ↓

const wholeCombinedConfig = {
  "screens": {
    "sm": "640px",
    "md": "768px",
    "lg": "1024px",
    "xl": "1280px"
  },
  "colors": {
    "transparent": "transparent",
    "current": "currentColor",
    "black": "#000",
    // + 1585 more lines!
};
``` 