### PR TITLE
Remove scrolling-touch and scrolling-auto utilities

### DIFF
--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -71,8 +71,6 @@ tw`overflow-x-visible`
 tw`overflow-y-visible`
 tw`overflow-x-scroll`
 tw`overflow-y-scroll`
-tw`scrolling-touch`
-tw`scrolling-auto`
 
 // https://tailwindcss.com/docs/position
 tw`static`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -7864,8 +7864,6 @@ tw\`overflow-x-visible\`
 tw\`overflow-y-visible\`
 tw\`overflow-x-scroll\`
 tw\`overflow-y-scroll\`
-tw\`scrolling-touch\`
-tw\`scrolling-auto\`
 
 // https://tailwindcss.com/docs/position
 tw\`static\`

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -89,14 +89,6 @@ export default {
   },
   'overflow-x-scroll': { output: { overflowX: 'scroll' }, config: 'overflow' },
   'overflow-y-scroll': { output: { overflowY: 'scroll' }, config: 'overflow' },
-  'scrolling-touch': {
-    output: { WebkitOverflowScrolling: 'touch' },
-    config: false,
-  },
-  'scrolling-auto': {
-    output: { WebkitOverflowScrolling: 'auto' },
-    config: false,
-  },
 
   // https://tailwindcss.com/docs/position
   static: { output: { position: 'static' } },


### PR DESCRIPTION
Small help for update to support Tailwindcss 2.0

Closes [Remove `scrolling-touch `and `scrolling-auto` utilities](https://github.com/tailwindlabs/tailwindcss/pull/2573) in #190 