### PR TITLE
Use [hidden] instead of template in space/divide utilities

### DIFF
--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -4081,644 +4081,644 @@ tw\`border-opacity-100\`
 }) // https://tailwindcss.com/docs/divide
 
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 0,
     borderRightWidth: 'calc(0px * var(--divide-x-reverse))',
     borderLeftWidth: 'calc(0px * calc(1 - var(--divide-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 0,
     borderRightWidth: 'calc(2px * var(--divide-x-reverse))',
     borderLeftWidth: 'calc(2px * calc(1 - var(--divide-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 0,
     borderRightWidth: 'calc(4px * var(--divide-x-reverse))',
     borderLeftWidth: 'calc(4px * calc(1 - var(--divide-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 0,
     borderRightWidth: 'calc(8px * var(--divide-x-reverse))',
     borderLeftWidth: 'calc(8px * calc(1 - var(--divide-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 0,
     borderRightWidth: 'calc(1px * var(--divide-x-reverse))',
     borderLeftWidth: 'calc(1px * calc(1 - var(--divide-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 0,
     borderTopWidth: 'calc(0px * calc(1 - var(--divide-y-reverse)))',
     borderBottomWidth: 'calc(0px * var(--divide-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 0,
     borderTopWidth: 'calc(2px * calc(1 - var(--divide-y-reverse)))',
     borderBottomWidth: 'calc(2px * var(--divide-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 0,
     borderTopWidth: 'calc(4px * calc(1 - var(--divide-y-reverse)))',
     borderBottomWidth: 'calc(4px * var(--divide-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 0,
     borderTopWidth: 'calc(8px * calc(1 - var(--divide-y-reverse)))',
     borderBottomWidth: 'calc(8px * var(--divide-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 0,
     borderTopWidth: 'calc(1px * calc(1 - var(--divide-y-reverse)))',
     borderBottomWidth: 'calc(1px * var(--divide-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-x-reverse': 1,
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-y-reverse': 1,
   },
 }) // https://tailwindcss.com/docs/divide-color
 
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     borderColor: 'transparent',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     borderColor: 'currentColor',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(0, 0, 0, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(255, 255, 255, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(247, 250, 252, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(237, 242, 247, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(226, 232, 240, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(203, 213, 224, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(160, 174, 192, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(113, 128, 150, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(74, 85, 104, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(45, 55, 72, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(26, 32, 44, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(255, 245, 245, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(254, 215, 215, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(254, 178, 178, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(252, 129, 129, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(245, 101, 101, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(229, 62, 62, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(197, 48, 48, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(155, 44, 44, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(116, 42, 42, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(255, 250, 240, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(254, 235, 200, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(251, 211, 141, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(246, 173, 85, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(237, 137, 54, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(221, 107, 32, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(192, 86, 33, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(156, 66, 33, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(123, 52, 30, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(255, 255, 240, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(254, 252, 191, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(250, 240, 137, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(246, 224, 94, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(236, 201, 75, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(214, 158, 46, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(183, 121, 31, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(151, 90, 22, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(116, 66, 16, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(240, 255, 244, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(198, 246, 213, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(154, 230, 180, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(104, 211, 145, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(72, 187, 120, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(56, 161, 105, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(47, 133, 90, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(39, 103, 73, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(34, 84, 61, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(230, 255, 250, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(178, 245, 234, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(129, 230, 217, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(79, 209, 197, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(56, 178, 172, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(49, 151, 149, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(44, 122, 123, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(40, 94, 97, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(35, 78, 82, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(235, 248, 255, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(190, 227, 248, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(144, 205, 244, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(99, 179, 237, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(66, 153, 225, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(49, 130, 206, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(43, 108, 176, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(44, 82, 130, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(42, 67, 101, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(235, 244, 255, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(195, 218, 254, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(163, 191, 250, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(127, 156, 245, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(102, 126, 234, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(90, 103, 216, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(76, 81, 191, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(67, 65, 144, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(60, 54, 107, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(250, 245, 255, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(233, 216, 253, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(214, 188, 250, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(183, 148, 244, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(159, 122, 234, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(128, 90, 213, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(107, 70, 193, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(85, 60, 154, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(68, 51, 122, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(255, 245, 247, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(254, 215, 226, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(251, 182, 206, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(246, 135, 179, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(237, 100, 166, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(213, 63, 140, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(184, 50, 128, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(151, 38, 109, var(--divide-opacity))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--divide-opacity': '1',
     borderColor: 'rgba(112, 36, 89, var(--divide-opacity))',
   },

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -436,26 +436,26 @@ const _GlobalStyles = () => (
   <_globalImport
     styles={_css\`
       @keyframes spin {
-          to { 
+          to {
             transform: rotate(360deg);
           }
         }
       @keyframes ping {
-          75%, 100% { 
+          75%, 100% {
             transform: scale(2); opacity: 0;
           }
         }
       @keyframes pulse {
-          50% { 
+          50% {
             opacity: .5;
           }
         }
       @keyframes bounce {
-          0%, 100% { 
+          0%, 100% {
             transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
           }
-        
-          50% { 
+
+          50% {
             transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
           }
         }\`}
@@ -8332,654 +8332,654 @@ tw\`space-y-12 -space-y-reverse\`
 }) // https://tailwindcss.com/docs/space
 
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(0px * var(--space-x-reverse))',
     marginLeft: 'calc(0px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(0.25rem * var(--space-x-reverse))',
     marginLeft: 'calc(0.25rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(0.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(0.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(0.75rem * var(--space-x-reverse))',
     marginLeft: 'calc(0.75rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(1rem * var(--space-x-reverse))',
     marginLeft: 'calc(1rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(1.25rem * var(--space-x-reverse))',
     marginLeft: 'calc(1.25rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(1.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(1.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(2rem * var(--space-x-reverse))',
     marginLeft: 'calc(2rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(2.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(2.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(3rem * var(--space-x-reverse))',
     marginLeft: 'calc(3rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(4rem * var(--space-x-reverse))',
     marginLeft: 'calc(4rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(5rem * var(--space-x-reverse))',
     marginLeft: 'calc(5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(6rem * var(--space-x-reverse))',
     marginLeft: 'calc(6rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(8rem * var(--space-x-reverse))',
     marginLeft: 'calc(8rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(10rem * var(--space-x-reverse))',
     marginLeft: 'calc(10rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(12rem * var(--space-x-reverse))',
     marginLeft: 'calc(12rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(14rem * var(--space-x-reverse))',
     marginLeft: 'calc(14rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(16rem * var(--space-x-reverse))',
     marginLeft: 'calc(16rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(1px * var(--space-x-reverse))',
     marginLeft: 'calc(1px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(0px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(0.25rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0.25rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(0.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(0.75rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0.75rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(1rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(1.25rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1.25rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(1.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(2rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(2rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(2.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(2.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(3rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(3rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(4rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(4rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(6rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(6rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(8rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(8rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(10rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(10rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(12rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(12rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(14rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(14rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(16rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(16rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(1px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-0px * var(--space-x-reverse))',
     marginLeft: 'calc(-0px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-0.25rem * var(--space-x-reverse))',
     marginLeft: 'calc(-0.25rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-0.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(-0.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-0.75rem * var(--space-x-reverse))',
     marginLeft: 'calc(-0.75rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-1rem * var(--space-x-reverse))',
     marginLeft: 'calc(-1rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-1.25rem * var(--space-x-reverse))',
     marginLeft: 'calc(-1.25rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-1.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(-1.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-2rem * var(--space-x-reverse))',
     marginLeft: 'calc(-2rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-2.5rem * var(--space-x-reverse))',
     marginLeft: 'calc(-2.5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-3rem * var(--space-x-reverse))',
     marginLeft: 'calc(-3rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-4rem * var(--space-x-reverse))',
     marginLeft: 'calc(-4rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-5rem * var(--space-x-reverse))',
     marginLeft: 'calc(-5rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-6rem * var(--space-x-reverse))',
     marginLeft: 'calc(-6rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-8rem * var(--space-x-reverse))',
     marginLeft: 'calc(-8rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-10rem * var(--space-x-reverse))',
     marginLeft: 'calc(-10rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-12rem * var(--space-x-reverse))',
     marginLeft: 'calc(-12rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-14rem * var(--space-x-reverse))',
     marginLeft: 'calc(-14rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-16rem * var(--space-x-reverse))',
     marginLeft: 'calc(-16rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(-1px * var(--space-x-reverse))',
     marginLeft: 'calc(-1px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-0px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-0px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-0.25rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-0.25rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-0.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-0.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-0.75rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-0.75rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-1rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-1rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-1.25rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-1.25rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-1.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-1.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-2rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-2rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-2.5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-2.5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-3rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-3rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-4rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-4rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-5rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-5rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-6rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-6rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-8rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-8rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-10rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-10rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-12rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-12rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-14rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-14rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-16rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-16rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(-1px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(-1px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 1,
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 1,
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(0px * var(--space-x-reverse))',
     marginLeft: 'calc(0px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 1,
     marginRight: 'calc(0px * var(--space-x-reverse))',
     marginLeft: 'calc(0px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(0px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 1,
     marginTop: 'calc(0px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(0px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(8rem * var(--space-x-reverse))',
     marginLeft: 'calc(8rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 1,
     marginRight: 'calc(8rem * var(--space-x-reverse))',
     marginLeft: 'calc(8rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(8rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(8rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 1,
     marginTop: 'calc(8rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(8rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(1px * var(--space-x-reverse))',
     marginLeft: 'calc(1px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 1,
     marginRight: 'calc(1px * var(--space-x-reverse))',
     marginLeft: 'calc(1px * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(1px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 1,
     marginTop: 'calc(1px * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(1px * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 0,
     marginRight: 'calc(3rem * var(--space-x-reverse))',
     marginLeft: 'calc(3rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-x-reverse': 1,
     marginRight: 'calc(3rem * var(--space-x-reverse))',
     marginLeft: 'calc(3rem * calc(1 - var(--space-x-reverse)))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 0,
     marginTop: 'calc(3rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(3rem * var(--space-y-reverse))',
   },
 })
 ;({
-  '> :not(template) ~ :not(template)': {
+  '> :not([hidden]) ~ :not([hidden])': {
     '--space-y-reverse': 1,
     marginTop: 'calc(3rem * calc(1 - var(--space-y-reverse)))',
     marginBottom: 'calc(3rem * var(--space-y-reverse))',

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -119,14 +119,14 @@ export default {
   // See dynamicStyles.js for the rest
   'space-x-reverse': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         '--space-x-reverse': 1,
       },
     },
   },
   'space-y-reverse': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         '--space-y-reverse': 1,
       },
     },
@@ -136,14 +136,14 @@ export default {
   // See dynamicStyles.js for the rest
   'divide-x-reverse': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         '--divide-x-reverse': 1,
       },
     },
   },
   'divide-y-reverse': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         '--divide-y-reverse': 1,
       },
     },
@@ -152,35 +152,35 @@ export default {
   // https://tailwindcss.com/docs/divide-style
   'divide-solid': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         borderStyle: 'solid',
       },
     },
   },
   'divide-dashed': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         borderStyle: 'dashed',
       },
     },
   },
   'divide-dotted': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         borderStyle: 'dotted',
       },
     },
   },
   'divide-double': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         borderStyle: 'double',
       },
     },
   },
   'divide-none': {
     output: {
-      '> :not(template) ~ :not(template)': {
+      '> :not([hidden]) ~ :not([hidden])': {
         borderStyle: 'none',
       },
     },

--- a/src/plugins/divide.js
+++ b/src/plugins/divide.js
@@ -14,7 +14,7 @@ const handleColor = ({ configValue, important, disableColorVariables }) => {
     important,
   })
 
-  return { '> :not(template) ~ :not(template)': borderColor }
+  return { '> :not([hidden]) ~ :not([hidden])': borderColor }
 }
 
 const handleOpacity = ({ configValue }) => {
@@ -22,7 +22,7 @@ const handleOpacity = ({ configValue }) => {
   if (!opacity) return
 
   return {
-    '> :not(template) ~ :not(template)': { '--divide-opacity': `${opacity}` },
+    '> :not([hidden]) ~ :not([hidden])': { '--divide-opacity': `${opacity}` },
   }
 }
 
@@ -46,7 +46,7 @@ const handleWidth = ({
 
   const innerStyles = { [cssVariableKey]: 0, ...styleKey }
 
-  return { '> :not(template) ~ :not(template)': innerStyles }
+  return { '> :not([hidden]) ~ :not([hidden])': innerStyles }
 }
 
 export default properties => {

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -28,5 +28,5 @@ export default ({
 
   const innerStyles = { [cssVariableKey]: 0, ...styleKey }
 
-  return { '> :not(template) ~ :not(template)': innerStyles }
+  return { '> :not([hidden]) ~ :not([hidden])': innerStyles }
 }


### PR DESCRIPTION
Small help for update to support Tailwindcss 2.0

Closes [Use `[hidden]` elements within `space-` and `divide-` utilities instead of `template` elements](https://github.com/tailwindlabs/tailwindcss/pull/2642) in #190

I hope I didn't miss anything