### PR TITLE
Emotion preset update

### DIFF
--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -428,8 +428,8 @@ const GlobalStylesTest = () => <GlobalStyles />
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import _styled from '@emotion/styled'
-import { css as _css } from '@emotion/core'
-import { Global as _globalImport } from '@emotion/core'
+import { css as _css } from '@emotion/react'
+import { Global as _globalImport } from '@emotion/react'
 import 'tailwindcss/dist/base.min.css'
 
 const _GlobalStyles = () => (

--- a/docs/emotion/typescript.md
+++ b/docs/emotion/typescript.md
@@ -18,10 +18,23 @@ import 'twin.macro'
 import styledImport from '@emotion/styled'
 import { css as cssImport } from '@emotion/react'
 
+// The css prop
+// https://emotion.sh/docs/typescript#css-prop
+import {} from '@emotion/react/types/css-prop'
+
 declare module 'twin.macro' {
   // The styled and css imports
   const styled: typeof styledImport
   const css: typeof cssImport
+}
+
+// The 'as' prop on styled components
+declare global {
+  namespace JSX {
+    interface IntrinsicAttributes<T> extends DOMAttributes<T> {
+      as?: string
+    }
+  }
 }
 ```
 

--- a/docs/styled-components/typescript.md
+++ b/docs/styled-components/typescript.md
@@ -33,6 +33,15 @@ declare module 'react' {
     css?: CSSProp
   }
 }
+
+// The 'as' prop on styled components
+declare global {
+  namespace JSX {
+    interface IntrinsicAttributes<T> extends DOMAttributes<T> {
+      as?: string
+    }
+  }
+}
 ```
 
 Then add the following in `tsconfig.json`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,11 +550,18 @@
         }
       }
     },
-    "@emotion/core": {
+    "@emotion/cache": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-11.0.0.tgz",
-      "integrity": "sha512-w4sE3AmHmyG6RDKf6mIbtHpgJUSJ2uGvPQb8VXFL7hFjMPibE8IiehG8cMX3Ztm4svfCQV6KqusQbeIOkurBcA==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.0.0.tgz",
+      "integrity": "sha512-NStfcnLkL5vj3mBILvkR2m/5vFxo3G0QEreYKDGHNHm9IMYoT/t3j6xwjx6lMI/S1LUJfVHQqn0m9wSINttTTQ==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/sheet": "^1.0.0",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "stylis": "^4.0.3"
+      }
     },
     "@emotion/hash": {
       "version": "0.8.0",
@@ -577,6 +584,21 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "dev": true
     },
+    "@emotion/react": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.1.1.tgz",
+      "integrity": "sha512-otA0Np8OnOeU9ChkOS9iuLB6vIxiM+bJiU0id33CsQn3R2Pk9ijVHnxevENIKV/P2S7AhrD8cFbUGysEciWlEA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/cache": "^11.0.0",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/sheet": "^1.0.0",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
     "@emotion/serialize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.0.tgz",
@@ -589,6 +611,12 @@
         "@emotion/utils": "^1.0.0",
         "csstype": "^3.0.2"
       }
+    },
+    "@emotion/sheet": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.0.tgz",
+      "integrity": "sha512-cdCHfZtf/0rahPDCZ9zyq+36EqfD/6c0WUqTFZ/hv9xadTUv2lGE5QK7/Z6Dnx2oRxC0usfVM2/BYn9q9B9wZA==",
+      "dev": true
     },
     "@emotion/styled": {
       "version": "11.0.0",
@@ -630,6 +658,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
       "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==",
+      "dev": true
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
     "@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.12.1",
-    "@emotion/core": "^11.0.0",
+    "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
     "@tailwindcss/typography": "^0.3.1",
     "@types/react": "^16.9.56",

--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -38,11 +38,11 @@ export default {
     },
     css: {
       import: 'css',
-      from: '@emotion/core',
+      from: '@emotion/react',
     },
     global: {
       import: 'Global',
-      from: '@emotion/core',
+      from: '@emotion/react',
     },
   },
   goober: {

--- a/types/tests/emotion/index.tsx
+++ b/types/tests/emotion/index.tsx
@@ -1,4 +1,8 @@
-import {} from '@emotion/core'
+/// <reference types="@emotion/react/types/css-prop" />
+// this also works:
+// import {} from '@emotion/react/types/css-prop'
+
+import {} from '@emotion/react'
 import styled from '@emotion/styled'
 import React from 'react'
 import tw from '../..'

--- a/types/tests/emotion/tsconfig.json
+++ b/types/tests/emotion/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["react", "@emotion/core", "@emotion/styled"]
+    "types": ["react", "@emotion/react", "@emotion/styled"]
   }
 }


### PR DESCRIPTION
This PR upgrades the `{ preset: "emotion" }` option to use the new imports added in emotion@11 (released 12th Nov 2020). See #184 for more info.

## Using the preset

Add `{ preset: "emotion" }` to your twin config.
The `css` and `GlobalStyles` imports will import from `@emotion/react`.

Adding `{ preset: "emotion" }` is the equivalent of this import config:

<pre><code>{
  <del>preset: 'emotion',</del>
  styled: {
    import: 'default',
    from: '@emotion/styled',
  },
  css: {
    import: 'css',
    from: '@emotion/react',
  },
  global: {
    import: 'Global',
    from: '@emotion/react',
  },
}
</pre></code>

## @emotion/core

Before version 11, the imports came from `@emotion/core`.
If you‘re using older versions then add these imports to your twin config:

<pre><code>{
  <del>preset: 'emotion',</del>
  styled: {
    import: 'default',
    from: '@emotion/styled',
  },
  css: {
    import: 'css',
    from: '@emotion/core',
  },
  global: {
    import: 'Global',
    from: '@emotion/core',
  },
}
</pre></code>
