### PR TITLE
Add sibling variant

### DIFF
--- a/__fixtures__/!variants.js
+++ b/__fixtures__/!variants.js
@@ -51,6 +51,7 @@ tw`even-of-type:flex`
 tw`svg:flex`
 tw`all:flex`
 tw`all-child:flex`
+tw`sibling:flex`
 
 // Group states
 tw`group-hover:flex`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1958,6 +1958,7 @@ tw\`even-of-type:flex\`
 tw\`svg:flex\`
 tw\`all:flex\`
 tw\`all-child:flex\`
+tw\`sibling:flex\`
 
 // Group states
 tw\`group-hover:flex\`
@@ -2200,6 +2201,11 @@ const multiVariants = tw\`xl:placeholder-red-500! first:md:block sm:disabled:fle
 })
 ;({
   '> *': {
+    display: 'flex',
+  },
+})
+;({
+  '~ *': {
     display: 'flex',
   },
 }) // Group states

--- a/src/config/variantConfig.js
+++ b/src/config/variantConfig.js
@@ -59,6 +59,7 @@ export default {
   svg: 'svg',
   all: '*',
   'all-child': '> *',
+  sibling: '~ *',
 
   // Group states
   // You'll need to add className="group" to an ancestor to make these work


### PR DESCRIPTION
This PR adds a new `sibling` variant discussed in #191.

You can use it to select the other siblings of the element it's added to.

```js
tw`sibling:block`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "~ *": {
    "display": "block"
  }
});
```

This is a great variant to use for styling checkboxes:

```js
<label>
  <input
    tw="hidden checked:sibling:(bg-green-500 text-white)"
    type="checkbox"
  />
  <div tw="text-black bg-black rounded">✓</div>
</label>
```