### PR TITLE
Add overflow-ellipsis and overflow-clip text overflow utilities

### DIFF
--- a/__fixtures__/typography.js
+++ b/__fixtures__/typography.js
@@ -312,8 +312,10 @@ tw`lowercase`
 tw`capitalize`
 tw`normal-case`
 
-// https://tailwindcss.com/docs/word-break
+// https://tailwindcss.com/docs/text-overflow
 tw`truncate`
+tw`overflow-ellipsis`
+tw`overflow-clip`
 
 // https://tailwindcss.com/docs/vertical-align
 tw`align-baseline`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -436,26 +436,26 @@ const _GlobalStyles = () => (
   <_globalImport
     styles={_css\`
       @keyframes spin {
-          to { 
+          to {
             transform: rotate(360deg);
           }
         }
       @keyframes ping {
-          75%, 100% { 
+          75%, 100% {
             transform: scale(2); opacity: 0;
           }
         }
       @keyframes pulse {
-          50% { 
+          50% {
             opacity: .5;
           }
         }
       @keyframes bounce {
-          0%, 100% { 
+          0%, 100% {
             transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
           }
-        
-          50% { 
+
+          50% {
             transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
           }
         }\`}
@@ -17563,8 +17563,10 @@ tw\`lowercase\`
 tw\`capitalize\`
 tw\`normal-case\`
 
-// https://tailwindcss.com/docs/word-break
+// https://tailwindcss.com/docs/text-overflow
 tw\`truncate\`
+tw\`overflow-ellipsis\`
+tw\`overflow-clip\`
 
 // https://tailwindcss.com/docs/vertical-align
 tw\`align-baseline\`
@@ -18863,12 +18865,18 @@ tw\`break-all\`
 })
 ;({
   textTransform: 'none',
-}) // https://tailwindcss.com/docs/word-break
+}) // https://tailwindcss.com/docs/text-overflow
 
 ;({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+})
+;({
+  textOverflow: 'ellipsis',
+})
+;({
+  textOverflow: 'clip',
 }) // https://tailwindcss.com/docs/vertical-align
 
 ;({

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -445,6 +445,8 @@ export default {
     config: 'wordbreak',
   },
   'break-all': { output: { wordBreak: 'break-all' }, config: 'wordbreak' },
+
+  // https://tailwindcss.com/docs/text-overflow
   truncate: {
     output: {
       overflow: 'hidden',
@@ -453,6 +455,8 @@ export default {
     },
     config: false,
   },
+  'overflow-ellipsis': { output: { textOverflow: 'ellipsis' } },
+  'overflow-clip': { output: { textOverflow: 'clip' } },
 
   /**
    * ===========================================


### PR DESCRIPTION
Adds text-overflow utilities (related Tailwind PR: https://github.com/tailwindlabs/tailwindcss/pull/1289) for [v2 compat](https://github.com/ben-rogerson/twin.macro/issues/190).

Let me know if anything looks amiss here, thanks!