### PR TITLE
Update preset styled-components `styled` import

### DIFF
--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -20,7 +20,7 @@ export default {
   'styled-components': {
     styled: {
       import: 'default',
-      from: 'styled-components',
+      from: 'styled-components/macro',
     },
     css: {
       import: 'css',


### PR DESCRIPTION
This PR updates the `styled` import when you use `{ preset: "styled-components" }`

```js
// New
import styled from 'styled-components/macro'

// Old
import styled from 'styled-components'
```

The new import allows you to [adjust the styled config](https://styled-components.com/docs/tooling#babel-macro) in the same place you define the twin config:

```js
// babel-plugin-macros.config.js
module.exports = {
  styledComponents: {
    ssr: true, // Make it behave with SSR
    displayName: true // Improved debugging with react display names in class names
    pure: true, // Enable Dead Code Elimination/Tree Shaking in minifiers like terser
  },
  twin: {
    preset: "styled-components",
    autoCssProp: true,
    debugProp: true,
  },
}

// or in package.json
"babelMacros": {
  "styledComponents": {
    "ssr": true,
    "displayName": true,
    "pure": true
  },
  "twin": {
    "preset": "styled-components",
    "autoCssProp": true,
    "debugProp": true
  }
},
```

Be sure to check the [styled-components docs](https://styled-components.com/docs/tooling#usage) for the rest of the available options.

> Note: The config for this macro is still marked as experimental on the styled-components site but that was based on the linked resource by [Kent C. Dodds who has since removed the experimental status](https://github.com/kentcdodds/babel-plugin-macros/commit/b6741235b69d07cd8f35a4d5db04e7df2b866c31#diff-1841923e97a9abf6f519cb969899dc74f61dddd27a2d6432d45a7b74477bec3bL171).
![image](https://user-images.githubusercontent.com/21288568/100150500-9feb6e00-2eef-11eb-839c-6e173081f1e2.png)
I also [checked with Max Stoiber (@mxstbr)](https://twitter.com/mxstbr/status/1331217160652328963) to be sure.