### PR TITLE
Add `autoCssProp: true` by default for styled-components

### DIFF
--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -1,14 +1,17 @@
-const configGooberDefaults = { sassyPseudo: true }
+// Defaults for different css-in-js libraries
+const configDefaultsStyledComponents = { autoCssProp: true } // Automates the import of styled-components when you use their css prop
+const configDefaultsGoober = { sassyPseudo: true } // Sets selectors like hover to &:hover
 
-const configTwinDefaults = state => ({
+const configDefaultsTwin = ({ isStyledComponents, isGoober }) => ({
   allowStyleProp: false, // Allows styles within style="blah" without throwing an error
-  autoCssProp: false, // Automates the import of styled-components so you can use their css prop
+  autoCssProp: false, // Automates the import of styled-components when you use their css prop
   disableColorVariables: false, // Disable css variables in colors (except gradients) to support older browsers/react native
   hasSuggestions: true, // Switch suggestions on/off when you use a tailwind class that's not found
   sassyPseudo: false, // Sets selectors like hover to &:hover
   // ...
   // TODO: Add the rest of the twin config items here (ongoing migration)
-  ...(state.isGoober && configGooberDefaults),
+  ...(isStyledComponents && configDefaultsStyledComponents),
+  ...(isGoober && configDefaultsGoober),
 })
 
 const isBoolean = value => typeof value === 'boolean'
@@ -36,4 +39,4 @@ const configTwinValidators = {
   ],
 }
 
-export { configTwinDefaults, configTwinValidators }
+export { configDefaultsTwin, configTwinValidators }

--- a/src/configHelpers.js
+++ b/src/configHelpers.js
@@ -3,7 +3,7 @@ import { resolve } from 'path'
 import { existsSync } from 'fs'
 import resolveTailwindConfig from 'tailwindcss/lib/util/resolveConfig'
 import defaultTailwindConfig from 'tailwindcss/stubs/defaultConfig.stub'
-import { configTwinValidators, configTwinDefaults } from './config/twinConfig'
+import { configTwinValidators, configDefaultsTwin } from './config/twinConfig'
 import { logGeneralError } from './logging'
 import { throwIf } from './utils'
 
@@ -35,7 +35,7 @@ const runConfigValidator = ([item, value]) => {
 }
 
 const getConfigTwin = (config, state) => ({
-  ...configTwinDefaults(state),
+  ...configDefaultsTwin(state),
   ...config,
 })
 


### PR DESCRIPTION
This PR activates the css prop by default for styled-components.
It does this by adding the import for styled-components only when required so you get the css prop they provide without having to import anything yourself.

If you're importing styled-components yourself and not using the `styled` and `css` imports that twin provides then you should turn this feature off in your twin config (`{ autoCssProp: false }`). 