### PR TITLE
Defined imports override the preset

### DIFF
--- a/src/macro.js
+++ b/src/macro.js
@@ -28,9 +28,13 @@ import getUserPluginData from './utils/getUserPluginData'
 import { debugPlugins } from './logging'
 
 const getPackageUsed = ({ config: { preset }, cssImport, styledImport }) => ({
-  isEmotion: preset === 'emotion' || cssImport.from.includes('emotion'),
+  isEmotion:
+    preset === 'emotion' ||
+    styledImport.from.includes('emotion') ||
+    cssImport.from.includes('emotion'),
   isStyledComponents:
     preset === 'styled-components' ||
+    styledImport.from.includes('styled-components') ||
     cssImport.from.includes('styled-components'),
   isGoober:
     preset === 'goober' ||

--- a/src/macro/css.js
+++ b/src/macro/css.js
@@ -4,7 +4,7 @@ import userPresets from './../config/userPresets'
 
 const getCssConfig = config => {
   const usedConfig =
-    userPresets[config.preset] || (config.css && config) || userPresets.emotion
+    (config.css && config) || userPresets[config.preset] || userPresets.emotion
 
   if (typeof usedConfig.css === 'string') {
     return { import: 'css', from: usedConfig.css }

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -5,8 +5,8 @@ import userPresets from './../config/userPresets'
 
 const getGlobalStylesConfig = config => {
   const usedConfig =
-    userPresets[config.preset] ||
     (config.global && config) ||
+    userPresets[config.preset] ||
     userPresets.emotion
   return usedConfig.global
 }

--- a/src/macro/styled.js
+++ b/src/macro/styled.js
@@ -4,8 +4,8 @@ import userPresets from './../config/userPresets'
 
 const getStyledConfig = config => {
   const usedConfig =
-    userPresets[config.preset] ||
     (config.styled && config) ||
+    userPresets[config.preset] ||
     userPresets.emotion
 
   if (typeof usedConfig.styled === 'string') {


### PR DESCRIPTION
The imports you define in the twin config for styled, css and global will now override the imports defined in the preset.

This means you can define the `preset` and then adjust the imports you need:

```js
// package.json
"babelMacros": {
  "twin": {
    "preset": "styled-components"
    "styled": { // Custom import
      "import": "default",
      "from": "styled-components/newImport"
    }
    // Twins other imports (css, global) are copied from the preset because they aren't being specified here
  }
},
```