### PR TITLE
#240 Fix Compile error when calling getUserPluginRules on Tailwind aspect-ratio plugin

### DIFF
--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -49,7 +49,7 @@ const getUserPluginRules = (rules, screens) =>
     const selector = parseSelector(rule.selector)
 
     // Rule isn't formatted correctly
-    if (selector === null) return null
+    if (!selector) return null
 
     // Combine the children styles
     const values = rule.nodes.reduce(


### PR DESCRIPTION
Not sure this is the whole story, but this at least fixes a basic error when the selectors are not well formed.