### PR TITLE
get loc from path.node before it is replaced

### DIFF
--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -208,9 +208,9 @@ function parseTte({ path, types: t, styledIdentifier, state }) {
 }
 
 function replaceWithLocation(path, replacement) {
+  const { loc } = path.node
   const newPaths = replacement ? path.replaceWith(replacement) : []
   if (Array.isArray(newPaths) && newPaths.length > 0) {
-    const { loc } = path.node
     newPaths.forEach(p => {
       p.node.loc = loc
     })


### PR DESCRIPTION
Hi, thanks for reviewing! I'm hoping to get this fix merged in order to fix the integration between `twin.macro` and the `@linaria` babel preset.

Prior to this change, when paired with the `@linaria` babel preset, it would result in the following error:

```
TypeError: <root>/packages/components/src/playground/button.tsx: Cannot destructure property 'end' of 'ex.node.loc' as it is undefined.
    at <root>/packages/components/node_modules/@linaria/babel-preset/lib/evaluators/templateProcessor.js:113:11
    at Array.forEach (<anonymous>)
    at process (<root>/packages/components/node_modules/@linaria/babel-preset/lib/evaluators/templateProcessor.js:81:18)
    at <root>/packages/components/node_modules/@linaria/babel-preset/lib/extract.js:160:39
    at Array.forEach (<anonymous>)
    at PluginPass.enter (<root>/packages/components/node_modules/@linaria/babel-preset/lib/extract.js:160:23)
    at newFn (<root>/packages/components/node_modules/@babel/core/node_modules/@babel/traverse/lib/visitors.js:175:21)
    at NodePath._call (<root>/packages/components/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:55:20)
    at NodePath.call (<root>/packages/components/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:42:17)
    at NodePath.visit (<root>/packages/components/node_modules/@babel/core/node_modules/@babel/traverse/lib/path/context.js:92:31) {
  code: 'BABEL_TRANSFORM_ERROR'
}
```
source: https://github.com/callstack/linaria/issues/679#issuecomment-742125558

It seems that this loc is removed when the node is replaced and so it's being set to undefined.

Unfortunately I don't know what tests to add that would catch this issue since it's making use of the `babel-plugin-tester` package which already produces all green test results.

If we're able to get this working, I'm also interested in exploring further support for Linaria from `twin.macro`.