### PR TITLE
Bracket groups

### DIFF
--- a/__fixtures__/!groups.js
+++ b/__fixtures__/!groups.js
@@ -9,3 +9,7 @@ const mediaHover = tw`sm:hover:(bg-black text-white)`
 const sloppySpacing = tw` last:( flex  mt-5)`
 const multipleGroups = tw`focus:(w-10 h-10 block bg-black) focus-within:(md:flex mt-5)`
 const nestedGroups = tw`md:(w-10 hocus:(h-10 block bg-black))`
+
+const BracketGroups = tw`(w-10) (h-10 block bg-black)`
+const BracketNestedGroups = tw`(w-10 (h-10 block bg-black))`
+const variantGroupNestedInBracketGroup = tw`(w-10 md:(h-10 block bg-black))`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -363,6 +363,129 @@ const plainVariable = \`bg-\${plainConditional}-500\`
 
 `;
 
+exports[`twin.macro !groups.js: !groups.js 1`] = `
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import tw from './macro'
+
+const basic = tw\`group-hover:(flex m-10)\`
+const subMediaQuery = tw\`focus-within:(md:flex mt-5)\`
+const multipleClasses = tw\`hover:(bg-black text-white underline)\`
+const pseudoElement = tw\`before:(content w-10 h-10 block bg-black)\`
+const mediaHover = tw\`sm:hover:(bg-black text-white)\`
+const sloppySpacing = tw\` last:( flex  mt-5)\`
+const multipleGroups = tw\`focus:(w-10 h-10 block bg-black) focus-within:(md:flex mt-5)\`
+const nestedGroups = tw\`md:(w-10 hocus:(h-10 block bg-black))\`
+
+const BracketGroups = tw\`(w-10) (h-10 block bg-black)\`
+const BracketNestedGroups = tw\`(w-10 (h-10 block bg-black))\`
+const variantGroupNestedInBracketGroup = tw\`(w-10 md:(h-10 block bg-black))\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const basic = {
+  '.group:hover &': {
+    display: 'flex',
+    margin: '2.5rem',
+  },
+}
+const subMediaQuery = {
+  ':focus-within': {
+    '@media (min-width: 768px)': {
+      display: 'flex',
+    },
+    marginTop: '1.25rem',
+  },
+}
+const multipleClasses = {
+  ':hover': {
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+    '--tw-text-opacity': '1',
+    color: 'rgba(255, 255, 255, var(--tw-text-opacity))',
+    textDecoration: 'underline',
+  },
+}
+const pseudoElement = {
+  ':before': {
+    content: '""',
+    width: '2.5rem',
+    height: '2.5rem',
+    display: 'block',
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+  },
+}
+const mediaHover = {
+  '@media (min-width: 640px)': {
+    ':hover': {
+      '--tw-bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+      '--tw-text-opacity': '1',
+      color: 'rgba(255, 255, 255, var(--tw-text-opacity))',
+    },
+  },
+}
+const sloppySpacing = {
+  ':last-child': {
+    display: 'flex',
+    marginTop: '1.25rem',
+  },
+}
+const multipleGroups = {
+  ':focus': {
+    width: '2.5rem',
+    height: '2.5rem',
+    display: 'block',
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+  },
+  ':focus-within': {
+    '@media (min-width: 768px)': {
+      display: 'flex',
+    },
+    marginTop: '1.25rem',
+  },
+}
+const nestedGroups = {
+  '@media (min-width: 768px)': {
+    width: '2.5rem',
+    ':hover, :focus': {
+      height: '2.5rem',
+      display: 'block',
+      '--tw-bg-opacity': '1',
+      backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+    },
+  },
+}
+const BracketGroups = {
+  width: '2.5rem',
+  height: '2.5rem',
+  display: 'block',
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+}
+const BracketNestedGroups = {
+  width: '2.5rem',
+  height: '2.5rem',
+  display: 'block',
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+}
+const variantGroupNestedInBracketGroup = {
+  width: '2.5rem',
+  '@media (min-width: 768px)': {
+    height: '2.5rem',
+    display: 'block',
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
+  },
+}
+
+
+`;
+
 exports[`twin.macro !imports.js: !imports.js 1`] = `
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -2112,102 +2235,6 @@ tw\`2xl:block\`
     display: 'block',
   },
 })
-
-
-`;
-
-exports[`twin.macro !variantGrouping.js: !variantGrouping.js 1`] = `
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import tw from './macro'
-
-const basic = tw\`group-hover:(flex m-10)\`
-const subMediaQuery = tw\`focus-within:(md:flex mt-5)\`
-const multipleClasses = tw\`hover:(bg-black text-white underline)\`
-const pseudoElement = tw\`before:(content w-10 h-10 block bg-black)\`
-const mediaHover = tw\`sm:hover:(bg-black text-white)\`
-const sloppySpacing = tw\` last:( flex  mt-5)\`
-const multipleGroups = tw\`focus:(w-10 h-10 block bg-black) focus-within:(md:flex mt-5)\`
-const nestedGroups = tw\`md:(w-10 hocus:(h-10 block bg-black))\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
-const basic = {
-  '.group:hover &': {
-    display: 'flex',
-    margin: '2.5rem',
-  },
-}
-const subMediaQuery = {
-  ':focus-within': {
-    '@media (min-width: 768px)': {
-      display: 'flex',
-    },
-    marginTop: '1.25rem',
-  },
-}
-const multipleClasses = {
-  ':hover': {
-    '--tw-bg-opacity': '1',
-    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
-    '--tw-text-opacity': '1',
-    color: 'rgba(255, 255, 255, var(--tw-text-opacity))',
-    textDecoration: 'underline',
-  },
-}
-const pseudoElement = {
-  ':before': {
-    content: '""',
-    width: '2.5rem',
-    height: '2.5rem',
-    display: 'block',
-    '--tw-bg-opacity': '1',
-    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
-  },
-}
-const mediaHover = {
-  '@media (min-width: 640px)': {
-    ':hover': {
-      '--tw-bg-opacity': '1',
-      backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
-      '--tw-text-opacity': '1',
-      color: 'rgba(255, 255, 255, var(--tw-text-opacity))',
-    },
-  },
-}
-const sloppySpacing = {
-  ':last-child': {
-    display: 'flex',
-    marginTop: '1.25rem',
-  },
-}
-const multipleGroups = {
-  ':focus': {
-    width: '2.5rem',
-    height: '2.5rem',
-    display: 'block',
-    '--tw-bg-opacity': '1',
-    backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
-  },
-  ':focus-within': {
-    '@media (min-width: 768px)': {
-      display: 'flex',
-    },
-    marginTop: '1.25rem',
-  },
-}
-const nestedGroups = {
-  '@media (min-width: 768px)': {
-    width: '2.5rem',
-    ':hover, :focus': {
-      height: '2.5rem',
-      display: 'block',
-      '--tw-bg-opacity': '1',
-      backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
-    },
-  },
-}
 
 
 `;

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -13,7 +13,7 @@ import {
 } from './logging'
 import { orderByScreens } from './screens'
 import applyTransforms from './transforms'
-import { addVariants, handleVariantGroups } from './variants'
+import { addVariants, handleGroups } from './variants'
 import {
   handleUserPlugins,
   handleCorePlugins,
@@ -32,7 +32,7 @@ export default (classes, t, state) => {
   classes = classes.replace(/ \| /g, ' ')
 
   // Unwrap grouped variants
-  classes = handleVariantGroups(classes)
+  classes = handleGroups(classes)
 
   // Move and sort the responsive items to the end of the list
   const classesOrdered = orderByScreens(classes, state)

--- a/src/variants.js
+++ b/src/variants.js
@@ -137,24 +137,7 @@ const throwOnMissingColon = unwrappedClasses => {
   )
 }
 
-const handleGroupsBracket = classes => {
-  const groups = classes.match(/(^|\s)\(([^\n\r()]*)\)/g)
-  if (!groups) return classes
-
-  let newClasses = classes.slice()
-
-  groups.forEach(group => {
-    const classGroup = group.match(/(^|\s)\(([^\n\r()]*)\)/)
-    if (!classGroup) return ''
-
-    const [wrappedClasses] = classGroup
-    const unwrappedClasses = wrappedClasses.replace(/(\(|\))/g, '')
-    newClasses = classes.replace(wrappedClasses, unwrappedClasses)
-  })
-
-  // Call this function again to take care of nested groups
-  return handleGroupsBracket(newClasses)
-}
+const handleGroupsBracket = classes => classes.slice().replace(/(\(|\))/g, '')
 
 const handleGroupsVariants = classes => {
   const groupedVariants = classes.match(/(\S*):\(([^\n\r()]*)\)/g)


### PR DESCRIPTION
This feature allows round brackets to be used to group classes:

```js
tw`(text-white bg-black) block`
``` 

It makes it easy to test group styles without having to unwrap the whole block:

```diff
- tw`xl:(w-10 h-10)`
+ tw`(w-10 h-10)`
```

Variants can also be nested which is handy when styling breakpoints:

```js
tw`md:(text-black bg-white hover:(bg-black text-white))`;
```