### PR TITLE
Remove macro from sc import preset

### DIFF
--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -24,7 +24,7 @@ export default {
     },
     css: {
       import: 'css',
-      from: 'styled-components/macro',
+      from: 'styled-components',
     },
     global: {
       import: 'createGlobalStyle',


### PR DESCRIPTION
This patch adjusts the css import to remove the macro.

This is due to an error that started being thrown in CRA when using `preset: "styled-components"`:

```shell
Attempted import error: 'css' is not exported from 'styled-components/macro' (imported as '_css').
```

Old:

```js
import { css } from 'styled-components/macro'
```

New:

```js
import { css } from 'styled-components'
```

Reference #264 