### PR TITLE
Enhance nested bracket groups

### DIFF
--- a/src/variants.js
+++ b/src/variants.js
@@ -121,21 +121,21 @@ const addVariants = ({ results, style, pieces }) => {
   return styleWithVariants
 }
 
-function findRightBracket(classes, start = 0) {
-  const stack = []
-  for (let index = start; index < classes.length; index++) {
+function findRightBracket(classes, start = 0, end = classes.length) {
+  let stack = 0
+  for (let index = start; index < end; index++) {
     if (classes[index] === '(') {
-      stack.push(index)
+      stack += 1
     } else if (classes[index] === ')') {
-      if (stack.length === 0) {
+      if (stack === 0) {
         return
       }
 
-      if (stack.length === 1) {
+      if (stack === 1) {
         return index
       }
 
-      stack.pop()
+      stack -= 1
     }
   }
 }

--- a/src/variants.js
+++ b/src/variants.js
@@ -199,7 +199,7 @@ function spreadVariantGroups(
       results.push(context + className + tail)
       context = baseContext
     } else if (weird) {
-      // TODO: throw error
+      results.push(context + weird)
     } else {
       const closeBracket = findRightBracket(classes, match.index)
       if (typeof closeBracket !== 'number') {


### PR DESCRIPTION
### Fix:
```
md:(hover:(font-black bg-black))
```

### Change:
1. support bracket groups

   ```
   (font-black bg-black)
   ((font-black bg-black))
   hover:(font-black bg-black)
   md:(hover:(font-black bg-black))
   md:(hover:(font-black (text-white) bg-black))
   ```

2. support important groups

   ```
   (font-black bg-black)! => font-black! bg-black!
   hover:(font-black bg-black)! => hover:font-black! hover:bg-black!
   md:(hover:(font-black (text-white)! bg-black)) => md:hover:font-black md:hover:text-white! md:hover:bg-black
   ```

3. ignore empty groups
   ```
   () =>
   md:() =>
   md:(hover:()) =>
   ```
