### PR TITLE
className matching

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,7 @@ module.exports = {
     'unicorn/import-style': 0,
     'unicorn/prefer-optional-catch-binding': 0,
     'unicorn/no-null': 0,
+    'unicorn/prevent-abbreviations': 0,
   },
   overrides: [
     {
@@ -94,4 +95,5 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: ['.eslintrc.js'],
 }

--- a/__fixtures__/!general.js
+++ b/__fixtures__/!general.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw from './macro'
 
 /**

--- a/__fixtures__/!imports.js
+++ b/__fixtures__/!imports.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw, { theme, styled, css, GlobalStyles } from './macro'
 
 const twPropertyTest = <div tw="text-purple-500" />

--- a/__fixtures__/!namelessImport.js
+++ b/__fixtures__/!namelessImport.js
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable import/no-unassigned-import */
-/* eslint-disable react/react-in-jsx-scope */
-/* eslint-disable react/jsx-curly-brace-presence */
 import './macro'
 
 const twPropertyString = <div tw="text-purple-500" />

--- a/__fixtures__/!plugins.js
+++ b/__fixtures__/!plugins.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 // Tailwind plugin tests

--- a/__fixtures__/!properties.js
+++ b/__fixtures__/!properties.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw from './macro'
 
 const Component1 = () => <div tw="uppercase" />

--- a/__fixtures__/!variantGrouping.js
+++ b/__fixtures__/!variantGrouping.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 const basic = tw`group-hover:(flex m-10)`

--- a/__fixtures__/!variants.js
+++ b/__fixtures__/!variants.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 // Before/after pseudo elements

--- a/__fixtures__/.eslintrc.js
+++ b/__fixtures__/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/no-unused-vars': 'off',
+    'react/react-in-jsx-scope': 'off',
+    'import/no-unassigned-import': 'off',
+    'react/jsx-curly-brace-presence': 'off',
+  },
+}

--- a/__fixtures__/includeClassNames/config.json
+++ b/__fixtures__/includeClassNames/config.json
@@ -1,0 +1,3 @@
+{
+  "includeClassNames": true
+}

--- a/__fixtures__/includeClassNames/includeClassNames.js
+++ b/__fixtures__/includeClassNames/includeClassNames.js
@@ -1,0 +1,144 @@
+import tw from './macro'
+
+const SkipEmptyClassName = <div className="" />
+const OnlyUppercaseConverted = <div className="uppercase spare-class" />
+const AllConverted = <div className="uppercase block" />
+const SkippedCurlies = <div className={'mt-1'} />
+const SkippedConditionals = <div className={true && 'mt-1'} />
+const SkippedGroup = <div className="group" />
+
+// css + className
+const CssPropFirst = (
+  <div
+    css={`
+      color: red;
+    `}
+    className="block"
+  />
+)
+const CssPropLast = (
+  <div
+    className="block"
+    css={`
+      color: red;
+    `}
+  />
+)
+
+// tw + className
+const TwPropFirst = <div tw="block" className="mt-1" />
+const TwPropLast = <div className="mt-1" tw="block" />
+
+// tw + css + className
+const TwThenCssThenClassName = (
+  <div
+    tw="block"
+    css={`
+      color: red;
+    `}
+    className="mt-1"
+  />
+)
+const TwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    tw="block"
+    className="mt-1"
+    css={`
+      color: red;
+    `}
+  />
+)
+const ClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    className="mt-1"
+    tw="block"
+    css={`
+      color: red;
+    `}
+  />
+)
+const ClassNameThenCssThenTw = (
+  <div
+    className="mt-1"
+    css={`
+      color: red;
+    `}
+    tw="block"
+  />
+)
+const CssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <div
+    css={`
+      color: red;
+    `}
+    className="mt-1"
+    tw="block"
+  />
+)
+const CssThenTwThenClassName = (
+  <div
+    css={`
+      color: red;
+    `}
+    tw="block"
+    className="mt-1"
+  />
+)
+
+// styled + everything
+const Button = tw.div``
+
+const StyledTwThenCssThenClassName = (
+  <Button
+    tw="block"
+    css={`
+      color: red;
+    `}
+    className="mt-1"
+  />
+)
+const StyledTwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    tw="block"
+    className="mt-1"
+    css={`
+      color: red;
+    `}
+  />
+)
+const StyledClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    className="mt-1"
+    tw="block"
+    css={`
+      color: red;
+    `}
+  />
+)
+const StyledClassNameThenCssThenTw = (
+  <Button
+    className="mt-1"
+    css={`
+      color: red;
+    `}
+    tw="block"
+  />
+)
+const StyledCssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <Button
+    css={`
+      color: red;
+    `}
+    className="mt-1"
+    tw="block"
+  />
+)
+const StyledCssThenTwThenClassName = (
+  <Button
+    css={`
+      color: red;
+    `}
+    tw="block"
+    className="mt-1"
+  />
+)

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -158,8 +158,6 @@ tw\`stroke-non-scaling\`
 
 exports[`twin.macro !general.js: !general.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw from './macro'
 
 /**
@@ -365,8 +363,6 @@ const plainVariable = \`bg-\${plainConditional}-500\`
 
 exports[`twin.macro !imports.js: !imports.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw, { theme, styled, css, GlobalStyles } from './macro'
 
 const twPropertyTest = <div tw="text-purple-500" />
@@ -1000,10 +996,6 @@ const GlobalStylesTest = () => <_GlobalStyles />
 
 exports[`twin.macro !namelessImport.js: !namelessImport.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable import/no-unassigned-import */
-/* eslint-disable react/react-in-jsx-scope */
-/* eslint-disable react/jsx-curly-brace-presence */
 import './macro'
 
 const twPropertyString = <div tw="text-purple-500" />
@@ -1011,13 +1003,6 @@ const twPropertyExpression = <div tw={'text-purple-500'} />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/* eslint-disable import/no-unassigned-import */
-
-/* eslint-disable react/react-in-jsx-scope */
-
-/* eslint-disable react/jsx-curly-brace-presence */
 const twPropertyString = (
   <div
     css={{
@@ -1081,7 +1066,6 @@ _styled.div({
 
 exports[`twin.macro !plugins.js: !plugins.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 // Tailwind plugin tests
@@ -1113,7 +1097,6 @@ tw\`aspect-test-6\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // Tailwind plugin tests
 ;({
   fontSize: '0.875rem',
@@ -2221,8 +2204,6 @@ const addComponentsResponsiveScoping = {
 
 exports[`twin.macro !properties.js: !properties.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable react/react-in-jsx-scope */
 import tw from './macro'
 
 const Component1 = () => <div tw="uppercase" />
@@ -2255,9 +2236,6 @@ const Component7 = () => (
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-/* eslint-disable react/react-in-jsx-scope */
 const Component1 = () => (
   <div
     css={{
@@ -2390,7 +2368,6 @@ tw\`2xl:block\`
 
 exports[`twin.macro !variantGrouping.js: !variantGrouping.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 const basic = tw\`group-hover:(flex m-10)\`
@@ -2404,7 +2381,6 @@ const nestedGroups = tw\`md:(w-10 hocus:(h-10 block bg-black))\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 const basic = {
   '.group:hover &': {
     display: 'flex',
@@ -2486,7 +2462,6 @@ const nestedGroups = {
 
 exports[`twin.macro !variants.js: !variants.js 1`] = `
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import tw from './macro'
 
 // Before/after pseudo elements
@@ -2565,7 +2540,6 @@ const multiVariants = tw\`xl:placeholder-red-500! first:md:block sm:disabled:fle
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // Before/after pseudo elements
 ;({
   ':before': {
@@ -8950,6 +8924,414 @@ tw\`gap-y-px\`
 ;({
   rowGap: '1px',
 })
+
+
+`;
+
+exports[`twin.macro includeClassNames.js: includeClassNames.js 1`] = `
+
+import tw from './macro'
+
+const SkipEmptyClassName = <div className="" />
+const OnlyUppercaseConverted = <div className="uppercase spare-class" />
+const AllConverted = <div className="uppercase block" />
+const SkippedCurlies = <div className={'mt-1'} />
+const SkippedConditionals = <div className={true && 'mt-1'} />
+const SkippedGroup = <div className="group" />
+
+// css + className
+const CssPropFirst = (
+  <div
+    css={\`
+      color: red;
+    \`}
+    className="block"
+  />
+)
+const CssPropLast = (
+  <div
+    className="block"
+    css={\`
+      color: red;
+    \`}
+  />
+)
+
+// tw + className
+const TwPropFirst = <div tw="block" className="mt-1" />
+const TwPropLast = <div className="mt-1" tw="block" />
+
+// tw + css + className
+const TwThenCssThenClassName = (
+  <div
+    tw="block"
+    css={\`
+      color: red;
+    \`}
+    className="mt-1"
+  />
+)
+const TwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    tw="block"
+    className="mt-1"
+    css={\`
+      color: red;
+    \`}
+  />
+)
+const ClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    className="mt-1"
+    tw="block"
+    css={\`
+      color: red;
+    \`}
+  />
+)
+const ClassNameThenCssThenTw = (
+  <div
+    className="mt-1"
+    css={\`
+      color: red;
+    \`}
+    tw="block"
+  />
+)
+const CssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <div
+    css={\`
+      color: red;
+    \`}
+    className="mt-1"
+    tw="block"
+  />
+)
+const CssThenTwThenClassName = (
+  <div
+    css={\`
+      color: red;
+    \`}
+    tw="block"
+    className="mt-1"
+  />
+)
+
+// styled + everything
+const Button = tw.div\`\`
+
+const StyledTwThenCssThenClassName = (
+  <Button
+    tw="block"
+    css={\`
+      color: red;
+    \`}
+    className="mt-1"
+  />
+)
+const StyledTwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    tw="block"
+    className="mt-1"
+    css={\`
+      color: red;
+    \`}
+  />
+)
+const StyledClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    className="mt-1"
+    tw="block"
+    css={\`
+      color: red;
+    \`}
+  />
+)
+const StyledClassNameThenCssThenTw = (
+  <Button
+    className="mt-1"
+    css={\`
+      color: red;
+    \`}
+    tw="block"
+  />
+)
+const StyledCssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <Button
+    css={\`
+      color: red;
+    \`}
+    className="mt-1"
+    tw="block"
+  />
+)
+const StyledCssThenTwThenClassName = (
+  <Button
+    css={\`
+      color: red;
+    \`}
+    tw="block"
+    className="mt-1"
+  />
+)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from '@emotion/styled'
+const SkipEmptyClassName = <div className="" />
+const OnlyUppercaseConverted = (
+  <div
+    className="spare-class"
+    css={{
+      textTransform: 'uppercase',
+    }}
+  />
+)
+const AllConverted = (
+  <div
+    css={{
+      textTransform: 'uppercase',
+      display: 'block',
+    }}
+  />
+)
+const SkippedCurlies = <div className={'mt-1'} />
+const SkippedConditionals = <div className={true && 'mt-1'} />
+const SkippedGroup = <div className="group" /> // css + className
+
+const CssPropFirst = (
+  <div
+    css={[
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+    ]}
+  />
+)
+const CssPropLast = (
+  <div
+    css={[
+      {
+        display: 'block',
+      },
+      \`
+      color: red;
+    \`,
+    ]}
+  />
+) // tw + className
+
+const TwPropFirst = (
+  <div
+    css={[
+      {
+        display: 'block',
+      },
+      {
+        marginTop: '0.25rem',
+      },
+    ]}
+  />
+)
+const TwPropLast = (
+  <div
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      {
+        display: 'block',
+      },
+    ]}
+  />
+) // tw + css + className
+
+const TwThenCssThenClassName = (
+  <div
+    css={[
+      {
+        display: 'block',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        marginTop: '0.25rem',
+      },
+    ]}
+  />
+)
+const TwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      {
+        display: 'block',
+      },
+      \`
+      color: red;
+    \`,
+    ]}
+  />
+)
+const ClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <div
+    css={[
+      {
+        display: 'block',
+      },
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+    ]}
+  />
+)
+const ClassNameThenCssThenTw = (
+  <div
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+    ]}
+  />
+)
+const CssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <div
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+    ]}
+  />
+)
+const CssThenTwThenClassName = (
+  <div
+    css={[
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+      {
+        marginTop: '0.25rem',
+      },
+    ]}
+  />
+) // styled + everything
+
+const Button = _styled.div({})
+
+const StyledTwThenCssThenClassName = (
+  <Button
+    css={[
+      {
+        display: 'block',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        marginTop: '0.25rem',
+      },
+    ]}
+  />
+)
+const StyledTwThenClassNameThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      {
+        display: 'block',
+      },
+      \`
+      color: red;
+    \`,
+    ]}
+  />
+)
+const StyledClassNameThenTwThenCss_KNOWN_ORDER_ISSUE = (
+  <Button
+    css={[
+      {
+        display: 'block',
+      },
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+    ]}
+  />
+)
+const StyledClassNameThenCssThenTw = (
+  <Button
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+    ]}
+  />
+)
+const StyledCssThenClassNameThenTw_KNOWN_ORDER_ISSUE = (
+  <Button
+    css={[
+      {
+        marginTop: '0.25rem',
+      },
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+    ]}
+  />
+)
+const StyledCssThenTwThenClassName = (
+  <Button
+    css={[
+      \`
+      color: red;
+    \`,
+      {
+        display: 'block',
+      },
+      {
+        marginTop: '0.25rem',
+      },
+    ]}
+  />
+)
 
 
 `;

--- a/plugin.test.js
+++ b/plugin.test.js
@@ -4,6 +4,8 @@ const path = require('path')
 const glob = require('glob-all')
 const fs = require('fs')
 
+const configFile = file => `${path.dirname(file)}/config.json`
+
 pluginTester({
   plugin,
   pluginName: 'twin.macro',
@@ -12,8 +14,13 @@ pluginTester({
     babelrc: true,
   },
   snapshot: true,
-  tests: glob.sync('__fixtures__/*.js').map(file => ({
+  tests: glob.sync('__fixtures__/**/*.js').map(file => ({
     title: path.basename(file),
     code: fs.readFileSync(file, 'utf-8'),
+    ...(fs.existsSync(configFile(file)) && {
+      pluginOptions: {
+        twin: JSON.parse(fs.readFileSync(configFile(file), 'utf-8')),
+      },
+    }),
   })),
 })

--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -10,6 +10,7 @@ const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
   hasSuggestions: true, // Switch suggestions on/off when you use a tailwind class that's not found
   sassyPseudo: false, // Sets selectors like hover to &:hover
   debug: false, // Show the output of the classes twin converts
+  includeClassNames: false, // Look in the className props for tailwind classes to convert
   ...(isStyledComponents && configDefaultsStyledComponents),
   ...(isGoober && configDefaultsGoober),
 })
@@ -47,6 +48,10 @@ const configTwinValidators = {
   debugProp: [
     value => value === undefined,
     `The “debugProp” option was renamed to “dataTwProp”, please rename it in your twin config`,
+  ],
+  includeClassNames: [
+    isBoolean,
+    'The config includeClassNames can only be true or false',
   ],
 }
 

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -46,6 +46,7 @@ export default (classes, t, state, silentMismatches = false) => {
 
   // Merge styles into a single css object
   const styles = classesOrdered.reduce((results, classNameRaw) => {
+    // Avoid prechecks on silent mode as they'll error loudly
     !silentMismatches && doPrechecks([precheckGroup], { classNameRaw })
 
     const pieces = getPieces({ classNameRaw, state })
@@ -70,12 +71,12 @@ export default (classes, t, state, silentMismatches = false) => {
       type,
     } = getProperties(className, state)
 
-    // Kick off suggestions when no class matches
     if (silentMismatches && !hasMatches && !hasUserPlugins) {
       classesMismatched.push(classNameRaw)
       return results
     }
 
+    // Kick off suggestions when no class matches
     throwIf(!hasMatches && !hasUserPlugins, () =>
       errorSuggestions({ pieces, state })
     )

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -21,8 +21,10 @@ import {
   handleDynamic,
 } from './handlers'
 
-export default (classes, t, state) => {
-  throwIf([null, 'null', undefined].includes(classes), () =>
+export default (classes, t, state, silentMismatches = false) => {
+  const hasEmptyClasses = [null, 'null', undefined].includes(classes)
+  if (silentMismatches && hasEmptyClasses) return
+  throwIf(hasEmptyClasses, () =>
     logGeneralError(
       'Only plain strings can be used with "tw".\nRead more at https://twinredirect.page.link/template-literals'
     )
@@ -39,13 +41,21 @@ export default (classes, t, state) => {
 
   const theme = getTheme(state.config.theme)
 
+  const classesMatched = []
+  const classesMismatched = []
+
   // Merge styles into a single css object
   const styles = classesOrdered.reduce((results, classNameRaw) => {
-    doPrechecks([precheckGroup], { classNameRaw })
+    !silentMismatches && doPrechecks([precheckGroup], { classNameRaw })
 
     const pieces = getPieces({ classNameRaw, state })
     const { className, hasVariants } = pieces
     const { configTwin } = state
+
+    if (silentMismatches && !className) {
+      classesMismatched.push(classNameRaw)
+      return results
+    }
 
     throwIf(!className, () =>
       hasVariants ? logNotFoundVariant({ classNameRaw }) : logNotFoundClass
@@ -61,6 +71,11 @@ export default (classes, t, state) => {
     } = getProperties(className, state)
 
     // Kick off suggestions when no class matches
+    if (silentMismatches && !hasMatches && !hasUserPlugins) {
+      classesMismatched.push(classNameRaw)
+      return results
+    }
+
     throwIf(!hasMatches && !hasUserPlugins, () =>
       errorSuggestions({ pieces, state })
     )
@@ -93,6 +108,11 @@ export default (classes, t, state) => {
     }
 
     // Check again there are no userPlugin matches
+    if (silentMismatches && !hasMatches && !style) {
+      classesMismatched.push(classNameRaw)
+      return results
+    }
+
     throwIf(!hasMatches && !style, () => errorSuggestions({ pieces, state }))
 
     style =
@@ -103,10 +123,16 @@ export default (classes, t, state) => {
       pieces.hasVariants ? addVariants({ results, style, pieces }) : style
     )
 
-    state.configTwin.debug && debug(classNameRaw, result)
+    state.configTwin.debug && debug(classNameRaw, style)
 
+    classesMatched.push(classNameRaw)
     return result
   }, {})
 
-  return astify(isEmpty(styles) ? {} : styles, t)
+  return {
+    // TODO: Avoid astifying here, move it outside function
+    styles: astify(isEmpty(styles) ? {} : styles, t),
+    mismatched: classesMismatched.join(' '),
+    matched: classesMatched.join(' '),
+  }
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -48,7 +48,6 @@ const twinMacro = ({ babel: { types: t }, references, state, config }) => {
 
   const program = state.file.path
 
-  /* eslint-disable-next-line unicorn/prevent-abbreviations */
   const isDev =
     process.env.NODE_ENV === 'development' ||
     process.env.NODE_ENV === 'dev' ||

--- a/src/macro.js
+++ b/src/macro.js
@@ -24,6 +24,7 @@ import {
 import { handleThemeFunction } from './macro/theme'
 import { handleGlobalStylesFunction } from './macro/globalStyles'
 import { handleTwProperty, handleTwFunction } from './macro/tw'
+import { handleClassNameProperty } from './macro/className'
 import getUserPluginData from './utils/getUserPluginData'
 import { debugPlugins } from './logging'
 
@@ -98,6 +99,8 @@ const twinMacro = ({ babel: { types: t }, references, state, config }) => {
       setCssIdentifier({ state, path, cssImport })
     },
     JSXAttribute(path) {
+      if (path.node.name.name === 'css') state.hasCssProp = true
+      handleClassNameProperty({ path, t, state })
       handleTwProperty({ path, t, state })
     },
   })

--- a/src/macro/className.js
+++ b/src/macro/className.js
@@ -1,0 +1,68 @@
+import { throwIf } from './../utils'
+import { logGeneralError } from './../logging'
+/* eslint-disable-next-line unicorn/prevent-abbreviations */
+import { addDataTwPropToPath, addDataTwPropToExistingPath } from './debug'
+import getStyles from './../getStyles'
+
+const handleClassNameProperty = ({ path, t, state }) => {
+  if (!state.configTwin.includeClassNames) return
+  if (path.node.name.name !== 'className') return
+
+  const nodeValue = path.node.value
+
+  // Ignore className if it cannot be resolved
+  if (nodeValue.expression) return
+
+  const rawClasses = nodeValue.value || ''
+  if (!rawClasses) return
+
+  const { styles, mismatched, matched } = getStyles(rawClasses, t, state, true)
+
+  // When classes can't be matched we add them back into the className (it exists as a few properties)
+  path.node.value.value = mismatched
+  path.node.value.extra.rawValue = mismatched
+  path.node.value.extra.raw = `"${mismatched}"`
+
+  const jsxPath = path.findParent(p => p.isJSXOpeningElement())
+  const attributes = jsxPath.get('attributes')
+  const cssAttributes = attributes.filter(
+    p => p.node.name && p.node.name.name === 'css'
+  )
+
+  if (cssAttributes.length === 0) {
+    const attribute = t.jsxAttribute(
+      t.jsxIdentifier('css'),
+      t.jsxExpressionContainer(styles)
+    )
+    mismatched ? path.insertAfter(attribute) : path.replaceWith(attribute)
+    addDataTwPropToPath({ t, attributes, rawClasses: matched, path, state })
+
+    return
+  }
+
+  const expr = cssAttributes[0].get('value').get('expression')
+
+  if (expr.isArrayExpression()) {
+    expr.unshiftContainer('elements', styles)
+  } else {
+    const cssProperty = expr.node
+    throwIf(!cssProperty, () =>
+      logGeneralError(
+        `An empty css prop (css="") isn’t supported alongside the className prop`
+      )
+    )
+    expr.replaceWith(t.arrayExpression([styles, cssProperty]))
+  }
+
+  if (!mismatched) path.remove()
+
+  addDataTwPropToExistingPath({
+    t,
+    attributes,
+    rawClasses: matched,
+    path: jsxPath,
+    state,
+  })
+}
+
+export { handleClassNameProperty }

--- a/src/macro/className.js
+++ b/src/macro/className.js
@@ -1,8 +1,18 @@
 import { throwIf } from './../utils'
 import { logGeneralError } from './../logging'
-/* eslint-disable-next-line unicorn/prevent-abbreviations */
 import { addDataTwPropToPath, addDataTwPropToExistingPath } from './debug'
-import getStyles from './../getStyles'
+import getStyleData from './../getStyleData'
+
+const getParentJSX = path => path.findParent(p => p.isJSXOpeningElement())
+
+const getAttributeNames = jsxPath => {
+  const attributes = jsxPath.get('attributes')
+  const attributeNames = attributes.map(p => p.node.name && p.node.name.name)
+  return attributeNames
+}
+
+const makeJsxAttribute = ([key, value], t) =>
+  t.jsxAttribute(t.jsxIdentifier(key), t.jsxExpressionContainer(value))
 
 const handleClassNameProperty = ({ path, t, state }) => {
   if (!state.configTwin.includeClassNames) return
@@ -16,42 +26,57 @@ const handleClassNameProperty = ({ path, t, state }) => {
   const rawClasses = nodeValue.value || ''
   if (!rawClasses) return
 
-  const { styles, mismatched, matched } = getStyles(rawClasses, t, state, true)
+  const { styles, mismatched, matched } = getStyleData(
+    rawClasses,
+    t,
+    state,
+    true
+  )
+  if (!matched) return
 
   // When classes can't be matched we add them back into the className (it exists as a few properties)
   path.node.value.value = mismatched
   path.node.value.extra.rawValue = mismatched
   path.node.value.extra.raw = `"${mismatched}"`
 
-  const jsxPath = path.findParent(p => p.isJSXOpeningElement())
+  const jsxPath = getParentJSX(path)
   const attributes = jsxPath.get('attributes')
   const cssAttributes = attributes.filter(
     p => p.node.name && p.node.name.name === 'css'
   )
 
   if (cssAttributes.length === 0) {
-    const attribute = t.jsxAttribute(
-      t.jsxIdentifier('css'),
-      t.jsxExpressionContainer(styles)
-    )
+    const attribute = makeJsxAttribute(['css', styles], t)
     mismatched ? path.insertAfter(attribute) : path.replaceWith(attribute)
     addDataTwPropToPath({ t, attributes, rawClasses: matched, path, state })
-
     return
   }
 
-  const expr = cssAttributes[0].get('value').get('expression')
+  const cssExpression = cssAttributes[0].get('value').get('expression')
+  const attributeNames = getAttributeNames(jsxPath)
+  const isBeforeTwAttribute =
+    attributeNames.indexOf('className') - attributeNames.indexOf('tw') < 0
+  const isBeforeCssAttribute =
+    attributeNames.indexOf('className') - attributeNames.indexOf('css') < 0
 
-  if (expr.isArrayExpression()) {
-    expr.unshiftContainer('elements', styles)
+  if (cssExpression.isArrayExpression()) {
+    //  The existing css prop is an array, eg: css={[...]}
+    isBeforeTwAttribute || isBeforeCssAttribute
+      ? cssExpression.unshiftContainer('elements', styles)
+      : cssExpression.pushContainer('elements', styles)
   } else {
-    const cssProperty = expr.node
-    throwIf(!cssProperty, () =>
+    // The existing css prop is not an array, eg: css={{ ... }} / css={`...`}
+    const existingCssAttribute = cssExpression.node
+    throwIf(!existingCssAttribute, () =>
       logGeneralError(
         `An empty css prop (css="") isn’t supported alongside the className prop`
       )
     )
-    expr.replaceWith(t.arrayExpression([styles, cssProperty]))
+    const styleArray =
+      isBeforeTwAttribute || isBeforeCssAttribute
+        ? [styles, existingCssAttribute]
+        : [existingCssAttribute, styles]
+    cssExpression.replaceWith(t.arrayExpression(styleArray))
   }
 
   if (!mismatched) path.remove()

--- a/src/macro/debug.js
+++ b/src/macro/debug.js
@@ -1,4 +1,3 @@
-/* eslint-disable-next-line unicorn/prevent-abbreviations */
 const addDataTwPropToPath = ({ t, attributes, rawClasses, path, state }) => {
   if (state.isProd || !state.configTwin.dataTwProp) return
 
@@ -14,7 +13,6 @@ const addDataTwPropToPath = ({ t, attributes, rawClasses, path, state }) => {
   )
 }
 
-/* eslint-disable-next-line unicorn/prevent-abbreviations */
 const addDataTwPropToExistingPath = ({
   t,
   attributes,

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -1,9 +1,8 @@
 import { parseTte, replaceWithLocation } from './../macroHelpers'
 import { throwIf } from './../utils'
 import { logGeneralError, logStylePropertyError } from './../logging'
-/* eslint-disable-next-line unicorn/prevent-abbreviations */
 import { addDataTwPropToPath, addDataTwPropToExistingPath } from './debug'
-import getStyles from './../getStyles'
+import getStyleData from './../getStyleData'
 
 const handleTwProperty = ({ path, t, state }) => {
   if (!path.node || path.node.name.name !== 'tw') return
@@ -26,7 +25,7 @@ const handleTwProperty = ({ path, t, state }) => {
 
   const rawClasses = expressionValue || nodeValue.value || ''
 
-  const { styles } = getStyles(rawClasses, t, state)
+  const { styles } = getStyleData(rawClasses, t, state)
 
   const jsxPath = path.findParent(p => p.isJSXOpeningElement())
   const attributes = jsxPath.get('attributes')
@@ -129,7 +128,7 @@ const handleTwFunction = ({ references, state, t }) => {
       })
     }
 
-    const { styles } = getStyles(rawClasses, t, state)
+    const { styles } = getStyleData(rawClasses, t, state)
     replaceWithLocation(parsed.path, styles)
   })
 }

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -6,9 +6,7 @@ import { addDataTwPropToPath, addDataTwPropToExistingPath } from './debug'
 import getStyles from './../getStyles'
 
 const handleTwProperty = ({ path, t, state }) => {
-  if (path.node.name.name === 'css') state.hasCssProp = true
-
-  if (path.node.name.name !== 'tw') return
+  if (!path.node || path.node.name.name !== 'tw') return
   state.hasTwProp = true
 
   const nodeValue = path.node.value
@@ -27,7 +25,8 @@ const handleTwProperty = ({ path, t, state }) => {
   )
 
   const rawClasses = expressionValue || nodeValue.value || ''
-  const styles = getStyles(rawClasses, t, state)
+
+  const { styles } = getStyles(rawClasses, t, state)
 
   const jsxPath = path.findParent(p => p.isJSXOpeningElement())
   const attributes = jsxPath.get('attributes')
@@ -130,7 +129,8 @@ const handleTwFunction = ({ references, state, t }) => {
       })
     }
 
-    replaceWithLocation(parsed.path, getStyles(rawClasses, t, state))
+    const { styles } = getStyles(rawClasses, t, state)
+    replaceWithLocation(parsed.path, styles)
   })
 }
 


### PR DESCRIPTION
This PR adds a `includeClassNames` flag that allows twin to check `className` props for tailwind classes:

```js
<button className="rounded some-other-class" />
```

When a tailwind class is matched, it's converted to a css object and delivered to the css prop:

```js
<button className="some-other-class" css={{ "borderRadius": "0.25rem" }} />
```

- Unmatched classes are skipped and preserved within the className
- Suggestions aren’t shown for unmatched classes like they are for the tw prop
- The tw/css props can be used on the same jsx element
- Limitation: classNames with conditional props or variables aren’t touched, eg: `<div className={isBlock && "block"} />`

## How to enable the feature

```js
// babel-plugin-macros.config.js
module.exports = {
  twin: {
    // ...
    includeClassNames: true,
  },
}

// or

// package.json
"babelMacros": {
    "twin": 
      // ...
      "includeClassNames": true
    },
},
```

Thanks to [@mxstbr](https://github.com/mxstbr) for the idea in [this discussion](https://github.com/ben-rogerson/twin.macro/discussions/280).