### PR TITLE
Add config presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7546,9 +7546,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -7556,6 +7556,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
+    },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
     "lodash.foreach": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "clean-set": "^1.1.1",
     "color": "^3.1.3",
     "dset": "^2.0.1",
+    "lodash.flatmap": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "postcss": "^8.1.8",
     "string-similarity": "^4.0.3",


### PR DESCRIPTION
This PR adds tailwind.config.js [presets](https://tailwindcss.com/docs/presets) so you can extend your config with other tailwind configs:

```diff
// tailwind.config.js

const defaultConfig = {
  theme: {
     colors: {
     hotpink: "hotpink",
    },
  },
};

module.exports = {
+ presets: [defaultConfig],
  theme: {
    colors: {
      black: "#000000",
      white: "#ffffff",
    },
  },
};
```

You can also publish your config to npm then install it into your various projects:

```diff
// tailwind.config.js
module.exports = {
+ presets: [require("my-sweet-sweet-config")],
  theme: {
    colors: {
      black: "#000000",
      white: "#ffffff",
    },
  },
};
```


Check out the [official tailwind documentation](https://tailwindcss.com/docs/presets) for more info.


Closes #255 