### PR TITLE
Add improved short css syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,8 @@ const Input = () => <StyledInput hasBorder />
 
 ## How it works
 
-When babel runs over your code, Twin’s `css` and `styled` imports get swapped with the real imports from libraries like [💅&nbsp;styled&#8209;components](https://styled-components.com/) and [👩‍🎤&nbsp;emotion](https://emotion.sh/docs/introduction).
-
-Twin offers import presets for these libraries or you can fully customise the imports.
-
-When you use `tw`, Twin converts your classes into css objects, ready for passing to your chosen css-in-js library:
+When babel runs over your javascript or typescript files at compile time, twin grabs your classes and converts them into css objects.
+These css objects are then passed into your chosen the css-in-js library without the need for an extra client-side bundle:
 
 ```js
 import tw from 'twin.macro'
@@ -107,6 +104,9 @@ tw`text-sm md:text-lg`
   },
 }
 ```
+
+Twin also swaps it’s the `css` and `styled` imports with the real imports from your css in js library.
+This feature avoids having to add extra imports as you can import them all from twin.
 
 ## Features
 
@@ -125,31 +125,7 @@ ml-8 [2rem] / ml-10 [2.5rem] / ml-12 [3rem] / ml-16 [4rem] / ml-20 [5rem] / ml-2
 ml-40 [10rem] / ml-48 [12rem] / ml-56 [14rem] / ml-64 [16rem] / ml-auto [auto] / ml-px [1px]
 ```
 
-**🖌️ Use the theme import to add values from your tailwind config**
-
-```js
-import { theme, css } from 'twin.macro'
-
-const Input = () => <input css={css({ color: theme`colors.purple.500` })} />
-```
-
-See more examples [using the theme import →](https://github.com/ben-rogerson/twin.macro/pull/106)
-
-**💥 Add !important to any class with a trailing bang!**
-
-```js
-<div tw="hidden!" />
-// ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
-<div css={{ "display": "none !important" }} />
-```
-
-Add !important to multiple classes with bracket groups:
-
-```js
-<div tw="(hidden ml-auto)!" />
-// ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
-<div css={{ "display": "none !important", "marginLeft": "auto !important" }} />
-```
+**💡 Works with the official tailwind vscode plugin** - Avoid having to look up your classes with auto-completions straight from your tailwind config - [See setup instructions →](https://github.com/ben-rogerson/twin.macro/discussions/227)
 
 **🚥 Over 40 variants to prefix on your classes** - Unlike Tailwind, the prefixes are always available to add to your classes
 
@@ -178,10 +154,50 @@ const pseudoElementStyles = () => (
 
 const stackedVariants = () => <div tw="sm:hover:(bg-black text-white)" />
 
-const groupsInGroups = () => <div tw="sm:(bg-black hover:(bg-white w-10))">
+const groupsInGroups = () => <div tw="sm:(bg-black hover:(bg-white w-10))" />
 ```
 
-**💡 Integrates with the official tailwind vscode plugin** - Avoid having to look up your classes with auto-completions straight from your tailwind config - [See setup instructions →](https://github.com/ben-rogerson/twin.macro/discussions/227)
+**👑 Add vanilla css that fully integrates with twins features**
+
+```js
+const setCssVariables = () => <div tw="--base-color[#C0FFEE]" />
+
+const useCssVariables = () => <div tw="background-color[var(--base-color)]" />
+
+const addBrowserVendorPrefixes = () => <div tw="-webkit-line-clamp[3]" />
+
+const addCustomGridProperties = () => tw`grid-area[1 / 1 / 4 / 2]`
+
+const addAlongsideTailwindClasses = () => (
+  <div tw="after:(content['hello'] bg-black text-white)" />
+)
+```
+
+**🖌️ Use the theme import to add values from your tailwind config**
+
+```js
+import { theme, css } from 'twin.macro'
+
+const Input = () => <input css={css({ color: theme`colors.purple.500` })} />
+```
+
+See more examples [using the theme import →](https://github.com/ben-rogerson/twin.macro/pull/106)
+
+**💥 Add !important to any class with a trailing bang!**
+
+```js
+<div tw="hidden!" />
+// ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
+<div css={{ "display": "none !important" }} />
+```
+
+Add !important to multiple classes with bracket groups:
+
+```js
+<div tw="(hidden ml-auto)!" />
+// ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
+<div css={{ "display": "none !important", "marginLeft": "auto !important" }} />
+```
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ tw`text-sm md:text-lg`
 }
 ```
 
-Twin also swaps it’s the `css` and `styled` imports with the real imports from your css in js library.
+Twin also swaps its own `css` and `styled` imports with the real imports from your css in js library.
 This feature avoids having to add extra imports as you can import them all from twin.
 
 ## Features
@@ -157,20 +157,20 @@ const stackedVariants = () => <div tw="sm:hover:(bg-black text-white)" />
 const groupsInGroups = () => <div tw="sm:(bg-black hover:(bg-white w-10))" />
 ```
 
-**👑 Add vanilla css that fully integrates with twins features**
+**👑 Add vanilla css that integrates with twins features**
 
 ```js
+const alongsideTailwindClasses = () => (
+  <div tw="after:(content['hello'] bg-black text-white)" />
+)
+
 const setCssVariables = () => <div tw="--base-color[#C0FFEE]" />
 
 const useCssVariables = () => <div tw="background-color[var(--base-color)]" />
 
-const addBrowserVendorPrefixes = () => <div tw="-webkit-line-clamp[3]" />
+const customGridProperties = () => <div tw="grid-area[1 / 1 / 4 / 2]" />
 
-const addCustomGridProperties = () => tw`grid-area[1 / 1 / 4 / 2]`
-
-const addAlongsideTailwindClasses = () => (
-  <div tw="after:(content['hello'] bg-black text-white)" />
-)
+const vendorPrefixes = () => <div tw="-webkit-mask-image[url(mask.png)]" />
 ```
 
 **🖌️ Use the theme import to add values from your tailwind config**

--- a/__fixtures__/csClasses.js
+++ b/__fixtures__/csClasses.js
@@ -29,3 +29,15 @@ tw`hover:(maxWidth[100vw - 2rem]! before:content['test'])`
 
 // prop ordering
 ;<div css={{ color: 'red' }} cs="margin[50px]" tw="mt-4 content['content']" />
+
+// Setting css variables
+tw`--css-prop[true] md:--css-prop[false]`
+
+// Using css variables
+tw`max-width[var(--css-react)] md:max-width[var(--css-react-md)]`
+
+// Browser vendor prefixes
+tw`-webkit-gradient[gradient here] md:-webkit-gradient[gradient here md]`
+
+// Grid template
+tw`grid-template-columns[[main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end]] md:grid-template-columns[[main-start-md] 1fr [content-start-md] 1fr [content-end-md] 1fr [main-end-md]]`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -7967,6 +7967,18 @@ tw\`hover:(maxWidth[100vw - 2rem]! before:content['test'])\`
 // prop ordering
 ;<div css={{ color: 'red' }} cs="margin[50px]" tw="mt-4 content['content']" />
 
+// Setting css variables
+tw\`--css-prop[true] md:--css-prop[false]\`
+
+// Using css variables
+tw\`max-width[var(--css-react)] md:max-width[var(--css-react-md)]\`
+
+// Browser vendor prefixes
+tw\`-webkit-gradient[gradient here] md:-webkit-gradient[gradient here md]\`
+
+// Grid template
+tw\`grid-template-columns[[main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end]] md:grid-template-columns[[main-start-md] 1fr [content-start-md] 1fr [content-end-md] 1fr [main-end-md]]\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 ;<div
@@ -8136,7 +8148,37 @@ tw\`hover:(maxWidth[100vw - 2rem]! before:content['test'])\`
       content: "'content'",
     },
   ]}
-/>
+/> // Setting css variables
+
+;({
+  '--css-prop': 'true',
+  '@media (min-width: 768px)': {
+    '--css-prop': 'false',
+  },
+}) // Using css variables
+
+;({
+  maxWidth: 'var(--css-react)',
+  '@media (min-width: 768px)': {
+    maxWidth: 'var(--css-react-md)',
+  },
+}) // Browser vendor prefixes
+
+;({
+  WebkitGradient: 'gradient here',
+  '@media (min-width: 768px)': {
+    WebkitGradient: 'gradient here md',
+  },
+}) // Grid template
+
+;({
+  gridTemplateColumns:
+    '[main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end]',
+  '@media (min-width: 768px)': {
+    gridTemplateColumns:
+      '[main-start-md] 1fr [content-start-md] 1fr [content-end-md] 1fr [main-end-md]',
+  },
+})
 
 
 `;

--- a/src/handlers/css.js
+++ b/src/handlers/css.js
@@ -1,13 +1,28 @@
 import { SPACE_ID } from './../contants'
-import { throwIf } from './../utils'
+import { throwIf, camelize } from './../utils'
 import { logBadGood } from './../logging'
 
+function splitOnFirst(str, sep) {
+  const index = str.indexOf(sep)
+  return index < 0
+    ? [str]
+    : [str.slice(0, index), str.slice(Number(index) + Number(sep.length))]
+}
+
 export default ({ className }) => {
-  const [property, value] = className
-    .replace(']', '')
-    // Replace the "stand-in spaces" with real ones
-    .replace(new RegExp(SPACE_ID, 'g'), ' ')
-    .split('[')
+  let [property, value] = splitOnFirst(
+    className
+      // Replace the "stand-in spaces" with real ones
+      .replace(new RegExp(SPACE_ID, 'g'), ' '),
+    '['
+  )
+
+  property =
+    (property.startsWith('--') && property) || // Retain css variables
+    camelize(property)
+
+  // Remove the last ']' and whitespace
+  value = value.slice(0, -1).trim()
 
   throwIf(!property, () =>
     logBadGood(

--- a/src/logging.js
+++ b/src/logging.js
@@ -44,7 +44,6 @@ const logNoVariant = (variant, validVariants) =>
 const logNotAllowed = ({ className, error }) =>
   spaced(warning(`${color.errorLight(`${className}`)} ${error}`))
 
-// TODO: Wrap this in spaced
 const logBadGood = (bad, good) =>
   spaced(`${color.error('✕ Bad:')} ${bad}\n${color.success('✓ Good:')} ${good}`)
 

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -47,9 +47,6 @@ const getGlobalDeclarationTte = ({ t, stylesUid, globalUid, styles }) =>
     ),
   ])
 
-const getGlobalTte = ({ t, stylesUid, styles }) =>
-  generateTaggedTemplateExpression({ t, identifier: stylesUid, styles })
-
 const getGlobalDeclarationProperty = ({
   t,
   stylesUid,
@@ -165,6 +162,7 @@ const handleGlobalStylesFunction = ({
       state,
       styles,
     })
+    // TODO: Check for presence of css import
     program.unshiftContainer('body', declaration)
     path.replaceWith(t.jSXIdentifier(globalUid.name))
     state.isImportingCss = true

--- a/src/negative.js
+++ b/src/negative.js
@@ -2,7 +2,10 @@
  * Split the negative from the className
  */
 const splitNegative = ({ className }) => {
-  const hasNegative = className.slice(0, 1) === '-'
+  const isShortCss = className.includes('[')
+  const hasNegative = !isShortCss && className.slice(0, 1) === '-'
+
+  // TODO: Look in deprecating the negative prefix removal
   if (hasNegative) {
     className = className.slice(1, className.length)
   }

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -1,5 +1,6 @@
 import processPlugins from 'tailwindcss/lib/util/processPlugins'
 import deepMerge from 'lodash.merge'
+import { camelize } from './../utils'
 
 const parseSelector = (selector, isBase) => {
   if (!selector) return
@@ -8,9 +9,6 @@ const parseSelector = (selector, isBase) => {
   if (isBase) return matches[0]
   return matches[0].startsWith('.') ? matches[0].slice(1) : matches[0]
 }
-
-const camelize = string =>
-  string && string.replace(/\W+(.)/g, (match, chr) => chr.toUpperCase())
 
 const parseRuleProperty = string => {
   if (string && string.match(/^--[a-z-]*$/i)) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ export {
   getTheme,
   stripNegative,
   get,
+  camelize,
 } from './misc'
 export { default as withAlpha } from './withAlpha'
 export { toRgba } from './withAlpha'

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -71,4 +71,7 @@ const stripNegative = string =>
     ? string.slice(1, string.length)
     : string
 
-export { throwIf, isEmpty, addPxTo0, getTheme, stripNegative, get }
+const camelize = string =>
+  string && string.replace(/\W+(.)/g, (match, chr) => chr.toUpperCase())
+
+export { throwIf, isEmpty, addPxTo0, getTheme, stripNegative, get, camelize }

--- a/src/variants.js
+++ b/src/variants.js
@@ -154,9 +154,8 @@ function spreadVariantGroups(
   const results = []
   classes = classes.slice(start, end).trim()
 
-  // variant format: /[\w-]+:/
-  // class format: /[\w-./]+/
-  const reg = /([\w-]+:)|([\w-./[]+!?)|\(|(\S+)/g
+  const reg = /([\w-]+:)|([\w-./[\]]+!?)|\(|(\S+)/g
+
   let match
   const baseContext = context
 
@@ -201,28 +200,24 @@ function spreadVariantGroups(
         classes.length,
         ['[', ']']
       )
-
       throwIf(typeof closeBracket !== 'number', () =>
         logGeneralError(
           `An ending bracket ']' wasn’t found for these classes:\n\n${classes}`
         )
       )
       const importantGroup = classes[closeBracket + 1] === '!'
-
-      const cssClass = classes.slice(
-        classes.indexOf(className),
-        closeBracket + 1
-      )
-
-      const spaceReplacedClass = cssClass.replace(/ /g, SPACE_ID)
+      const cssClass = classes.slice(match.index, closeBracket + 1)
 
       // Convert spaces in classes to a temporary string so the css won't be
       // split into multiple classes
+      const spaceReplacedClass = cssClass.replace(/ /g, SPACE_ID)
+
       results.push(
         context +
           spaceReplacedClass +
           (importantGroup || importantContext ? '!' : '')
       )
+
       reg.lastIndex = closeBracket + (importantGroup ? 2 : 1)
       context = baseContext
     } else if (className) {


### PR DESCRIPTION
This PR adds support for a bunch of less common css properties and css property variable setting.

It also adds support for using dashed-case css property names as it was restricted to camel case before:

```js
tw`
max-width[100px]
grid-template-columns[[linename1] 100px [linename2 linename3]]
--base-color[#C0FFEE]
-webkit-line-clamp[3]
`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "maxWidth": "100px",
  "gridTemplateColumns": "[linename1] 100px [linename2 linename3]",
  "--base-color": "#C0FFEE",
  "webkitLineClamp": "3",
});
```

Fixes #317
Fixes #315 
Fixes #314 