### PR TITLE
Better plugin support

### DIFF
--- a/__fixtures__/!plugins.js
+++ b/__fixtures__/!plugins.js
@@ -12,16 +12,13 @@ const addUtilitiesTest2Media = tw`sm:skew-15deg lg:type-sm`
 const addUtilitiesTest2Variants = tw`hover:active:skew-15deg even:visited:skew-15deg`
 
 const addComponentsTest = tw`btn btn-blue btn-red`
-// const addComponentsTestImportant = tw`btn! btn-blue!` // Issue showing sub selectors and important
+// const addComponentsTestImportant = tw`btn! btn-blue!` // TODO: Issue showing sub selectors and important
 const addComponentsTestMedia = tw`xl:btn sm:btn-blue lg:btn-red`
 const addComponentsTestVariants = tw`hover:active:btn hocus:before:btn-blue even:visited:btn-red`
 
 const addComponentsTestMediaQueriesVariants = tw`fluid-container ml-10`
-const addComponentsTestElementSelectors = tw`rich-text`
 const addComponentsTestElementPrefixes = tw`prefixes`
 const addComponentsTestElementScreenReplacements = tw`screenies`
-
-const addComponentsResponsiveScoping = tw`prose sm:prose-sm lg:prose-lg xl:prose-xl`
 
 tw`aspect-test-2`
 tw`aspect-test-4`

--- a/__fixtures__/pluginTypography/config.json
+++ b/__fixtures__/pluginTypography/config.json
@@ -1,0 +1,3 @@
+{
+  "config": "__fixtures__/pluginTypography/tailwind.config.js"
+}

--- a/__fixtures__/pluginTypography/pluginTypography.js
+++ b/__fixtures__/pluginTypography/pluginTypography.js
@@ -1,0 +1,7 @@
+import tw from './macro'
+
+// From @tailwindcss/typography
+tw`prose sm:prose-sm lg:prose-lg xl:prose-xl`
+
+// From tailwindcss-typography
+tw`rich-text`

--- a/__fixtures__/pluginTypography/tailwind.config.js
+++ b/__fixtures__/pluginTypography/tailwind.config.js
@@ -1,0 +1,78 @@
+const textStyles = theme => ({
+  heading: {
+    output: false,
+    fontWeight: theme('fontWeight.bold'),
+    lineHeight: theme('lineHeight.tight'),
+  },
+  h1: {
+    extends: 'heading',
+    fontSize: theme('fontSize.5xl'),
+    '@screen sm': {
+      fontSize: theme('fontSize.6xl'),
+    },
+  },
+  h2: {
+    extends: 'heading',
+    fontSize: theme('fontSize.4xl'),
+    '@screen sm': {
+      fontSize: theme('fontSize.5xl'),
+      lineHeight: '50px',
+    },
+  },
+  '@screen sm': {
+    h3: {
+      extends: 'heading',
+      fontSize: theme('fontSize.4xl'),
+    },
+    ':hover': {
+      color: theme('colors.blue.300'),
+    },
+  },
+  link: {
+    fontWeight: theme('fontWeight.bold'),
+    color: theme('colors.blue.400'),
+    '&:hover, &:focus': {
+      color: theme('colors.blue.600'),
+      textDecoration: 'underline',
+    },
+    '&:active': {
+      color: theme('colors.orange.600'),
+    },
+  },
+  richText: {
+    fontWeight: theme('fontWeight.normal'),
+    fontSize: theme('fontSize.base'),
+    lineHeight: theme('lineHeight.relaxed'),
+    '> * + *': {
+      marginTop: '1em',
+    },
+    h1: {
+      extends: 'h1',
+    },
+    a: {
+      extends: 'link',
+    },
+    'b, strong': {
+      fontWeight: theme('fontWeight.bold'),
+    },
+    'i, em': {
+      fontStyle: 'italic',
+    },
+  },
+})
+
+module.exports = {
+  theme: {
+    textStyles,
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('tailwindcss-typography')({
+      ellipsis: false,
+      hyphens: false,
+      kerning: false,
+      textUnset: false,
+      componentPrefix: '',
+    }),
+  ],
+}

--- a/__fixtures__/sassyPseudo/config.json
+++ b/__fixtures__/sassyPseudo/config.json
@@ -1,0 +1,3 @@
+{
+  "sassyPseudo": true
+}

--- a/__fixtures__/sassyPseudo/sassyPseudo.js
+++ b/__fixtures__/sassyPseudo/sassyPseudo.js
@@ -1,0 +1,3 @@
+import tw from './macro'
+
+tw`hover:block first:mt-2 last-of-type:max-width[20px]`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1085,11 +1085,8 @@ const addComponentsTestMedia = tw\`xl:btn sm:btn-blue lg:btn-red\`
 const addComponentsTestVariants = tw\`hover:active:btn hocus:before:btn-blue even:visited:btn-red\`
 
 const addComponentsTestMediaQueriesVariants = tw\`fluid-container ml-10\`
-const addComponentsTestElementSelectors = tw\`rich-text\`
 const addComponentsTestElementPrefixes = tw\`prefixes\`
 const addComponentsTestElementScreenReplacements = tw\`screenies\`
-
-const addComponentsResponsiveScoping = tw\`prose sm:prose-sm lg:prose-lg xl:prose-xl\`
 
 tw\`aspect-test-2\`
 tw\`aspect-test-4\`
@@ -1239,54 +1236,6 @@ const addComponentsTestMediaQueriesVariants = {
     backgroundColor: 'red',
   },
 }
-const addComponentsTestElementSelectors = {
-  fontWeight: '400',
-  fontSize: '1rem',
-  lineHeight: '1.625',
-  '> * + *': {
-    marginTop: '1em',
-  },
-  h1: {
-    fontWeight: '700',
-    fontSize: '3rem',
-  },
-  'h1 lineHeight': {
-    lineHeight: '1',
-  },
-  a: {
-    fontWeight: '700',
-    color: '#60a5fa',
-  },
-  'a:hover': {
-    color: '#2563eb',
-    textDecoration: 'underline',
-  },
-  'a:focus': {
-    color: '#2563eb',
-    textDecoration: 'underline',
-  },
-  'a:active': {},
-  b: {
-    fontWeight: '700',
-  },
-  strong: {
-    fontWeight: '700',
-  },
-  i: {
-    fontStyle: 'italic',
-  },
-  em: {
-    fontStyle: 'italic',
-  },
-  '@media (min-width: 640px)': {
-    h1: {
-      fontSize: '3.75rem',
-    },
-    'h1 lineHeight': {
-      lineHeight: '1',
-    },
-  },
-}
 const addComponentsTestElementPrefixes = {
   h1: {
     margin: 'auto',
@@ -1324,868 +1273,6 @@ const addComponentsTestElementScreenReplacements = {
     },
     'h1:focus': {
       color: 'blue',
-    },
-  },
-}
-const addComponentsResponsiveScoping = {
-  color: '#374151',
-  maxWidth: '65ch',
-  fontSize: '1rem',
-  lineHeight: '1.75',
-  '[class~="lead"]': {
-    color: '#4b5563',
-    fontSize: '1.25em',
-    lineHeight: '1.6',
-    marginTop: '1.2em',
-    marginBottom: '1.2em',
-  },
-  a: {
-    color: '#111827',
-    textDecoration: 'underline',
-    fontWeight: '500',
-  },
-  strong: {
-    color: '#111827',
-    fontWeight: '600',
-  },
-  ol: {
-    counterReset: 'list-counter',
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  'ol > li': {
-    position: 'relative',
-    counterIncrement: 'list-counter',
-    paddingLeft: '1.75em',
-  },
-  'ol > li::before': {
-    content: 'counter(list-counter) "."',
-    position: 'absolute',
-    fontWeight: '400',
-    color: '#6b7280',
-    left: '0',
-  },
-  'ul > li': {
-    position: 'relative',
-    paddingLeft: '1.75em',
-  },
-  'ul > li::before': {
-    content: '""',
-    position: 'absolute',
-    backgroundColor: '#d1d5db',
-    borderRadius: '50%',
-    width: '0.375em',
-    height: '0.375em',
-    top: 'calc(0.875em - 0.1875em)',
-    left: '0.25em',
-  },
-  hr: {
-    borderColor: '#e5e7eb',
-    borderTopWidth: '1px',
-    marginTop: '3em',
-    marginBottom: '3em',
-  },
-  blockquote: {
-    fontWeight: '500',
-    fontStyle: 'italic',
-    color: '#111827',
-    borderLeftWidth: '0.25rem',
-    borderLeftColor: '#e5e7eb',
-    quotes: '"\\\\201C""\\\\201D""\\\\2018""\\\\2019"',
-    marginTop: '1.6em',
-    marginBottom: '1.6em',
-    paddingLeft: '1em',
-  },
-  'blockquote p:first-of-type::before': {
-    content: 'open-quote',
-  },
-  'blockquote p:last-of-type::after': {
-    content: 'close-quote',
-  },
-  h1: {
-    color: '#111827',
-    fontWeight: '800',
-    fontSize: '2.25em',
-    marginTop: '0',
-    marginBottom: '0.8888889em',
-    lineHeight: '1.1111111',
-  },
-  h2: {
-    color: '#111827',
-    fontWeight: '700',
-    fontSize: '1.5em',
-    marginTop: '2em',
-    marginBottom: '1em',
-    lineHeight: '1.3333333',
-  },
-  h3: {
-    color: '#111827',
-    fontWeight: '600',
-    fontSize: '1.25em',
-    marginTop: '1.6em',
-    marginBottom: '0.6em',
-    lineHeight: '1.6',
-  },
-  h4: {
-    color: '#111827',
-    fontWeight: '600',
-    marginTop: '1.5em',
-    marginBottom: '0.5em',
-    lineHeight: '1.5',
-  },
-  'figure figcaption': {
-    color: '#6b7280',
-    fontSize: '0.875em',
-    lineHeight: '1.4285714',
-    marginTop: '0.8571429em',
-  },
-  code: {
-    color: '#111827',
-    fontWeight: '600',
-    fontSize: '0.875em',
-  },
-  'code::before': {
-    content: '"\`"',
-  },
-  'code::after': {
-    content: '"\`"',
-  },
-  'a code': {
-    color: '#111827',
-  },
-  pre: {
-    color: '#e5e7eb',
-    backgroundColor: '#1f2937',
-    overflowX: 'auto',
-    fontSize: '0.875em',
-    lineHeight: '1.7142857',
-    marginTop: '1.7142857em',
-    marginBottom: '1.7142857em',
-    borderRadius: '0.375rem',
-    paddingTop: '0.8571429em',
-    paddingRight: '1.1428571em',
-    paddingBottom: '0.8571429em',
-    paddingLeft: '1.1428571em',
-  },
-  'pre code': {
-    backgroundColor: 'transparent',
-    borderWidth: '0',
-    borderRadius: '0',
-    padding: '0',
-    fontWeight: '400',
-    color: 'inherit',
-    fontSize: 'inherit',
-    fontFamily: 'inherit',
-    lineHeight: 'inherit',
-  },
-  'pre code::before': {
-    content: '""',
-  },
-  'pre code::after': {
-    content: '""',
-  },
-  table: {
-    width: '100%',
-    tableLayout: 'auto',
-    textAlign: 'left',
-    marginTop: '2em',
-    marginBottom: '2em',
-    fontSize: '0.875em',
-    lineHeight: '1.7142857',
-  },
-  thead: {
-    color: '#111827',
-    fontWeight: '600',
-    borderBottomWidth: '1px',
-    borderBottomColor: '#d1d5db',
-  },
-  'thead th': {
-    verticalAlign: 'bottom',
-    paddingRight: '0.5714286em',
-    paddingBottom: '0.5714286em',
-    paddingLeft: '0.5714286em',
-  },
-  'tbody tr': {
-    borderBottomWidth: '1px',
-    borderBottomColor: '#e5e7eb',
-  },
-  'tbody tr:last-child': {
-    borderBottomWidth: '0',
-  },
-  'tbody td': {
-    verticalAlign: 'top',
-    paddingTop: '0.5714286em',
-    paddingRight: '0.5714286em',
-    paddingBottom: '0.5714286em',
-    paddingLeft: '0.5714286em',
-  },
-  p: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  img: {
-    marginTop: '2em',
-    marginBottom: '2em',
-  },
-  video: {
-    marginTop: '2em',
-    marginBottom: '2em',
-  },
-  figure: {
-    marginTop: '2em',
-    marginBottom: '2em',
-  },
-  'figure > *': {
-    marginTop: '0',
-    marginBottom: '0',
-  },
-  'h2 code': {
-    fontSize: '0.875em',
-  },
-  'h3 code': {
-    fontSize: '0.9em',
-  },
-  ul: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  li: {
-    marginTop: '0.5em',
-    marginBottom: '0.5em',
-  },
-  '> ul > li p': {
-    marginTop: '0.75em',
-    marginBottom: '0.75em',
-  },
-  '> ul > li > *:first-child': {
-    marginTop: '1.25em',
-  },
-  '> ul > li > *:last-child': {
-    marginBottom: '1.25em',
-  },
-  '> ol > li > *:first-child': {
-    marginTop: '1.25em',
-  },
-  '> ol > li > *:last-child': {
-    marginBottom: '1.25em',
-  },
-  'ul ul': {
-    marginTop: '0.75em',
-    marginBottom: '0.75em',
-  },
-  'ul ol': {
-    marginTop: '0.75em',
-    marginBottom: '0.75em',
-  },
-  'ol ul': {
-    marginTop: '0.75em',
-    marginBottom: '0.75em',
-  },
-  'ol ol': {
-    marginTop: '0.75em',
-    marginBottom: '0.75em',
-  },
-  'hr + *': {
-    marginTop: '0',
-  },
-  'h2 + *': {
-    marginTop: '0',
-  },
-  'h3 + *': {
-    marginTop: '0',
-  },
-  'h4 + *': {
-    marginTop: '0',
-  },
-  'thead th:first-child': {
-    paddingLeft: '0',
-  },
-  'thead th:last-child': {
-    paddingRight: '0',
-  },
-  'tbody td:first-child': {
-    paddingLeft: '0',
-  },
-  'tbody td:last-child': {
-    paddingRight: '0',
-  },
-  '> :first-child': {
-    marginTop: '0',
-  },
-  '> :last-child': {
-    marginBottom: '0',
-  },
-  '@media (min-width: 640px)': {
-    fontSize: '0.875rem',
-    lineHeight: '1.7142857',
-    p: {
-      marginTop: '1.1428571em',
-      marginBottom: '1.1428571em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2857143em',
-      lineHeight: '1.5555556',
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    blockquote: {
-      marginTop: '1.3333333em',
-      marginBottom: '1.3333333em',
-      paddingLeft: '1.1111111em',
-    },
-    h1: {
-      fontSize: '2.1428571em',
-      marginTop: '0',
-      marginBottom: '0.8em',
-      lineHeight: '1.2',
-    },
-    h2: {
-      fontSize: '1.4285714em',
-      marginTop: '1.6em',
-      marginBottom: '0.8em',
-      lineHeight: '1.4',
-    },
-    h3: {
-      fontSize: '1.2857143em',
-      marginTop: '1.5555556em',
-      marginBottom: '0.4444444em',
-      lineHeight: '1.5555556',
-    },
-    h4: {
-      marginTop: '1.4285714em',
-      marginBottom: '0.5714286em',
-      lineHeight: '1.4285714',
-    },
-    img: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    video: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    figure: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.8571429em',
-      lineHeight: '1.3333333',
-      marginTop: '0.6666667em',
-    },
-    code: {
-      fontSize: '0.8571429em',
-    },
-    'h2 code': {
-      fontSize: '0.9em',
-    },
-    'h3 code': {
-      fontSize: '0.8888889em',
-    },
-    pre: {
-      fontSize: '0.8571429em',
-      lineHeight: '1.6666667',
-      marginTop: '1.6666667em',
-      marginBottom: '1.6666667em',
-      borderRadius: '0.25rem',
-      paddingTop: '0.6666667em',
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
-    ol: {
-      marginTop: '1.1428571em',
-      marginBottom: '1.1428571em',
-    },
-    ul: {
-      marginTop: '1.1428571em',
-      marginBottom: '1.1428571em',
-    },
-    li: {
-      marginTop: '0.2857143em',
-      marginBottom: '0.2857143em',
-    },
-    'ol > li': {
-      paddingLeft: '1.5714286em',
-    },
-    'ol > li::before': {
-      left: '0',
-    },
-    'ul > li': {
-      paddingLeft: '1.5714286em',
-    },
-    'ul > li::before': {
-      height: '0.3571429em',
-      width: '0.3571429em',
-      top: 'calc(0.8571429em - 0.1785714em)',
-      left: '0.2142857em',
-    },
-    '> ul > li p': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
-    },
-    '> ul > li > *:first-child': {
-      marginTop: '1.1428571em',
-    },
-    '> ul > li > *:last-child': {
-      marginBottom: '1.1428571em',
-    },
-    '> ol > li > *:first-child': {
-      marginTop: '1.1428571em',
-    },
-    '> ol > li > *:last-child': {
-      marginBottom: '1.1428571em',
-    },
-    'ul ul': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
-    },
-    'ul ol': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
-    },
-    'ol ul': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
-    },
-    'ol ol': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
-    },
-    hr: {
-      marginTop: '2.8571429em',
-      marginBottom: '2.8571429em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.8571429em',
-      lineHeight: '1.5',
-    },
-    'thead th': {
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.6666667em',
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
-    },
-  },
-  '@media (min-width: 1024px)': {
-    fontSize: '1.125rem',
-    lineHeight: '1.7777778',
-    p: {
-      marginTop: '1.3333333em',
-      marginBottom: '1.3333333em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2222222em',
-      lineHeight: '1.4545455',
-      marginTop: '1.0909091em',
-      marginBottom: '1.0909091em',
-    },
-    blockquote: {
-      marginTop: '1.6666667em',
-      marginBottom: '1.6666667em',
-      paddingLeft: '1em',
-    },
-    h1: {
-      fontSize: '2.6666667em',
-      marginTop: '0',
-      marginBottom: '0.8333333em',
-      lineHeight: '1',
-    },
-    h2: {
-      fontSize: '1.6666667em',
-      marginTop: '1.8666667em',
-      marginBottom: '1.0666667em',
-      lineHeight: '1.3333333',
-    },
-    h3: {
-      fontSize: '1.3333333em',
-      marginTop: '1.6666667em',
-      marginBottom: '0.6666667em',
-      lineHeight: '1.5',
-    },
-    h4: {
-      marginTop: '1.7777778em',
-      marginBottom: '0.4444444em',
-      lineHeight: '1.5555556',
-    },
-    img: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    video: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    figure: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.8888889em',
-      lineHeight: '1.5',
-      marginTop: '1em',
-    },
-    code: {
-      fontSize: '0.8888889em',
-    },
-    'h2 code': {
-      fontSize: '0.8666667em',
-    },
-    'h3 code': {
-      fontSize: '0.875em',
-    },
-    pre: {
-      fontSize: '0.8888889em',
-      lineHeight: '1.75',
-      marginTop: '2em',
-      marginBottom: '2em',
-      borderRadius: '0.375rem',
-      paddingTop: '1em',
-      paddingRight: '1.5em',
-      paddingBottom: '1em',
-      paddingLeft: '1.5em',
-    },
-    ol: {
-      marginTop: '1.3333333em',
-      marginBottom: '1.3333333em',
-    },
-    ul: {
-      marginTop: '1.3333333em',
-      marginBottom: '1.3333333em',
-    },
-    li: {
-      marginTop: '0.6666667em',
-      marginBottom: '0.6666667em',
-    },
-    'ol > li': {
-      paddingLeft: '1.6666667em',
-    },
-    'ol > li::before': {
-      left: '0',
-    },
-    'ul > li': {
-      paddingLeft: '1.6666667em',
-    },
-    'ul > li::before': {
-      width: '0.3333333em',
-      height: '0.3333333em',
-      top: 'calc(0.8888889em - 0.1666667em)',
-      left: '0.2222222em',
-    },
-    '> ul > li p': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    '> ul > li > *:first-child': {
-      marginTop: '1.3333333em',
-    },
-    '> ul > li > *:last-child': {
-      marginBottom: '1.3333333em',
-    },
-    '> ol > li > *:first-child': {
-      marginTop: '1.3333333em',
-    },
-    '> ol > li > *:last-child': {
-      marginBottom: '1.3333333em',
-    },
-    'ul ul': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    'ul ol': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    'ol ul': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    'ol ol': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    hr: {
-      marginTop: '3.1111111em',
-      marginBottom: '3.1111111em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.8888889em',
-      lineHeight: '1.5',
-    },
-    'thead th': {
-      paddingRight: '0.75em',
-      paddingBottom: '0.75em',
-      paddingLeft: '0.75em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.75em',
-      paddingRight: '0.75em',
-      paddingBottom: '0.75em',
-      paddingLeft: '0.75em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
-    },
-  },
-  '@media (min-width: 1280px)': {
-    fontSize: '1.25rem',
-    lineHeight: '1.8',
-    p: {
-      marginTop: '1.2em',
-      marginBottom: '1.2em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2em',
-      lineHeight: '1.5',
-      marginTop: '1em',
-      marginBottom: '1em',
-    },
-    blockquote: {
-      marginTop: '1.6em',
-      marginBottom: '1.6em',
-      paddingLeft: '1.0666667em',
-    },
-    h1: {
-      fontSize: '2.8em',
-      marginTop: '0',
-      marginBottom: '0.8571429em',
-      lineHeight: '1',
-    },
-    h2: {
-      fontSize: '1.8em',
-      marginTop: '1.5555556em',
-      marginBottom: '0.8888889em',
-      lineHeight: '1.1111111',
-    },
-    h3: {
-      fontSize: '1.5em',
-      marginTop: '1.6em',
-      marginBottom: '0.6666667em',
-      lineHeight: '1.3333333',
-    },
-    h4: {
-      marginTop: '1.8em',
-      marginBottom: '0.6em',
-      lineHeight: '1.6',
-    },
-    img: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    video: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    figure: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.9em',
-      lineHeight: '1.5555556',
-      marginTop: '1em',
-    },
-    code: {
-      fontSize: '0.9em',
-    },
-    'h2 code': {
-      fontSize: '0.8611111em',
-    },
-    'h3 code': {
-      fontSize: '0.9em',
-    },
-    pre: {
-      fontSize: '0.9em',
-      lineHeight: '1.7777778',
-      marginTop: '2em',
-      marginBottom: '2em',
-      borderRadius: '0.5rem',
-      paddingTop: '1.1111111em',
-      paddingRight: '1.3333333em',
-      paddingBottom: '1.1111111em',
-      paddingLeft: '1.3333333em',
-    },
-    ol: {
-      marginTop: '1.2em',
-      marginBottom: '1.2em',
-    },
-    ul: {
-      marginTop: '1.2em',
-      marginBottom: '1.2em',
-    },
-    li: {
-      marginTop: '0.6em',
-      marginBottom: '0.6em',
-    },
-    'ol > li': {
-      paddingLeft: '1.8em',
-    },
-    'ol > li::before': {
-      left: '0',
-    },
-    'ul > li': {
-      paddingLeft: '1.8em',
-    },
-    'ul > li::before': {
-      width: '0.35em',
-      height: '0.35em',
-      top: 'calc(0.9em - 0.175em)',
-      left: '0.25em',
-    },
-    '> ul > li p': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
-    },
-    '> ul > li > *:first-child': {
-      marginTop: '1.2em',
-    },
-    '> ul > li > *:last-child': {
-      marginBottom: '1.2em',
-    },
-    '> ol > li > *:first-child': {
-      marginTop: '1.2em',
-    },
-    '> ol > li > *:last-child': {
-      marginBottom: '1.2em',
-    },
-    'ul ul': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
-    },
-    'ul ol': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
-    },
-    'ol ul': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
-    },
-    'ol ol': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
-    },
-    hr: {
-      marginTop: '2.8em',
-      marginBottom: '2.8em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.9em',
-      lineHeight: '1.5555556',
-    },
-    'thead th': {
-      paddingRight: '0.6666667em',
-      paddingBottom: '0.8888889em',
-      paddingLeft: '0.6666667em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.8888889em',
-      paddingRight: '0.6666667em',
-      paddingBottom: '0.8888889em',
-      paddingLeft: '0.6666667em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
     },
   },
 }
@@ -13099,6 +12186,934 @@ tw\`z-auto\`
 })
 ;({
   zIndex: 'auto',
+})
+
+
+`;
+
+exports[`twin.macro pluginTypography.js: pluginTypography.js 1`] = `
+
+import tw from './macro'
+
+// From @tailwindcss/typography
+tw\`prose sm:prose-sm lg:prose-lg xl:prose-xl\`
+
+// From tailwindcss-typography
+tw\`rich-text\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// From @tailwindcss/typography
+;({
+  color: '#374151',
+  maxWidth: '65ch',
+  fontSize: '1rem',
+  lineHeight: '1.75',
+  '[class~="lead"]': {
+    color: '#4b5563',
+    fontSize: '1.25em',
+    lineHeight: '1.6',
+    marginTop: '1.2em',
+    marginBottom: '1.2em',
+  },
+  a: {
+    color: '#111827',
+    textDecoration: 'underline',
+    fontWeight: '500',
+  },
+  strong: {
+    color: '#111827',
+    fontWeight: '600',
+  },
+  ol: {
+    counterReset: 'list-counter',
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
+  },
+  'ol > li': {
+    position: 'relative',
+    counterIncrement: 'list-counter',
+    paddingLeft: '1.75em',
+  },
+  'ol > li::before': {
+    content: 'counter(list-counter) "."',
+    position: 'absolute',
+    fontWeight: '400',
+    color: '#6b7280',
+    left: '0',
+  },
+  'ul > li': {
+    position: 'relative',
+    paddingLeft: '1.75em',
+  },
+  'ul > li::before': {
+    content: '""',
+    position: 'absolute',
+    backgroundColor: '#d1d5db',
+    borderRadius: '50%',
+    width: '0.375em',
+    height: '0.375em',
+    top: 'calc(0.875em - 0.1875em)',
+    left: '0.25em',
+  },
+  hr: {
+    borderColor: '#e5e7eb',
+    borderTopWidth: '1px',
+    marginTop: '3em',
+    marginBottom: '3em',
+  },
+  blockquote: {
+    fontWeight: '500',
+    fontStyle: 'italic',
+    color: '#111827',
+    borderLeftWidth: '0.25rem',
+    borderLeftColor: '#e5e7eb',
+    quotes: '"\\\\201C""\\\\201D""\\\\2018""\\\\2019"',
+    marginTop: '1.6em',
+    marginBottom: '1.6em',
+    paddingLeft: '1em',
+  },
+  'blockquote p:first-of-type::before': {
+    content: 'open-quote',
+  },
+  'blockquote p:last-of-type::after': {
+    content: 'close-quote',
+  },
+  h1: {
+    color: '#111827',
+    fontWeight: '800',
+    fontSize: '2.25em',
+    marginTop: '0',
+    marginBottom: '0.8888889em',
+    lineHeight: '1.1111111',
+  },
+  h2: {
+    color: '#111827',
+    fontWeight: '700',
+    fontSize: '1.5em',
+    marginTop: '2em',
+    marginBottom: '1em',
+    lineHeight: '1.3333333',
+  },
+  h3: {
+    color: '#111827',
+    fontWeight: '600',
+    fontSize: '1.25em',
+    marginTop: '1.6em',
+    marginBottom: '0.6em',
+    lineHeight: '1.6',
+  },
+  h4: {
+    color: '#111827',
+    fontWeight: '600',
+    marginTop: '1.5em',
+    marginBottom: '0.5em',
+    lineHeight: '1.5',
+  },
+  'figure figcaption': {
+    color: '#6b7280',
+    fontSize: '0.875em',
+    lineHeight: '1.4285714',
+    marginTop: '0.8571429em',
+  },
+  code: {
+    color: '#111827',
+    fontWeight: '600',
+    fontSize: '0.875em',
+  },
+  'code::before': {
+    content: '"\`"',
+  },
+  'code::after': {
+    content: '"\`"',
+  },
+  'a code': {
+    color: '#111827',
+  },
+  pre: {
+    color: '#e5e7eb',
+    backgroundColor: '#1f2937',
+    overflowX: 'auto',
+    fontSize: '0.875em',
+    lineHeight: '1.7142857',
+    marginTop: '1.7142857em',
+    marginBottom: '1.7142857em',
+    borderRadius: '0.375rem',
+    paddingTop: '0.8571429em',
+    paddingRight: '1.1428571em',
+    paddingBottom: '0.8571429em',
+    paddingLeft: '1.1428571em',
+  },
+  'pre code': {
+    backgroundColor: 'transparent',
+    borderWidth: '0',
+    borderRadius: '0',
+    padding: '0',
+    fontWeight: '400',
+    color: 'inherit',
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    lineHeight: 'inherit',
+  },
+  'pre code::before': {
+    content: '""',
+  },
+  'pre code::after': {
+    content: '""',
+  },
+  table: {
+    width: '100%',
+    tableLayout: 'auto',
+    textAlign: 'left',
+    marginTop: '2em',
+    marginBottom: '2em',
+    fontSize: '0.875em',
+    lineHeight: '1.7142857',
+  },
+  thead: {
+    color: '#111827',
+    fontWeight: '600',
+    borderBottomWidth: '1px',
+    borderBottomColor: '#d1d5db',
+  },
+  'thead th': {
+    verticalAlign: 'bottom',
+    paddingRight: '0.5714286em',
+    paddingBottom: '0.5714286em',
+    paddingLeft: '0.5714286em',
+  },
+  'tbody tr': {
+    borderBottomWidth: '1px',
+    borderBottomColor: '#e5e7eb',
+  },
+  'tbody tr:last-child': {
+    borderBottomWidth: '0',
+  },
+  'tbody td': {
+    verticalAlign: 'top',
+    paddingTop: '0.5714286em',
+    paddingRight: '0.5714286em',
+    paddingBottom: '0.5714286em',
+    paddingLeft: '0.5714286em',
+  },
+  p: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
+  },
+  img: {
+    marginTop: '2em',
+    marginBottom: '2em',
+  },
+  video: {
+    marginTop: '2em',
+    marginBottom: '2em',
+  },
+  figure: {
+    marginTop: '2em',
+    marginBottom: '2em',
+  },
+  'figure > *': {
+    marginTop: '0',
+    marginBottom: '0',
+  },
+  'h2 code': {
+    fontSize: '0.875em',
+  },
+  'h3 code': {
+    fontSize: '0.9em',
+  },
+  ul: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
+  },
+  li: {
+    marginTop: '0.5em',
+    marginBottom: '0.5em',
+  },
+  '> ul > li p': {
+    marginTop: '0.75em',
+    marginBottom: '0.75em',
+  },
+  '> ul > li > *:first-child': {
+    marginTop: '1.25em',
+  },
+  '> ul > li > *:last-child': {
+    marginBottom: '1.25em',
+  },
+  '> ol > li > *:first-child': {
+    marginTop: '1.25em',
+  },
+  '> ol > li > *:last-child': {
+    marginBottom: '1.25em',
+  },
+  'ul ul': {
+    marginTop: '0.75em',
+    marginBottom: '0.75em',
+  },
+  'ul ol': {
+    marginTop: '0.75em',
+    marginBottom: '0.75em',
+  },
+  'ol ul': {
+    marginTop: '0.75em',
+    marginBottom: '0.75em',
+  },
+  'ol ol': {
+    marginTop: '0.75em',
+    marginBottom: '0.75em',
+  },
+  'hr + *': {
+    marginTop: '0',
+  },
+  'h2 + *': {
+    marginTop: '0',
+  },
+  'h3 + *': {
+    marginTop: '0',
+  },
+  'h4 + *': {
+    marginTop: '0',
+  },
+  'thead th:first-child': {
+    paddingLeft: '0',
+  },
+  'thead th:last-child': {
+    paddingRight: '0',
+  },
+  'tbody td:first-child': {
+    paddingLeft: '0',
+  },
+  'tbody td:last-child': {
+    paddingRight: '0',
+  },
+  '> :first-child': {
+    marginTop: '0',
+  },
+  '> :last-child': {
+    marginBottom: '0',
+  },
+  '@media (min-width: 640px)': {
+    fontSize: '0.875rem',
+    lineHeight: '1.7142857',
+    p: {
+      marginTop: '1.1428571em',
+      marginBottom: '1.1428571em',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2857143em',
+      lineHeight: '1.5555556',
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    blockquote: {
+      marginTop: '1.3333333em',
+      marginBottom: '1.3333333em',
+      paddingLeft: '1.1111111em',
+    },
+    h1: {
+      fontSize: '2.1428571em',
+      marginTop: '0',
+      marginBottom: '0.8em',
+      lineHeight: '1.2',
+    },
+    h2: {
+      fontSize: '1.4285714em',
+      marginTop: '1.6em',
+      marginBottom: '0.8em',
+      lineHeight: '1.4',
+    },
+    h3: {
+      fontSize: '1.2857143em',
+      marginTop: '1.5555556em',
+      marginBottom: '0.4444444em',
+      lineHeight: '1.5555556',
+    },
+    h4: {
+      marginTop: '1.4285714em',
+      marginBottom: '0.5714286em',
+      lineHeight: '1.4285714',
+    },
+    img: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    video: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    figure: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    'figure figcaption': {
+      fontSize: '0.8571429em',
+      lineHeight: '1.3333333',
+      marginTop: '0.6666667em',
+    },
+    code: {
+      fontSize: '0.8571429em',
+    },
+    'h2 code': {
+      fontSize: '0.9em',
+    },
+    'h3 code': {
+      fontSize: '0.8888889em',
+    },
+    pre: {
+      fontSize: '0.8571429em',
+      lineHeight: '1.6666667',
+      marginTop: '1.6666667em',
+      marginBottom: '1.6666667em',
+      borderRadius: '0.25rem',
+      paddingTop: '0.6666667em',
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    ol: {
+      marginTop: '1.1428571em',
+      marginBottom: '1.1428571em',
+    },
+    ul: {
+      marginTop: '1.1428571em',
+      marginBottom: '1.1428571em',
+    },
+    li: {
+      marginTop: '0.2857143em',
+      marginBottom: '0.2857143em',
+    },
+    'ol > li': {
+      paddingLeft: '1.5714286em',
+    },
+    'ol > li::before': {
+      left: '0',
+    },
+    'ul > li': {
+      paddingLeft: '1.5714286em',
+    },
+    'ul > li::before': {
+      height: '0.3571429em',
+      width: '0.3571429em',
+      top: 'calc(0.8571429em - 0.1785714em)',
+      left: '0.2142857em',
+    },
+    '> ul > li p': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.1428571em',
+    },
+    '> ul > li > *:last-child': {
+      marginBottom: '1.1428571em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.1428571em',
+    },
+    '> ol > li > *:last-child': {
+      marginBottom: '1.1428571em',
+    },
+    'ul ul': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    'ul ol': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    'ol ul': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    'ol ol': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    hr: {
+      marginTop: '2.8571429em',
+      marginBottom: '2.8571429em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    table: {
+      fontSize: '0.8571429em',
+      lineHeight: '1.5',
+    },
+    'thead th': {
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td': {
+      paddingTop: '0.6666667em',
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+  },
+  '@media (min-width: 1024px)': {
+    fontSize: '1.125rem',
+    lineHeight: '1.7777778',
+    p: {
+      marginTop: '1.3333333em',
+      marginBottom: '1.3333333em',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2222222em',
+      lineHeight: '1.4545455',
+      marginTop: '1.0909091em',
+      marginBottom: '1.0909091em',
+    },
+    blockquote: {
+      marginTop: '1.6666667em',
+      marginBottom: '1.6666667em',
+      paddingLeft: '1em',
+    },
+    h1: {
+      fontSize: '2.6666667em',
+      marginTop: '0',
+      marginBottom: '0.8333333em',
+      lineHeight: '1',
+    },
+    h2: {
+      fontSize: '1.6666667em',
+      marginTop: '1.8666667em',
+      marginBottom: '1.0666667em',
+      lineHeight: '1.3333333',
+    },
+    h3: {
+      fontSize: '1.3333333em',
+      marginTop: '1.6666667em',
+      marginBottom: '0.6666667em',
+      lineHeight: '1.5',
+    },
+    h4: {
+      marginTop: '1.7777778em',
+      marginBottom: '0.4444444em',
+      lineHeight: '1.5555556',
+    },
+    img: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    video: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    figure: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    'figure figcaption': {
+      fontSize: '0.8888889em',
+      lineHeight: '1.5',
+      marginTop: '1em',
+    },
+    code: {
+      fontSize: '0.8888889em',
+    },
+    'h2 code': {
+      fontSize: '0.8666667em',
+    },
+    'h3 code': {
+      fontSize: '0.875em',
+    },
+    pre: {
+      fontSize: '0.8888889em',
+      lineHeight: '1.75',
+      marginTop: '2em',
+      marginBottom: '2em',
+      borderRadius: '0.375rem',
+      paddingTop: '1em',
+      paddingRight: '1.5em',
+      paddingBottom: '1em',
+      paddingLeft: '1.5em',
+    },
+    ol: {
+      marginTop: '1.3333333em',
+      marginBottom: '1.3333333em',
+    },
+    ul: {
+      marginTop: '1.3333333em',
+      marginBottom: '1.3333333em',
+    },
+    li: {
+      marginTop: '0.6666667em',
+      marginBottom: '0.6666667em',
+    },
+    'ol > li': {
+      paddingLeft: '1.6666667em',
+    },
+    'ol > li::before': {
+      left: '0',
+    },
+    'ul > li': {
+      paddingLeft: '1.6666667em',
+    },
+    'ul > li::before': {
+      width: '0.3333333em',
+      height: '0.3333333em',
+      top: 'calc(0.8888889em - 0.1666667em)',
+      left: '0.2222222em',
+    },
+    '> ul > li p': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.3333333em',
+    },
+    '> ul > li > *:last-child': {
+      marginBottom: '1.3333333em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.3333333em',
+    },
+    '> ol > li > *:last-child': {
+      marginBottom: '1.3333333em',
+    },
+    'ul ul': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    'ul ol': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    'ol ul': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    'ol ol': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    hr: {
+      marginTop: '3.1111111em',
+      marginBottom: '3.1111111em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    table: {
+      fontSize: '0.8888889em',
+      lineHeight: '1.5',
+    },
+    'thead th': {
+      paddingRight: '0.75em',
+      paddingBottom: '0.75em',
+      paddingLeft: '0.75em',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td': {
+      paddingTop: '0.75em',
+      paddingRight: '0.75em',
+      paddingBottom: '0.75em',
+      paddingLeft: '0.75em',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+  },
+  '@media (min-width: 1280px)': {
+    fontSize: '1.25rem',
+    lineHeight: '1.8',
+    p: {
+      marginTop: '1.2em',
+      marginBottom: '1.2em',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2em',
+      lineHeight: '1.5',
+      marginTop: '1em',
+      marginBottom: '1em',
+    },
+    blockquote: {
+      marginTop: '1.6em',
+      marginBottom: '1.6em',
+      paddingLeft: '1.0666667em',
+    },
+    h1: {
+      fontSize: '2.8em',
+      marginTop: '0',
+      marginBottom: '0.8571429em',
+      lineHeight: '1',
+    },
+    h2: {
+      fontSize: '1.8em',
+      marginTop: '1.5555556em',
+      marginBottom: '0.8888889em',
+      lineHeight: '1.1111111',
+    },
+    h3: {
+      fontSize: '1.5em',
+      marginTop: '1.6em',
+      marginBottom: '0.6666667em',
+      lineHeight: '1.3333333',
+    },
+    h4: {
+      marginTop: '1.8em',
+      marginBottom: '0.6em',
+      lineHeight: '1.6',
+    },
+    img: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    video: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    figure: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    'figure figcaption': {
+      fontSize: '0.9em',
+      lineHeight: '1.5555556',
+      marginTop: '1em',
+    },
+    code: {
+      fontSize: '0.9em',
+    },
+    'h2 code': {
+      fontSize: '0.8611111em',
+    },
+    'h3 code': {
+      fontSize: '0.9em',
+    },
+    pre: {
+      fontSize: '0.9em',
+      lineHeight: '1.7777778',
+      marginTop: '2em',
+      marginBottom: '2em',
+      borderRadius: '0.5rem',
+      paddingTop: '1.1111111em',
+      paddingRight: '1.3333333em',
+      paddingBottom: '1.1111111em',
+      paddingLeft: '1.3333333em',
+    },
+    ol: {
+      marginTop: '1.2em',
+      marginBottom: '1.2em',
+    },
+    ul: {
+      marginTop: '1.2em',
+      marginBottom: '1.2em',
+    },
+    li: {
+      marginTop: '0.6em',
+      marginBottom: '0.6em',
+    },
+    'ol > li': {
+      paddingLeft: '1.8em',
+    },
+    'ol > li::before': {
+      left: '0',
+    },
+    'ul > li': {
+      paddingLeft: '1.8em',
+    },
+    'ul > li::before': {
+      width: '0.35em',
+      height: '0.35em',
+      top: 'calc(0.9em - 0.175em)',
+      left: '0.25em',
+    },
+    '> ul > li p': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.2em',
+    },
+    '> ul > li > *:last-child': {
+      marginBottom: '1.2em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.2em',
+    },
+    '> ol > li > *:last-child': {
+      marginBottom: '1.2em',
+    },
+    'ul ul': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    'ul ol': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    'ol ul': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    'ol ol': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    hr: {
+      marginTop: '2.8em',
+      marginBottom: '2.8em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    table: {
+      fontSize: '0.9em',
+      lineHeight: '1.5555556',
+    },
+    'thead th': {
+      paddingRight: '0.6666667em',
+      paddingBottom: '0.8888889em',
+      paddingLeft: '0.6666667em',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td': {
+      paddingTop: '0.8888889em',
+      paddingRight: '0.6666667em',
+      paddingBottom: '0.8888889em',
+      paddingLeft: '0.6666667em',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+  },
+}) // From tailwindcss-typography
+
+;({
+  fontWeight: '400',
+  fontSize: '1rem',
+  lineHeight: '1.625',
+  '> * + *': {
+    marginTop: '1em',
+  },
+  h1: {
+    fontWeight: '700',
+    fontSize: '3rem',
+  },
+  'h1 lineHeight': {
+    lineHeight: '1',
+  },
+  a: {
+    fontWeight: '700',
+    color: '#60a5fa',
+  },
+  'a:hover': {
+    color: '#2563eb',
+    textDecoration: 'underline',
+  },
+  'a:focus': {
+    color: '#2563eb',
+    textDecoration: 'underline',
+  },
+  'a:active': {},
+  b: {
+    fontWeight: '700',
+  },
+  strong: {
+    fontWeight: '700',
+  },
+  i: {
+    fontStyle: 'italic',
+  },
+  em: {
+    fontStyle: 'italic',
+  },
+  '@media (min-width: 640px)': {
+    h1: {
+      fontSize: '3.75rem',
+    },
+    'h1 lineHeight': {
+      lineHeight: '1',
+    },
+  },
 })
 
 

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1080,7 +1080,7 @@ const addUtilitiesTest2Media = tw\`sm:skew-15deg lg:type-sm\`
 const addUtilitiesTest2Variants = tw\`hover:active:skew-15deg even:visited:skew-15deg\`
 
 const addComponentsTest = tw\`btn btn-blue btn-red\`
-// const addComponentsTestImportant = tw\`btn! btn-blue!\` // Issue showing sub selectors and important
+// const addComponentsTestImportant = tw\`btn! btn-blue!\` // TODO: Issue showing sub selectors and important
 const addComponentsTestMedia = tw\`xl:btn sm:btn-blue lg:btn-red\`
 const addComponentsTestVariants = tw\`hover:active:btn hocus:before:btn-blue even:visited:btn-red\`
 
@@ -1157,7 +1157,7 @@ const addComponentsTest = {
   ':hover': {
     backgroundColor: '#cc1f1a',
   },
-} // const addComponentsTestImportant = tw\`btn! btn-blue!\` // Issue showing sub selectors and important
+} // const addComponentsTestImportant = tw\`btn! btn-blue!\` // TODO: Issue showing sub selectors and important
 
 const addComponentsTestMedia = {
   '@media (min-width: 640px)': {
@@ -13140,6 +13140,29 @@ tw\`text-hamburger\`
 ;({
   '--tw-text-opacity': '1',
   color: 'rgba(165, 42, 42, var(--tw-text-opacity))',
+})
+
+
+`;
+
+exports[`twin.macro sassyPseudo.js: sassyPseudo.js 1`] = `
+
+import tw from './macro'
+
+tw\`hover:block first:mt-2 last-of-type:max-width[20px]\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  '&:hover': {
+    display: 'block',
+  },
+  '&:first-child': {
+    marginTop: '0.5rem',
+  },
+  '&:last-of-type': {
+    maxWidth: '20px',
+  },
 })
 
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -15,7 +15,7 @@ const spaced = string => `\n\n${string}\n`
 const warning = string => color.error(`✕ ${string}`)
 
 const inOutPlugins = (input, output) =>
-  `${color.highlight2('→')} ${input} ${color.highlight2(
+  `${color.highlight2('→')} ${input.replace(/\\/g, '')} ${color.highlight2(
     JSON.stringify(output)
   )}`
 

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -68,7 +68,7 @@ const normalizeDynamicConfig = ({ config, input, dynamicKey, hasNegative }) =>
         (result, transformer) => transformer({ dynamicKey, target: result }),
         target
       ),
-      value: `${value}`,
+      value: JSON.stringify(value), // Make sure objects are flattened and viewable
     }))
     .filter(
       item =>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,69 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Used for tests (see '/__fixtures__/-plugins.js')
 
-const textStyles = theme => ({
-  heading: {
-    output: false,
-    fontWeight: theme('fontWeight.bold'),
-    lineHeight: theme('lineHeight.tight'),
-  },
-  h1: {
-    extends: 'heading',
-    fontSize: theme('fontSize.5xl'),
-    '@screen sm': {
-      fontSize: theme('fontSize.6xl'),
-    },
-  },
-  h2: {
-    extends: 'heading',
-    fontSize: theme('fontSize.4xl'),
-    '@screen sm': {
-      fontSize: theme('fontSize.5xl'),
-      lineHeight: '50px',
-    },
-  },
-  '@screen sm': {
-    h3: {
-      extends: 'heading',
-      fontSize: theme('fontSize.4xl'),
-    },
-    ':hover': {
-      color: theme('colors.blue.300'),
-    },
-  },
-  link: {
-    fontWeight: theme('fontWeight.bold'),
-    color: theme('colors.blue.400'),
-    '&:hover, &:focus': {
-      color: theme('colors.blue.600'),
-      textDecoration: 'underline',
-    },
-    '&:active': {
-      color: theme('colors.orange.600'),
-    },
-  },
-  richText: {
-    fontWeight: theme('fontWeight.normal'),
-    fontSize: theme('fontSize.base'),
-    lineHeight: theme('lineHeight.relaxed'),
-    '> * + *': {
-      marginTop: '1em',
-    },
-    h1: {
-      extends: 'h1',
-    },
-    a: {
-      extends: 'link',
-    },
-    'b, strong': {
-      fontWeight: theme('fontWeight.bold'),
-    },
-    'i, em': {
-      fontStyle: 'italic',
-    },
-  },
-})
-
 module.exports = {
   darkMode: 'media',
   theme: {
@@ -89,7 +26,6 @@ module.exports = {
       small: '25%',
       large: '75%',
     },
-    textStyles,
     aspectRatio: {
       2: '2',
       4: '4',
@@ -155,14 +91,6 @@ module.exports = {
     addComponentsTestElementScreenReplacements,
     addComponentsTestCssVariableAsRuleProperty,
     require('@tailwindcss/forms'),
-    require('@tailwindcss/typography'),
-    require('tailwindcss-typography')({
-      ellipsis: false,
-      hyphens: false,
-      kerning: false,
-      textUnset: false,
-      componentPrefix: '',
-    }),
     pluginBaseSelectors,
     baseSelectorTest,
   ],


### PR DESCRIPTION
This PR mostly adds better support for user-defined tailwind plugins:

- User plugins now allow class names with dots in them eg: `flex-gap-y-1.5`
- Support for more selector types in user plugins
- Beefed up the `addUtilities` function support
- Fixed pluginDebug display for escaped classes
- Fixed suggestion display for escaped classes + values that contain objects