### PR TITLE
Plugin parent selectors

### DIFF
--- a/__fixtures__/globalStyles/config.json
+++ b/__fixtures__/globalStyles/config.json
@@ -1,4 +1,3 @@
 {
-  "config": "__fixtures__/globalStyles/tailwind.config.js",
   "preset": "emotion"
 }

--- a/__fixtures__/pluginGapFallback/config.json
+++ b/__fixtures__/pluginGapFallback/config.json
@@ -1,3 +1,0 @@
-{
-  "config": "__fixtures__/pluginGapFallback/tailwind.config.js"
-}

--- a/__fixtures__/pluginGapFallback/pluginGapFallback.js
+++ b/__fixtures__/pluginGapFallback/pluginGapFallback.js
@@ -6,3 +6,13 @@ tw`flex-gap-x-3`
 tw`flex-gap-y-3`
 tw`flex-gap-px`
 tw`flex-gap-x-1.5`
+
+tw`gap-0`
+tw`gap-3`
+tw`gap-x-3`
+tw`gap-y-3`
+tw`gap-px`
+tw`gap-x-1.5`
+
+tw`test-1`
+tw`test-2`

--- a/__fixtures__/pluginGapFallback/tailwind.config.js
+++ b/__fixtures__/pluginGapFallback/tailwind.config.js
@@ -1,8 +1,6 @@
 const plugin = require('tailwindcss/plugin')
 
-function half(value) {
-  return value.replace(/\d+(.\d+)?/, number => number / 2)
-}
+const half = value => value.replace(/\d+(.\d+)?/, number => number / 2)
 
 // Basic plugin that creates new gap classes
 const gapReplacementPlugin = plugin(({ addUtilities, e, theme }) => {

--- a/__fixtures__/pluginGapFallback/tailwind.config.js
+++ b/__fixtures__/pluginGapFallback/tailwind.config.js
@@ -4,38 +4,95 @@ function half(value) {
   return value.replace(/\d+(.\d+)?/, number => number / 2)
 }
 
+// Basic plugin that creates new gap classes
+const gapReplacementPlugin = plugin(({ addUtilities, e, theme }) => {
+  Object.entries(theme('gap')).forEach(([key, value]) =>
+    addUtilities({
+      [`.flex-gap-${e(key)}`]: {
+        margin: `-${half(value)}`,
+        '& > *': {
+          margin: half(value),
+        },
+      },
+      [`.flex-gap-x-${e(key)}`]: {
+        marginRight: `-${half(value)}`,
+        marginLeft: `-${half(value)}`,
+        '& > *': {
+          marginRight: half(value),
+          marginLeft: half(value),
+        },
+      },
+      [`.flex-gap-y-${e(key)}`]: {
+        marginTop: `-${half(value)}`,
+        marginBottom: `-${half(value)}`,
+        '& > *': {
+          marginTop: half(value),
+          marginBottom: half(value),
+        },
+      },
+    })
+  )
+})
+
+// Alternative gap plugin that uses a parent class that's dynamically added
+const gapSupportPlugin = plugin(({ addUtilities, e, theme }) => {
+  Object.entries(theme('gap')).forEach(([key, value]) =>
+    addUtilities({
+      [`.gap-${e(key)}`]: {
+        '.no-flex-gap &': {
+          margin: `-${half(value)}`,
+        },
+        '.no-flex-gap & > *': {
+          margin: half(value),
+        },
+      },
+      [`.gap-x-${e(key)}`]: {
+        '.no-flex-gap &': {
+          marginRight: `-${half(value)}`,
+          marginLeft: `-${half(value)}`,
+        },
+        '.no-flex-gap & > *': {
+          marginRight: half(value),
+          marginLeft: half(value),
+        },
+      },
+      [`.gap-y-${e(key)}`]: {
+        '.no-flex-gap &': {
+          marginTop: `-${half(value)}`,
+          marginBottom: `-${half(value)}`,
+        },
+        '.no-flex-gap & > *': {
+          marginTop: half(value),
+          marginBottom: half(value),
+        },
+      },
+    })
+  )
+})
+
+// Test a couple extra things
+const testPlugin = plugin(({ addUtilities, e, theme }) => {
+  addUtilities({
+    [`.test-1`]: {
+      background: '5px',
+      '.a-class & .some-class': {
+        margin: '10px',
+      },
+      '.a-class & > *': {
+        margin: '20px',
+      },
+    },
+    [`.test-2`]: {
+      '.a-class & .some-class': {
+        margin: '10px',
+      },
+      '.a-class & > *': {
+        margin: '20px',
+      },
+    },
+  })
+})
+
 module.exports = {
-  plugins: [
-    plugin(({ addUtilities, e, theme, variants }) => {
-      Object.entries(theme('gap')).forEach(([key, value]) =>
-        addUtilities(
-          {
-            [`.flex-gap-${e(key)}`]: {
-              margin: `-${half(value)}`,
-              '& > *': {
-                margin: half(value),
-              },
-            },
-            [`.flex-gap-x-${e(key)}`]: {
-              marginRight: `-${half(value)}`,
-              marginLeft: `-${half(value)}`,
-              '& > *': {
-                marginRight: half(value),
-                marginLeft: half(value),
-              },
-            },
-            [`.flex-gap-y-${e(key)}`]: {
-              marginTop: `-${half(value)}`,
-              marginBottom: `-${half(value)}`,
-              '& > *': {
-                marginTop: half(value),
-                marginBottom: half(value),
-              },
-            },
-          },
-          variants('gap')
-        )
-      )
-    }),
-  ],
+  plugins: [gapReplacementPlugin, gapSupportPlugin, testPlugin],
 }

--- a/__fixtures__/pluginTypography/config.json
+++ b/__fixtures__/pluginTypography/config.json
@@ -1,3 +1,0 @@
-{
-  "config": "__fixtures__/pluginTypography/tailwind.config.js"
-}

--- a/__fixtures__/pluginUserParentSelector/pluginUserParentSelector.js
+++ b/__fixtures__/pluginUserParentSelector/pluginUserParentSelector.js
@@ -1,7 +1,8 @@
 import tw from './macro'
 
-tw`hover:block first:mt-2 last-of-type:max-width[20px]`
-
 tw`my-class1`
 tw`my-class2`
 tw`my-class3`
+tw`my-class4`
+tw`my-class5`
+tw`my-class6`

--- a/__fixtures__/pluginUserParentSelector/tailwind.config.js
+++ b/__fixtures__/pluginUserParentSelector/tailwind.config.js
@@ -1,0 +1,45 @@
+const plugin = require('tailwindcss/plugin')
+
+module.exports = {
+  plugins: [
+    plugin(({ addComponents }) =>
+      addComponents({
+        '.my-class1': {
+          backgroundColor: 'black',
+          h2: {
+            backgroundColor: 'red',
+          },
+        },
+        '.my-class2': {
+          backgroundColor: 'green',
+          'h2 &': {
+            backgroundColor: 'yellow',
+          },
+        },
+        '.my-class3': {
+          backgroundColor: 'green',
+          '.dark &:hover': {
+            backgroundColor: 'yellow',
+          },
+        },
+        '.my-class4': {
+          '.test & :hover': {
+            backgroundColor: 'orange',
+          },
+        },
+        '.my-class5': {
+          backgroundColor: 'brown',
+          '&:hover': {
+            backgroundColor: 'pink',
+          },
+        },
+        '.my-class6': {
+          backgroundColor: 'blue',
+          ':hover': {
+            backgroundColor: 'orange',
+          },
+        },
+      })
+    ),
+  ],
+}

--- a/__fixtures__/sassyPseudo/tailwind.config.js
+++ b/__fixtures__/sassyPseudo/tailwind.config.js
@@ -1,0 +1,25 @@
+const plugin = require('tailwindcss/plugin')
+
+module.exports = {
+  plugins: [
+    plugin(({ addComponents }) =>
+      addComponents({
+        '.my-class1': {
+          '&:hover': {
+            backgroundColor: 'pink',
+          },
+        },
+        '.my-class2': {
+          ':hover': {
+            backgroundColor: 'orange',
+          },
+        },
+        '.my-class3': {
+          '.test & :hover': {
+            backgroundColor: 'orange',
+          },
+        },
+      })
+    ),
+  ],
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12312,6 +12312,16 @@ tw\`flex-gap-y-3\`
 tw\`flex-gap-px\`
 tw\`flex-gap-x-1.5\`
 
+tw\`gap-0\`
+tw\`gap-3\`
+tw\`gap-x-3\`
+tw\`gap-y-3\`
+tw\`gap-px\`
+tw\`gap-x-1.5\`
+
+tw\`test-1\`
+tw\`test-2\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 ;({
@@ -12356,6 +12366,77 @@ tw\`flex-gap-x-1.5\`
     marginLeft: '0.1875rem',
   },
 })
+;({
+  '.no-flex-gap &': {
+    margin: '-0px',
+  },
+  '.no-flex-gap &> *': {
+    margin: '0px',
+  },
+})
+;({
+  '.no-flex-gap &': {
+    margin: '-0.375rem',
+  },
+  '.no-flex-gap &> *': {
+    margin: '0.375rem',
+  },
+})
+;({
+  '.no-flex-gap &': {
+    marginRight: '-0.375rem',
+    marginLeft: '-0.375rem',
+  },
+  '.no-flex-gap &> *': {
+    marginRight: '0.375rem',
+    marginLeft: '0.375rem',
+  },
+})
+;({
+  '.no-flex-gap &': {
+    marginTop: '-0.375rem',
+    marginBottom: '-0.375rem',
+  },
+  '.no-flex-gap &> *': {
+    marginTop: '0.375rem',
+    marginBottom: '0.375rem',
+  },
+})
+;({
+  '.no-flex-gap &': {
+    margin: '-0.5px',
+  },
+  '.no-flex-gap & > *': {
+    margin: '0.5px',
+  },
+})
+;({
+  '.no-flex-gap &': {
+    marginRight: '-0.1875rem',
+    marginLeft: '-0.1875rem',
+  },
+  '.no-flex-gap & > *': {
+    marginRight: '0.1875rem',
+    marginLeft: '0.1875rem',
+  },
+})
+;({
+  background: '5px',
+  '.a-class & .some-class': {
+    margin: '10px',
+  },
+  '.a-class & > *': {
+    margin: '20px',
+  },
+})
+;({
+  '.a-class & .some-class': {
+    margin: '10px',
+  },
+  '.a-class & > *': {
+    margin: '20px',
+  },
+})
 
 
 `;
@@ -12376,6 +12457,8 @@ tw\`rich-text\`
 ;({
   color: '#374151',
   maxWidth: '65ch',
+  fontSize: '1rem',
+  lineHeight: '1.75',
   '[class~="lead"]': {
     color: '#4b5563',
     fontSize: '1.25em',
@@ -12584,8 +12667,6 @@ tw\`rich-text\`
     paddingBottom: '0.5714286em',
     paddingLeft: '0.5714286em',
   },
-  fontSize: '1rem',
-  lineHeight: '1.75',
   p: {
     marginTop: '1.25em',
     marginBottom: '1.25em',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12376,8 +12376,6 @@ tw\`rich-text\`
 ;({
   color: '#374151',
   maxWidth: '65ch',
-  fontSize: '1rem',
-  lineHeight: '1.75',
   '[class~="lead"]': {
     color: '#4b5563',
     fontSize: '1.25em',
@@ -12394,18 +12392,39 @@ tw\`rich-text\`
     color: '#111827',
     fontWeight: '600',
   },
-  ol: {
-    counterReset: 'list-counter',
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
+  'ol[type="A"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="A s"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a s"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="I"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  'ol[type="I s"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i s"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  'ol[type="1"]': {
+    '--list-counter-style': 'decimal',
   },
   'ol > li': {
     position: 'relative',
-    counterIncrement: 'list-counter',
     paddingLeft: '1.75em',
   },
   'ol > li::before': {
-    content: 'counter(list-counter) "."',
+    content: 'counter(list-item, var(--list-counter-style, decimal)) "."',
     position: 'absolute',
     fontWeight: '400',
     color: '#6b7280',
@@ -12525,10 +12544,10 @@ tw\`rich-text\`
     lineHeight: 'inherit',
   },
   'pre code::before': {
-    content: '""',
+    content: 'none',
   },
   'pre code::after': {
-    content: '""',
+    content: 'none',
   },
   table: {
     width: '100%',
@@ -12565,6 +12584,8 @@ tw\`rich-text\`
     paddingBottom: '0.5714286em',
     paddingLeft: '0.5714286em',
   },
+  fontSize: '1rem',
+  lineHeight: '1.75',
   p: {
     marginTop: '1.25em',
     marginBottom: '1.25em',
@@ -12590,6 +12611,10 @@ tw\`rich-text\`
   },
   'h3 code': {
     fontSize: '0.9em',
+  },
+  ol: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
   ul: {
     marginTop: '1.25em',
@@ -13288,6 +13313,58 @@ tw\`rich-text\`
 
 `;
 
+exports[`twin.macro pluginUserParentSelector.js: pluginUserParentSelector.js 1`] = `
+
+import tw from './macro'
+
+tw\`my-class1\`
+tw\`my-class2\`
+tw\`my-class3\`
+tw\`my-class4\`
+tw\`my-class5\`
+tw\`my-class6\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  backgroundColor: 'black',
+  h2: {
+    backgroundColor: 'red',
+  },
+})
+;({
+  backgroundColor: 'green',
+  'h2 &': {
+    backgroundColor: 'yellow',
+  },
+})
+;({
+  backgroundColor: 'green',
+  '.dark &:hover': {
+    backgroundColor: 'yellow',
+  },
+})
+;({
+  '.test & :hover': {
+    backgroundColor: 'orange',
+  },
+})
+;({
+  backgroundColor: 'brown',
+  ':hover': {
+    backgroundColor: 'pink',
+  },
+})
+;({
+  backgroundColor: 'blue',
+  ':hover': {
+    backgroundColor: 'orange',
+  },
+})
+
+
+`;
+
 exports[`twin.macro presets.js: presets.js 1`] = `
 
 import tw from './macro'
@@ -13320,6 +13397,10 @@ import tw from './macro'
 
 tw\`hover:block first:mt-2 last-of-type:max-width[20px]\`
 
+tw\`my-class1\`
+tw\`my-class2\`
+tw\`my-class3\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 ;({
@@ -13331,6 +13412,21 @@ tw\`hover:block first:mt-2 last-of-type:max-width[20px]\`
   },
   '&:last-of-type': {
     maxWidth: '20px',
+  },
+})
+;({
+  '&:hover': {
+    backgroundColor: 'pink',
+  },
+})
+;({
+  '&:hover': {
+    backgroundColor: 'orange',
+  },
+})
+;({
+  '.test & :hover': {
+    backgroundColor: 'orange',
   },
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,10 +1104,16 @@
       }
     },
     "@tailwindcss/typography": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.3.1.tgz",
-      "integrity": "sha512-HyZ+3Eay8SGaPq7kcFoANZLr4EjeXQ19yjjb9fp6B0PHHpvZoe00jdsnpnooMEbx9J5rQ93nxPUG3MQmXVxGMQ==",
-      "dev": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.4.0.tgz",
+      "integrity": "sha512-3BfOYT5MYNEq81Ism3L2qu/HRP2Q5vWqZtZRQqQrthHuaTK9qpuPfbMT5WATjAM5J1OePKBaI5pLoX4S1JGNMQ==",
+      "dev": true,
+      "requires": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      }
     },
     "@types/babel-plugin-tester": {
       "version": "9.0.1",
@@ -7557,6 +7563,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
+    },
     "lodash.flatmap": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
@@ -7572,6 +7584,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
     "@tailwindcss/forms": "^0.2.1",
-    "@tailwindcss/typography": "^0.3.1",
+    "@tailwindcss/typography": "^0.4.0",
     "@types/react": "^17.0.0",
     "@types/styled-components": "^5.1.4",
     "@typescript-eslint/eslint-plugin": "^4.8.1",

--- a/plugin.test.js
+++ b/plugin.test.js
@@ -19,10 +19,16 @@ pluginTester({
     .map(file => ({
       title: path.basename(file),
       code: fs.readFileSync(file, 'utf-8'),
-      ...(fs.existsSync(configFile(file)) && {
-        pluginOptions: {
-          twin: JSON.parse(fs.readFileSync(configFile(file), 'utf-8')),
+      pluginOptions: {
+        twin: {
+          ...(fs.existsSync(
+            path.join(path.dirname(file), 'tailwind.config.js')
+          ) && {
+            config: path.join(path.dirname(file), 'tailwind.config.js'),
+          }),
+          ...(fs.existsSync(configFile(file)) &&
+            JSON.parse(fs.readFileSync(configFile(file), 'utf-8'))),
         },
-      }),
+      },
     })),
 })

--- a/src/getProperties.js
+++ b/src/getProperties.js
@@ -47,7 +47,8 @@ const getProperties = (className, state, { isCsOnly = false }) => {
   if (!className) return
 
   const isCss = isCssClass(className)
-  if (isCsOnly) return { hasMatches: isCss, type: 'css' }
+  if (isCsOnly || className.includes('['))
+    return { hasMatches: isCss, type: 'css' }
 
   const isStatic = isStaticClass(className)
   const { isDynamicClass, dynamicConfig, dynamicKey } = getDynamicProperties(

--- a/src/handlers/userPlugins.js
+++ b/src/handlers/userPlugins.js
@@ -60,7 +60,7 @@ const getMatches = ({ className, data, sassyPseudo }) =>
     return result
   }, {})
 
-// The key gets formated with these checks
+// The key gets formatted with these checks
 const formatTasks = [
   ({ key }) => key.replace(/\\/g, '').trim(),
   // Replace the parent selector placeholder

--- a/src/handlers/userPlugins.js
+++ b/src/handlers/userPlugins.js
@@ -12,17 +12,21 @@ const reorderAtRules = className =>
     })
     .reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
 
-const mergeValueStatements = [
+// If these tasks return true then the rule is matched
+const mergeChecks = [
   // Match exact selector
   ({ key, className }) => key === className,
-  // Match class selector (whole word)
+  // Match class selector (inc dot)
   ({ key, className }) =>
-    key.match(new RegExp(`(?:^| ).${className}(?: |:|$)`, 'g')),
+    !key.includes('{{') &&
+    key.match(
+      new RegExp(`(?:^|>|~|\\+|\\*| )\\.${className}(?: |>|~|\\+|\\*|:|$)`, 'g')
+    ),
   // Match parent selector placeholder
   ({ key, className }) => key.includes(`{{${className}}}`),
-  // Match possible symbols after the selector
+  // Match possible symbols after the selector (ex dot)
   ({ key, className }) =>
-    [' ', ':', '>', '~', '+', '*'].some(suffix =>
+    [(' ', ':', '>', '~', '+', '*')].some(suffix =>
       key.startsWith(`${className}${suffix}`)
     ),
 ]
@@ -32,19 +36,23 @@ const getMatches = ({ className, data, sassyPseudo }) =>
     let [key, value] = item
     key = key.replace(/\\/g, '') // Unescape characters
 
-    const subKeyValue = Object.values(value)[0]
-    const isObject =
-      !Array.isArray(subKeyValue) && typeof subKeyValue === 'object'
-    if (isObject) {
-      const subMatches = getMatches({ className, data: value, sassyPseudo })
-      if (!isEmpty(subMatches)) return { ...result, [key]: subMatches }
+    const childValue = Object.values(value)[0]
+    const hasChildNesting =
+      !Array.isArray(childValue) && typeof childValue === 'object'
+    if (hasChildNesting) {
+      const matches = getMatches({
+        className,
+        data: value,
+        sassyPseudo,
+      })
+      if (!isEmpty(matches)) return { ...result, [key]: matches }
     }
 
-    const shouldMergeValue = mergeValueStatements.findIndex(item =>
-      item({ key, value, className })
+    const shouldMergeValue = mergeChecks.some(item =>
+      item({ key, value, className, data })
     )
 
-    if (shouldMergeValue >= 0) {
+    if (shouldMergeValue) {
       const newKey = formatKey(key, className, sassyPseudo)
       return newKey ? { ...result, [newKey]: value } : { ...result, ...value }
     }
@@ -52,7 +60,8 @@ const getMatches = ({ className, data, sassyPseudo }) =>
     return result
   }, {})
 
-const replacementTasks = [
+// The key gets formated with these checks
+const formatTasks = [
   ({ key }) => key.replace(/\\/g, '').trim(),
   // Replace the parent selector placeholder
   ({ key, className }) => {
@@ -63,23 +72,19 @@ const replacementTasks = [
   // Replace the classname at start of selector (postCSS supplies flattened selectors)
   ({ key, className }) =>
     key.startsWith(`.${className}`) ? key.slice(`.${className}`.length) : key,
-  // Replace parent selector with ampsersand within
-  ({ key, className }) => {
-    const matches = key.match(new RegExp(`(?:^| ).${className}(?: |:|$)`, 'g'))
-    const match = matches && matches[0].trim()
-    return match ? key.replace(match, '&') : key
-  },
   ({ key }) => key.trim(),
   // Add the parent selector at the start when it has the sassy pseudo enabled
   ({ key, sassyPseudo }) =>
     sassyPseudo && key.startsWith(':') ? `&${key}` : key,
+  // Remove the unmatched class wrapping
+  ({ key }) => key.replace(/{{/g, '.').replace(/}}/g, ''),
 ]
 
 const formatKey = (selector, className, sassyPseudo) => {
   if (selector === className) return
 
   let key = selector
-  for (const task of replacementTasks) {
+  for (const task of formatTasks) {
     key = task({ key, className, sassyPseudo })
   }
 

--- a/src/logging.js
+++ b/src/logging.js
@@ -15,7 +15,7 @@ const spaced = string => `\n\n${string}\n`
 const warning = string => color.error(`✕ ${string}`)
 
 const inOutPlugins = (input, output) =>
-  `${color.highlight2('→')} ${input.replace(/\\/g, '')} ${color.highlight2(
+  `${color.highlight2('→')} ${input} ${color.highlight2(
     JSON.stringify(output)
   )}`
 
@@ -54,12 +54,16 @@ const logGeneralError = error => spaced(warning(error))
 
 const debug = (className, log) => console.log(inOut(className, log))
 
+const formatPluginKey = key => key.replace(/(\\|(}}))/g, '').replace(/{{/g, '.')
+
 const debugPlugins = processedPlugins => {
   console.log(
     Object.entries(processedPlugins)
       .map(([, group]) =>
         Object.entries(group)
-          .map(([className, styles]) => inOutPlugins(className, styles))
+          .map(([className, styles]) =>
+            inOutPlugins(formatPluginKey(className), styles)
+          )
           .join('\n')
       )
       .join(`\n`)

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -22,7 +22,7 @@ const parseSelector = (selector, { isBase }) => {
   // eg: .something.something or &.something
   match = match.replace(/(?<=\w)\./g, ' .')
 
-  // If there's no spaces in the selector then
+  // If the selector is just a single selector then return
   if (!match.includes(' ')) return match
 
   // Look for class matching candidates


### PR DESCRIPTION
This PR adds the ability to use the parent selector (&) within plugins.
This is useful for things like custom theming or fallbacks based on browser support.
It was quite difficult to achieve as the matching works so differently to tailwindcss - anyway hope you enjoy the feature!

## Custom theming example

Place the theme className on a parent and the children with the tailwind classes will be conditionally styled:

```js
const UsageExample = ({ themeName = "dark" }) => (
  <div className={themeName}>
    <div tw="themed-box">
      Themed item
    </div>
  </div>
)
```

```js
const plugin = require('tailwindcss/plugin')

const themePlugin = plugin(({ addComponents }) =>
  addComponents({
    ".themed-box": {
      ".dark &": {
        backgroundColor: "black",
      },
      ".light &": {
        backgroundColor: "white",
      },
    },
  })
);

module.exports = {
  plugins: [themePlugin],
};
```

```js
tw`themed-box`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  ".dark &": {
    "backgroundColor": "black"
  },
  ".light &": {
    "backgroundColor": "white"
  }
});
```

## Css feature support example

You may also want to add classNames the body/html element to indicate whether a css feature is supported. You can style your elements based on the presence of that selector by using the parent selector (&) like this:

```js
const UsageExample = () => (
  <div className="no-flex-gap">
    <div tw="gap-1.5">
      <div>gapped item</div>
      <div>gapped item</div>
    </div>
  </div>
)
```

```js
const plugin = require('tailwindcss/plugin')

const half = value => value.replace(/\d+(.\d+)?/, number => number / 2)

const customGapPlugin = plugin(({ addUtilities, e, theme }) => {
  Object.entries(theme('gap')).forEach(([key, value]) =>
    addUtilities({
      [`.gap-${e(key)}`]: {
		gap: value,
        '.no-flex-gap &': {
          margin: `-${half(value)}`,
        },
        '.no-flex-gap & > *': {
          margin: half(value),
        },
      },
      [`.gap-x-${e(key)}`]: {
        columnGap: value,
        '.no-flex-gap &': {
          marginRight: `-${half(value)}`,
          marginLeft: `-${half(value)}`,
        },
        '.no-flex-gap & > *': {
          marginRight: half(value),
          marginLeft: half(value),
        },
      },
      [`.gap-y-${e(key)}`]: {
	    rowGap: value,
        '.no-flex-gap &': {
          marginTop: `-${half(value)}`,
          marginBottom: `-${half(value)}`,
        },
        '.no-flex-gap & > *': {
          marginTop: half(value),
          marginBottom: half(value),
        },
      },
    })
  )
});

module.exports = {
  plugins: [customGapPlugin],
};
```

```js
tw`gap-1.5`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "gap": "0.375rem",
  ".no-flex-gap &": {
    "margin": "-0.1875rem"
  },
  ".no-flex-gap & > *": {
    "margin": "0.1875rem"
  }
});
```