### PR TITLE
Class prefix

### DIFF
--- a/__fixtures__/prefix/config.json
+++ b/__fixtures__/prefix/config.json
@@ -1,0 +1,5 @@
+{
+  "config": "__fixtures__/prefix/tailwind.config.js",
+  "includeClassNames": true,
+  "dataTwProp": "all"
+}

--- a/__fixtures__/prefix/prefix.js
+++ b/__fixtures__/prefix/prefix.js
@@ -1,0 +1,28 @@
+import tw from './macro'
+
+// tw prop prefix
+;<div tw="tw-text-black" />
+
+// tw import prefix
+;<div css={tw`tw-bg-red-500`} />
+
+// tw prop + import prefix
+;<div tw="tw-text-black" css={tw`lg:tw-bg-red-500`} />
+
+// tw import + short css
+;<div css={tw`lg:tw-bg-red-500 max-width[100vw]`} />
+
+// className should be ignored without the prefix
+;<div className="block" />
+
+// className should be converted with a prefix
+;<div className="tw-block" />
+
+// group
+;<div tw="hover:(lg:tw-bg-red-500)" />
+;<div tw="hover:(lg:tw-bg-red-500 max-width[100vw])" />
+;<div css={tw`hover:(lg:tw-bg-red-500)`} />
+;<div css={tw`hover:(lg:tw-bg-red-500 max-width[100vw])`} />
+
+// custom plugin class
+;<div tw="tw-plugin-class" />

--- a/__fixtures__/prefix/prefix.js
+++ b/__fixtures__/prefix/prefix.js
@@ -24,5 +24,7 @@ import tw from './macro'
 ;<div css={tw`hover:(lg:tw-bg-red-500)`} />
 ;<div css={tw`hover:(lg:tw-bg-red-500 max-width[100vw])`} />
 
-// custom plugin class
+// custom plugin classes
 ;<div tw="tw-plugin-class" />
+;<div tw="tw-test-1" />
+;<div tw="tw-test-2" />

--- a/__fixtures__/prefix/tailwind.config.js
+++ b/__fixtures__/prefix/tailwind.config.js
@@ -1,0 +1,14 @@
+function pluginClass({ addComponents }) {
+  addComponents([
+    {
+      '.plugin-class': {
+        content: 'working',
+      },
+    },
+  ])
+}
+
+module.exports = {
+  prefix: 'tw-',
+  plugins: [pluginClass],
+}

--- a/__fixtures__/prefix/tailwind.config.js
+++ b/__fixtures__/prefix/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require('tailwindcss/plugin')
+
 function pluginClass({ addComponents }) {
   addComponents([
     {
@@ -8,7 +10,30 @@ function pluginClass({ addComponents }) {
   ])
 }
 
+// Test a couple extra things
+const parentTestPlugin = plugin(({ addUtilities }) => {
+  addUtilities({
+    '.test-1': {
+      background: '5px',
+      '.a-class & .some-class': {
+        margin: '10px',
+      },
+      '.a-class & > *': {
+        margin: '20px',
+      },
+    },
+    '.test-2': {
+      '.a-class & .some-class': {
+        margin: '10px',
+      },
+      '.a-class & > *': {
+        margin: '20px',
+      },
+    },
+  })
+})
+
 module.exports = {
   prefix: 'tw-',
-  plugins: [pluginClass],
+  plugins: [pluginClass, parentTestPlugin],
 }

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12748,39 +12748,18 @@ tw\`rich-text\`
     color: '#111827',
     fontWeight: '600',
   },
-  'ol[type="A"]': {
-    '--list-counter-style': 'upper-alpha',
-  },
-  'ol[type="a"]': {
-    '--list-counter-style': 'lower-alpha',
-  },
-  'ol[type="A s"]': {
-    '--list-counter-style': 'upper-alpha',
-  },
-  'ol[type="a s"]': {
-    '--list-counter-style': 'lower-alpha',
-  },
-  'ol[type="I"]': {
-    '--list-counter-style': 'upper-roman',
-  },
-  'ol[type="i"]': {
-    '--list-counter-style': 'lower-roman',
-  },
-  'ol[type="I s"]': {
-    '--list-counter-style': 'upper-roman',
-  },
-  'ol[type="i s"]': {
-    '--list-counter-style': 'lower-roman',
-  },
-  'ol[type="1"]': {
-    '--list-counter-style': 'decimal',
+  ol: {
+    counterReset: 'list-counter',
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
   'ol > li': {
     position: 'relative',
+    counterIncrement: 'list-counter',
     paddingLeft: '1.75em',
   },
   'ol > li::before': {
-    content: 'counter(list-item, var(--list-counter-style, decimal)) "."',
+    content: 'counter(list-counter) "."',
     position: 'absolute',
     fontWeight: '400',
     color: '#6b7280',
@@ -12900,10 +12879,10 @@ tw\`rich-text\`
     lineHeight: 'inherit',
   },
   'pre code::before': {
-    content: 'none',
+    content: '""',
   },
   'pre code::after': {
-    content: 'none',
+    content: '""',
   },
   table: {
     width: '100%',
@@ -12965,10 +12944,6 @@ tw\`rich-text\`
   },
   'h3 code': {
     fontSize: '0.9em',
-  },
-  ol: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
   },
   ul: {
     marginTop: '1.25em',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -13747,8 +13747,10 @@ import tw from './macro'
 ;<div css={tw\`hover:(lg:tw-bg-red-500)\`} />
 ;<div css={tw\`hover:(lg:tw-bg-red-500 max-width[100vw])\`} />
 
-// custom plugin class
+// custom plugin classes
 ;<div tw="tw-plugin-class" />
+;<div tw="tw-test-1" />
+;<div tw="tw-test-2" />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -13843,12 +13845,35 @@ import tw from './macro'
     },
   }}
   data-tw={'hover:(lg:tw-bg-red-500 max-width[100vw])'}
-/> // custom plugin class
+/> // custom plugin classes
 ;<div
   css={{
     content: 'working',
   }}
   data-tw="tw-plugin-class"
+/>
+;<div
+  css={{
+    background: '5px',
+    '.a-class & .some-class': {
+      margin: '10px',
+    },
+    '.a-class & > *': {
+      margin: '20px',
+    },
+  }}
+  data-tw="tw-test-1"
+/>
+;<div
+  css={{
+    '.a-class & .some-class': {
+      margin: '10px',
+    },
+    '.a-class & > *': {
+      margin: '20px',
+    },
+  }}
+  data-tw="tw-test-2"
 />
 
 

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12748,18 +12748,39 @@ tw\`rich-text\`
     color: '#111827',
     fontWeight: '600',
   },
-  ol: {
-    counterReset: 'list-counter',
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
+  'ol[type="A"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="A s"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a s"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="I"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  'ol[type="I s"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i s"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  'ol[type="1"]': {
+    '--list-counter-style': 'decimal',
   },
   'ol > li': {
     position: 'relative',
-    counterIncrement: 'list-counter',
     paddingLeft: '1.75em',
   },
   'ol > li::before': {
-    content: 'counter(list-counter) "."',
+    content: 'counter(list-item, var(--list-counter-style, decimal)) "."',
     position: 'absolute',
     fontWeight: '400',
     color: '#6b7280',
@@ -12879,10 +12900,10 @@ tw\`rich-text\`
     lineHeight: 'inherit',
   },
   'pre code::before': {
-    content: '""',
+    content: 'none',
   },
   'pre code::after': {
-    content: '""',
+    content: 'none',
   },
   table: {
     width: '100%',
@@ -12944,6 +12965,10 @@ tw\`rich-text\`
   },
   'h3 code': {
     fontSize: '0.9em',
+  },
+  ol: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
   ul: {
     marginTop: '1.25em',
@@ -13690,6 +13715,141 @@ tw\`my-class6\`
     backgroundColor: 'orange',
   },
 })
+
+
+`;
+
+exports[`twin.macro prefix.js: prefix.js 1`] = `
+
+import tw from './macro'
+
+// tw prop prefix
+;<div tw="tw-text-black" />
+
+// tw import prefix
+;<div css={tw\`tw-bg-red-500\`} />
+
+// tw prop + import prefix
+;<div tw="tw-text-black" css={tw\`lg:tw-bg-red-500\`} />
+
+// tw import + short css
+;<div css={tw\`lg:tw-bg-red-500 max-width[100vw]\`} />
+
+// className should be ignored without the prefix
+;<div className="block" />
+
+// className should be converted with a prefix
+;<div className="tw-block" />
+
+// group
+;<div tw="hover:(lg:tw-bg-red-500)" />
+;<div tw="hover:(lg:tw-bg-red-500 max-width[100vw])" />
+;<div css={tw\`hover:(lg:tw-bg-red-500)\`} />
+;<div css={tw\`hover:(lg:tw-bg-red-500 max-width[100vw])\`} />
+
+// custom plugin class
+;<div tw="tw-plugin-class" />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;<div
+  css={{
+    '--tw-text-opacity': '1',
+    color: 'rgba(0, 0, 0, var(--tw-text-opacity))',
+  }}
+  data-tw="tw-text-black"
+/> // tw import prefix
+;<div
+  css={{
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+  }}
+  data-tw={'tw-bg-red-500'}
+/> // tw prop + import prefix
+;<div
+  css={[
+    {
+      '--tw-text-opacity': '1',
+      color: 'rgba(0, 0, 0, var(--tw-text-opacity))',
+    },
+    {
+      '@media (min-width: 1024px)': {
+        '--tw-bg-opacity': '1',
+        backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+      },
+    },
+  ]}
+  data-tw={'tw-text-black | lg:tw-bg-red-500'}
+/> // tw import + short css
+;<div
+  css={{
+    maxWidth: '100vw',
+    '@media (min-width: 1024px)': {
+      '--tw-bg-opacity': '1',
+      backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+    },
+  }}
+  data-tw={'lg:tw-bg-red-500 max-width[100vw]'}
+/> // className should be ignored without the prefix
+;<div className="block" /> // className should be converted with a prefix
+;<div
+  css={{
+    display: 'block',
+  }}
+  data-tw="tw-block"
+/> // group
+;<div
+  css={{
+    ':hover': {
+      '@media (min-width: 1024px)': {
+        '--tw-bg-opacity': '1',
+        backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+      },
+    },
+  }}
+  data-tw="hover:(lg:tw-bg-red-500)"
+/>
+;<div
+  css={{
+    ':hover': {
+      '@media (min-width: 1024px)': {
+        '--tw-bg-opacity': '1',
+        backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+      },
+      maxWidth: '100vw',
+    },
+  }}
+  data-tw="hover:(lg:tw-bg-red-500 max-width[100vw])"
+/>
+;<div
+  css={{
+    ':hover': {
+      '@media (min-width: 1024px)': {
+        '--tw-bg-opacity': '1',
+        backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+      },
+    },
+  }}
+  data-tw={'hover:(lg:tw-bg-red-500)'}
+/>
+;<div
+  css={{
+    ':hover': {
+      '@media (min-width: 1024px)': {
+        '--tw-bg-opacity': '1',
+        backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+      },
+      maxWidth: '100vw',
+    },
+  }}
+  data-tw={'hover:(lg:tw-bg-red-500 max-width[100vw])'}
+/> // custom plugin class
+;<div
+  css={{
+    content: 'working',
+  }}
+  data-tw="tw-plugin-class"
+/>
 
 
 `;

--- a/src/getProperties.js
+++ b/src/getProperties.js
@@ -35,7 +35,7 @@ const getDynamicProperties = className => {
   return { isDynamicClass, dynamicConfig, dynamicKey }
 }
 
-const isCssClass = className => className.includes('[')
+export const isCssClass = className => className.includes('[')
 
 const isEmpty = value =>
   value === undefined ||
@@ -43,7 +43,7 @@ const isEmpty = value =>
   (typeof value === 'object' && Object.keys(value).length === 0) ||
   (typeof value === 'string' && value.trim().length === 0)
 
-const getProperties = (className, state, { isCsOnly = false }) => {
+export const getProperties = (className, state, { isCsOnly = false }) => {
   if (!className) return
 
   const isCss = isCssClass(className)
@@ -72,5 +72,3 @@ const getProperties = (className, state, { isCsOnly = false }) => {
     hasUserPlugins,
   }
 }
-
-export default getProperties

--- a/src/prechecks.js
+++ b/src/prechecks.js
@@ -1,5 +1,6 @@
 import { throwIf } from './utils'
 import { logBadGood } from './logging'
+import { isCssClass } from './getProperties'
 
 const precheckGroup = ({ classNameRaw }) =>
   throwIf(
@@ -11,10 +12,30 @@ const precheckGroup = ({ classNameRaw }) =>
       )}\nRead more at https://twinredirect.page.link/group\n`
   )
 
+const joinWithNoDoubleHyphens = arr => arr.join('-').replace(/-+/g, '-')
+
+const preCheckPrefix = ({ pieces: { className, hasPrefix }, state }) => {
+  if (isCssClass(className)) return
+
+  const { prefix } = state.config
+  if (hasPrefix === Boolean(prefix)) return
+
+  const classSuggestion = joinWithNoDoubleHyphens([prefix, className])
+
+  throwIf(
+    !className.startsWith(prefix),
+    () =>
+      `\n\n“${className}” should have a prefix:${logBadGood(
+        className,
+        classSuggestion
+      )}`
+  )
+}
+
 const doPrechecks = (prechecks, context) => {
   for (const precheck of prechecks) {
     precheck(context)
   }
 }
 
-export { doPrechecks as default, precheckGroup }
+export { doPrechecks as default, precheckGroup, preCheckPrefix }

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -1,0 +1,11 @@
+const splitPrefix = props => {
+  const { className, state } = props
+  const { prefix } = state.config
+  if (!prefix) return { className, hasPrefix: false }
+
+  if (!className.startsWith(prefix)) return { className, hasPrefix: false }
+
+  return { className: className.slice(prefix.length), hasPrefix: true }
+}
+
+export { splitPrefix }

--- a/src/utils/getPieces.js
+++ b/src/utils/getPieces.js
@@ -1,8 +1,9 @@
 import { splitVariants } from './../variants'
 import { splitImportant } from './../important'
 import { splitNegative } from './../negative'
+import { splitPrefix } from './../prefix'
 
-const splitters = [splitVariants, splitNegative, splitImportant]
+const splitters = [splitVariants, splitPrefix, splitNegative, splitImportant]
 
 export default context => {
   const results = splitters.reduce(

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -26,9 +26,11 @@ const parseSelector = (selector, { isBase }) => {
   if (!match.includes(' ')) return match
 
   // Look for class matching candidates
-  const match2 = match.match(/(?<=>|~|\+|\*| )\.[\w.\\-]+(?= |>|~|\+|\*|:|$)/gm)
-  if (!match2) return match
+  const match2 = match.match(
+    /(?<=>|^|~|\+|\*| )\.[\w.\\-]+(?= |>|~|\+|\*|:|$)/gm
+  )
 
+  if (!match2) return match
   // Wrap the matching classes in {{class}}
   for (const item of match2) {
     match = replaceSelectorWithParent(match, item)

--- a/src/variants.js
+++ b/src/variants.js
@@ -105,7 +105,7 @@ const splitVariants = ({ classNameRaw, state }) => {
 
   return {
     classNameRawNoVariants: className,
-    className,
+    className, // TODO: Hoist the definition for className up, it's buried here
     variants,
     hasVariants,
   }


### PR DESCRIPTION
This PR adds support for the [prefix feature from tailwindcss](https://tailwindcss.com/docs/configuration#prefix).

You can activate this feature by adding a prefix to your tailwind config:

```js
// tailwind.config.js
module.exports = {
  prefix: "twin-"
};
```

The prefix is now enforced on all tailwind classes (including your custom plugin classes):

```js
<div tw="twin-block" />
<div css={tw`twin-block`} />
<div className="twin-block" /> // with `includeClassNames: true` in your twin config
styled.div(tw`twin-block`)
tw.div`twin-block`
```