### PR TITLE
Reorder col-span-x, col-start-x and col-end-x so a grid works as expected

### DIFF
--- a/__fixtures__/grid.js
+++ b/__fixtures__/grid.js
@@ -59,6 +59,18 @@ tw`col-end-12`
 tw`col-end-13`
 tw`col-end-auto`
 
+// col-span-x should always come before col-start-x & col-end-x
+// https://github.com/ben-rogerson/twin.macro/issues/363
+tw`col-start-3 col-span-3`
+tw`col-span-3 col-start-3`
+tw`col-end-3 col-span-3`
+tw`col-span-3 col-end-3`
+tw`col-start-3 col-end-3 col-span-3`
+tw`col-span-3 col-start-3 col-end-3`
+tw`grid col-span-3`
+tw`grid col-start-3 col-end-3`
+tw`col-start-3 col-span-3 col-end-3 grid`
+
 // https://tailwindcss.com/docs/grid-template-rows
 tw`grid-rows-1`
 tw`grid-rows-2`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -8015,6 +8015,18 @@ tw\`col-end-12\`
 tw\`col-end-13\`
 tw\`col-end-auto\`
 
+// col-span-x should always come before col-start-x & col-end-x
+// https://github.com/ben-rogerson/twin.macro/issues/363
+tw\`col-start-3 col-span-3\`
+tw\`col-span-3 col-start-3\`
+tw\`col-end-3 col-span-3\`
+tw\`col-span-3 col-end-3\`
+tw\`col-start-3 col-end-3 col-span-3\`
+tw\`col-span-3 col-start-3 col-end-3\`
+tw\`grid col-span-3\`
+tw\`grid col-start-3 col-end-3\`
+tw\`col-start-3 col-span-3 col-end-3 grid\`
+
 // https://tailwindcss.com/docs/grid-template-rows
 tw\`grid-rows-1\`
 tw\`grid-rows-2\`
@@ -8333,6 +8345,49 @@ tw\`gap-y-px\`
 })
 ;({
   gridColumnEnd: 'auto',
+}) // col-span-x should always come before col-start-x & col-end-x
+// https://github.com/ben-rogerson/twin.macro/issues/363
+
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnStart: '3',
+})
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnStart: '3',
+})
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnEnd: '3',
+})
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnEnd: '3',
+})
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnStart: '3',
+  gridColumnEnd: '3',
+})
+;({
+  gridColumn: 'span 3 / span 3',
+  gridColumnStart: '3',
+  gridColumnEnd: '3',
+})
+;({
+  display: 'grid',
+  gridColumn: 'span 3 / span 3',
+})
+;({
+  display: 'grid',
+  gridColumnStart: '3',
+  gridColumnEnd: '3',
+})
+;({
+  display: 'grid',
+  gridColumn: 'span 3 / span 3',
+  gridColumnStart: '3',
+  gridColumnEnd: '3',
 }) // https://tailwindcss.com/docs/grid-template-rows
 
 ;({

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -12,6 +12,7 @@ import {
   debug,
 } from './logging'
 import { orderByScreens } from './screens'
+import { orderGridProperty } from './grid'
 import applyTransforms from './transforms'
 import { addVariants, handleVariantGroups } from './variants'
 import {
@@ -49,6 +50,8 @@ const formatTasks = [
   ({ classes }) => handleVariantGroups(classes),
   // Move and sort the responsive items to the end of the list
   ({ classes, state }) => orderByScreens(classes, state),
+  // Sort some grid properties so it works as expected
+  ({ classes }) => orderGridProperty(classes),
 ]
 
 export default (

--- a/src/grid.js
+++ b/src/grid.js
@@ -1,0 +1,16 @@
+const gridCompare = attr => {
+  // The order of the css properties in a grid matter when combined into one class
+  // https://github.com/ben-rogerson/twin.macro/issues/363
+  // We send them all to the end and move col-span-x
+  // to the beginning of col-start-x and col-end-x
+  if (attr.includes('col-span-')) return 1
+  if (attr.includes('col-start-')) return 2
+  if (attr.includes('col-end-')) return 2
+  return 0
+}
+
+const orderGridProperty = className => {
+  return className.sort((a, b) => gridCompare(a) - gridCompare(b))
+}
+
+export { orderGridProperty }


### PR DESCRIPTION
This PR reorders col-span-x, col-start-x and col-end-x to make a grid act more like you expect.

Not sure how advanced to make the reordering, it now always sends them to the end of the array in the right order.
It make the code less complex but I'm not sure if something else requires things to be in the certain order.
Also added some tests fixtures to display that happens. 

Fixes https://github.com/ben-rogerson/twin.macro/issues/363