### PR TITLE
Push `ring-opacity-x` to end of class lists

### DIFF
--- a/__fixtures__/borders.js
+++ b/__fixtures__/borders.js
@@ -537,3 +537,8 @@ tw`ring ring-inset ring-purple-500 ring-offset-black ring-offset-4`
 tw`ring ring-purple-500 ring-offset-black ring-offset-4`
 tw`ring ring-offset-black ring-offset-4`
 tw`ring ring-offset-4`
+
+// Test the ring-opacity ordering - 'ring-opacity-x' should be moved to the end
+// https://github.com/ben-rogerson/twin.macro/issues/374
+tw`ring-4 ring-opacity-20 ring-green-500`
+tw`mt-5 md:(ring-opacity-20 ring-4 ring-green-500) mb-5`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -4773,6 +4773,11 @@ tw\`ring ring-purple-500 ring-offset-black ring-offset-4\`
 tw\`ring ring-offset-black ring-offset-4\`
 tw\`ring ring-offset-4\`
 
+// Test the ring-opacity ordering - 'ring-opacity-x' should be moved to the end
+// https://github.com/ben-rogerson/twin.macro/issues/374
+tw\`ring-4 ring-opacity-20 ring-green-500\`
+tw\`mt-5 md:(ring-opacity-20 ring-4 ring-green-500) mb-5\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 // https://tailwindcss.com/docs/border-radius
@@ -6917,6 +6922,32 @@ tw\`ring ring-offset-4\`
   boxShadow:
     'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
   '--tw-ring-offset-width': '4px',
+}) // Test the ring-opacity ordering - 'ring-opacity-x' should be moved to the end
+// https://github.com/ben-rogerson/twin.macro/issues/374
+
+;({
+  '--tw-ring-offset-shadow':
+    'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+  '--tw-ring-shadow':
+    'var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+  boxShadow:
+    'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+  '--tw-ring-opacity': '0.2',
+  '--tw-ring-color': 'rgba(16, 185, 129, var(--tw-ring-opacity))',
+})
+;({
+  marginTop: '1.25rem',
+  marginBottom: '1.25rem',
+  '@media (min-width: 768px)': {
+    '--tw-ring-offset-shadow':
+      'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+    '--tw-ring-shadow':
+      'var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+    boxShadow:
+      'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+    '--tw-ring-opacity': '0.2',
+    '--tw-ring-color': 'rgba(16, 185, 129, var(--tw-ring-opacity))',
+  },
 })
 
 

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -15,6 +15,7 @@ import { orderByScreens } from './screens'
 import { orderGridProperty } from './grid'
 import { orderTransitionProperty } from './transition'
 import { orderTransformProperty } from './transform'
+import { orderRingProperty } from './ring'
 import applyTransforms from './transforms'
 import { addVariants, handleVariantGroups } from './variants'
 import {
@@ -54,6 +55,7 @@ const formatTasks = [
   ({ classes }) => orderGridProperty(classes),
   ({ classes }) => orderTransitionProperty(classes),
   ({ classes }) => orderTransformProperty(classes),
+  ({ classes }) => orderRingProperty(classes),
   // Move and sort the responsive items to the end of the list
   ({ classes, state }) => orderByScreens(classes, state),
 ]

--- a/src/ring.js
+++ b/src/ring.js
@@ -1,0 +1,20 @@
+import timSort from 'timsort'
+
+const ringCompare = (a, b) => {
+  // The order of ring properties matter when combined into a single object
+  // So here we move ring-opacity-xxx to the end to avoid being trumped
+  // https://github.com/ben-rogerson/twin.macro/issues/374
+  const A = /(^|:)ring-opacity-/.test(a) ? 0 : -1
+  const B = /(^|:)ring-opacity-/.test(b) ? 0 : -1
+  return A - B
+}
+
+const orderRingProperty = className => {
+  const classNames = className.match(/\S+/g) || []
+  // Tim Sort provides accurate sorting in node < 11
+  // https://github.com/ben-rogerson/twin.macro/issues/20
+  timSort.sort(classNames, ringCompare)
+  return classNames.join(' ')
+}
+
+export { orderRingProperty }


### PR DESCRIPTION
This PR orders `ring-opacity-x` to the end of the class list to make sure it doesn't get merge overwritten by any default opacity variables.

Related to the recent [class reordering](https://github.com/ben-rogerson/twin.macro/commit/aebf6da061ec49d55628c19c203fabd57d2d0d06) work.

Closes #374