### PR TITLE
Add Solid.js support

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -99,6 +99,36 @@ export default GlobalStyles
 
 [createGlobalStyle docs →](https://goober.js.org/api/createGlobalStyles)
 
+### Solid
+
+```js
+// styles/GlobalStyles.js
+import { createGlobalStyle } from 'solid-styled-components'
+import tw, { GlobalStyles as BaseStyles } from 'twin.macro'
+
+const CustomStyles = createGlobalStyle`
+  @font-face {
+    font-family: 'Foo';
+    src: url('/path/to/exampleFont.woff') format('woff');
+    font-style: normal;
+    font-weight: 400;
+    /* https://styled-components.com/docs/faqs#how-do-i-fix-flickering-text-after-server-side-rendering */
+    font-display: fallback;
+  }
+`
+
+const GlobalStyles = () => (
+  <>
+    <BaseStyles />
+    <CustomStyles />
+  </>
+)
+
+export default GlobalStyles
+```
+
+[createGlobalStyle docs →](https://github.com/ryansolid/solid/tree/main/packages/solid-styled-components#createglobalstyles)
+
 ## Add the `@font-face` in a .css file and import it
 
 This method may help to remove text flickering in some frameworks.

--- a/docs/options.md
+++ b/docs/options.md
@@ -31,7 +31,7 @@ You can add these options in your twin config:
 | Name                  | Default                | Description                                                                                                                                                          |
 | --------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | config                | `"tailwind.config.js"` | The path to your Tailwind config.                                                                                                                                    |
-| preset                | `"emotion"`            | The css-in-js library behind the scenes - also allows `'styled-components'` and `'goober'`.                                                                          |
+| preset                | `"emotion"`            | The css-in-js library behind the scenes - also allows `'styled-components'`, `'goober'` and `'solid'`.                                                               |
 | hasSuggestions        | `true`                 | Display suggestions when a class isn’t found.                                                                                                                        |
 | dataTwProp            | `true`                 | Add a prop to your elements in development so you can see the original tailwind classes, eg: `<div data-tw="bg-black" />`, add `all` to keep the prop in production. |
 | debugPlugins          | `false`                | Display generated class information in your terminal from your plugins.                                                                                              |
@@ -69,7 +69,7 @@ module.exports = {
 preset: 'emotion', // Set the css-in-js library to use with twin
 ```
 
-Supports: `'emotion'` / `'styled-components'` / `'goober'`.
+Supports: `'emotion'` / `'styled-components'` / `'goober'` / `'solid'`.
 
 The preset controls which imports get added when twins `css`, `styled` and `GlobalStyles` imports are used.
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "nodemon": "^2.0.6",
     "prettier": "^2.1.2",
     "react": "^17.0.1",
+    "solid-styled-components": "^0.26.1",
     "styled-components": "^5.2.1",
     "tailwindcss-typography": "^3.1.0",
     "typescript": "^4.0.5"

--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -2,7 +2,7 @@
 const configDefaultsStyledComponents = { autoCssProp: true } // Automates the import of styled-components when you use their css prop
 const configDefaultsGoober = { sassyPseudo: true } // Sets selectors like hover to &:hover
 
-const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
+const configDefaultsTwin = ({ isStyledComponents, isGoober, isSolid, isDev }) => ({
   allowStyleProp: false, // Allows styles within style="blah" without throwing an error
   autoCssProp: false, // Automates the import of styled-components when you use their css prop
   dataTwProp: isDev, // During development, add a data-tw="" prop containing your tailwind classes for backtracing
@@ -14,7 +14,7 @@ const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
   dataCsProp: isDev, // During development, add a data-cs="" prop containing your short css classes for backtracing
   disableCsProp: false, // Disable converting css styles in the cs prop
   ...(isStyledComponents && configDefaultsStyledComponents),
-  ...(isGoober && configDefaultsGoober),
+  ...((isGoober || isSolid) && configDefaultsGoober),
 })
 
 const isBoolean = value => typeof value === 'boolean'
@@ -23,8 +23,8 @@ const configTwinValidators = {
   preset: [
     value =>
       value === undefined ||
-      ['styled-components', 'emotion', 'goober'].includes(value),
-    `The config “preset” can only be set to ‘emotion’ (default), ‘styled-components’ or ‘goober’`,
+      ['styled-components', 'emotion', 'goober', 'solid'].includes(value),
+    `The config “preset” can only be set to ‘emotion’ (default), ‘styled-components’, ‘goober’ or 'solid'`,
   ],
   allowStyleProp: [
     isBoolean,

--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -14,6 +14,10 @@
  * goober
  * { "babelMacros": { "twin": { "preset": "goober" } } }
  * module.exports = { twin: { preset: "goober" } }
+ *
+ * solid
+ * { "babelMacros": { "twin": { "preset": "solid" } } }
+ * module.exports = { twin: { preset: "solid" } }
  */
 
 export default {
@@ -57,6 +61,20 @@ export default {
     global: {
       import: 'createGlobalStyles',
       from: 'goober/global',
+    },
+  },
+  solid: {
+    styled: {
+      import: 'styled',
+      from: 'solid-styled-components',
+    },
+    css: {
+      import: 'css',
+      from: 'solid-styled-components',
+    },
+    global: {
+      import: 'createGlobalStyles',
+      from: 'solid-styled-components',
     },
   },
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -37,12 +37,18 @@ const getPackageUsed = ({ config: { preset }, cssImport, styledImport }) => ({
     cssImport.from.includes('emotion'),
   isStyledComponents:
     preset === 'styled-components' ||
-    styledImport.from.includes('styled-components') ||
-    cssImport.from.includes('styled-components'),
+    (styledImport.from.includes('styled-components') &&
+      !styledImport.from.includes('solid')) ||
+    (cssImport.from.includes('styled-components') &&
+      !cssImport.from.includes('solid')),
   isGoober:
     preset === 'goober' ||
     styledImport.from.includes('goober') ||
     cssImport.from.includes('goober'),
+  isSolid:
+    preset === 'solid' ||
+    styledImport.from.includes('solid-styled-components') ||
+    cssImport.from.includes('solid-styled-components'),
 })
 
 const twinMacro = ({ babel: { types: t }, references, state, config }) => {

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -169,7 +169,7 @@ const handleGlobalStylesFunction = ({
     state.isImportingCss = !state.existingCssIdentifier
   }
 
-  if (state.isGoober) {
+  if (state.isGoober || state.isSolid) {
     const declaration = getGlobalDeclarationTte({
       t,
       globalUid,


### PR DESCRIPTION
The `solid-styled-component` package for Solid is a thin wrapper around Goober.

This patch adds `preset: solid`, which loads the Goober wrappers and otherwise behaves as Goober would.

A [small site](https://github.com/AequoreaVictoria/live.tv) has been written using this PR, as well as this recently merged [Solid PR](https://github.com/ryansolid/solid/pull/407) for `createGlobalStyles` support.

I'm not sure exactly how you'd like to see these changes implemented and there are currently caveats. At the moment, however, I'd say it's entirely usable as a feature. Whatever you advise is fine.

Here are the current caveats. The following pattern works: 

```JavaScript
import tw, { styled } from "twin.macro";

export default function App(props) {
  const Button = styled("button")`
    ${() => tw`text-white`}
  `;
  return <Button {...props} />;
}
```

The following will not:

```JavaScript
import "twin.macro";

export default function App(props) {
  return <button {...props} tw="text-white" />;
}
```

However, the following also works: 

```JavaScript
export default function App(props) {
  const ToggleButton = styled("button")`
    ${() => (props.active ? tw`text-white` : tw`text-gray-700`)}
  `;
  return <ToggleButton {...props} />;
}

<ToggleButton active={state.volume > 0} onClick={click}>
  <Svg alt="speaker" />
</ToggleButton>
```

Where `Svg` also demonstrates the `css` escape hatch:

```JavaScript
import tw, { css } from "twin.macro";

export default function App(props) {
  const svg = css`
    ${() => tw`
      h-8
      w-8
      fill-current
      stroke-current
      inline-block
      text-center 
      bg-cover
    `}
  `;
  return (
    <svg {...props} class={svg}>
      <use xlink:href={`#svg-${props.alt}`}></use>
    </svg>
  );
}
```

And most importantly GlobalStyles works: 

```JavaScript
import { createGlobalStyles } from "solid-styled-components";
import tw, { GlobalStyles as BaseStyles } from "twin.macro";

export default function App() {
  const CustomStyles = createGlobalStyles`   
    body { 
      ${() => tw`subpixel-antialiased`}
    }
    video {
      ${() => tw`h-screen w-full bg-black z-0`}
    }
    video::-webkit-media-controls {
      ${() => tw`hidden`}
    }
  `;

  return (
    <>
      <BaseStyles />
      <CustomStyles />
    </>
  );
}
```

The only setup needed is `package.json`: 

```JSON
{
  "babelMacros": {
    "twin": {
      "preset": "solid"
    }
  },
  "devDependencies": {
    "vite": "^2.2.1",
    "vite-plugin-babel-macros": "^1.0.5",
    "vite-plugin-solid": "^1.5.1"
  },
  "dependencies": {
    "solid-js": "^0.26.1",
    "solid-styled-components": "^0.26.1",
    "twin.macro": "^2.3.3"
  }
}
```

and `vite.config.js`:

```JavaScript
import { defineConfig } from "vite";
import solid from "vite-plugin-solid";
import macros from "vite-plugin-babel-macros";

export default defineConfig({
  plugins: [ solid(), macros(), ],

  build: {
    target: "esnext",
    polyfillDynamicImport: false,
  },
});
```