### PR TITLE
Reorder user plugins

### DIFF
--- a/__fixtures__/!plugins.js
+++ b/__fixtures__/!plugins.js
@@ -16,7 +16,6 @@ const addComponentsTest = tw`btn btn-blue btn-red`
 const addComponentsTestMedia = tw`xl:btn sm:btn-blue lg:btn-red`
 const addComponentsTestVariants = tw`hover:active:btn hocus:before:btn-blue even:visited:btn-red`
 
-const addComponentsTestMediaQueriesVariants = tw`fluid-container ml-10`
 const addComponentsTestElementPrefixes = tw`prefixes`
 const addComponentsTestElementScreenReplacements = tw`screenies`
 

--- a/__fixtures__/fluidContainer/fluidContainer.js
+++ b/__fixtures__/fluidContainer/fluidContainer.js
@@ -1,0 +1,3 @@
+import tw from './macro'
+
+tw`fluid-container ml-10`

--- a/__fixtures__/fluidContainer/tailwind.config.js
+++ b/__fixtures__/fluidContainer/tailwind.config.js
@@ -1,0 +1,70 @@
+function fluidContainer({ addComponents, theme }) {
+  const styles = [
+    {
+      '.fluid-container': {
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        width: theme('fluidContainer.default', '100%'),
+      },
+    },
+    {
+      '.fluid-container:focus': {
+        marginLeft: '10rem',
+        marginRight: '11rem',
+        width: theme('fluidContainer.default', '100%'),
+      },
+    },
+    {
+      '.not-container': {
+        content: 'not-container',
+      },
+    },
+    {
+      '@media (min-width: 1440px)': {
+        '.fluid-container': {
+          display: 'block',
+        },
+      },
+    },
+    {
+      '@media (min-width: 768px)': {
+        '.fluid-container:hover': {
+          width: theme('fluidContainer.small', '100%'),
+        },
+        '.not-fluid-container': {
+          content: 'not-fluid-container:focus',
+        },
+        '.fluid-container:focus': {
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          width: theme('fluidContainer.default', '100%'),
+        },
+      },
+    },
+    {
+      '.fluid-container': {
+        '@media (min-width: 1440px)': {
+          width: theme('fluidContainer.large', '100%'),
+          backgroundColor: 'black',
+        },
+        '@media only screen and (max-width: 540px)': {
+          width: '33%',
+          backgroundColor: 'red',
+        },
+      },
+    },
+  ]
+
+  addComponents(styles)
+}
+
+module.exports = {
+  theme: {
+    fluidContainer: {
+      DEFAULT: '10%',
+      small: '25%',
+      large: '75%',
+    },
+  },
+  plugins: [fluidContainer],
+}

--- a/__fixtures__/pluginForms/pluginForms.js
+++ b/__fixtures__/pluginForms/pluginForms.js
@@ -1,0 +1,2 @@
+import { GlobalStyles } from './macro'
+;<GlobalStyles />

--- a/__fixtures__/pluginForms/tailwind.config.js
+++ b/__fixtures__/pluginForms/tailwind.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('@tailwindcss/forms')],
+}

--- a/__fixtures__/userPluginOrdering/tailwind.config.js
+++ b/__fixtures__/userPluginOrdering/tailwind.config.js
@@ -1,0 +1,58 @@
+function fluidContainer({ addComponents, theme }) {
+  const styles = [
+    {
+      '.selector': {
+        content: '.selector',
+        '.selector2': {
+          content: '.selector .selector2',
+        },
+        '@media (min-width: 1px)': {
+          '.selector3': {
+            content: '.selector:hover @media .selector3',
+          },
+        },
+      },
+    },
+    {
+      '.selector:hover': {
+        content: '.selector:hover',
+        '@media (min-width: 1px)': {
+          '.selector2': {
+            content: '.selector:hover @media .selector',
+          },
+        },
+        '.selector3': {
+          content: '.selector:hover .selector3',
+        },
+      },
+    },
+    {
+      '.not-selector': {
+        content: 'not-container',
+      },
+    },
+    {
+      '@media (min-width: 1px)': {
+        '.selector': {
+          content: '@media .selector',
+        },
+      },
+    },
+    {
+      '.selector': {
+        margin: '1px',
+        padding: 'padding',
+        display: 'block',
+        '@media (min-width: 2px)': {
+          content: '.selector @media',
+        },
+      },
+    },
+  ]
+
+  addComponents(styles)
+}
+
+module.exports = {
+  plugins: [fluidContainer],
+}

--- a/__fixtures__/userPluginOrdering/userPluginOrdering.js
+++ b/__fixtures__/userPluginOrdering/userPluginOrdering.js
@@ -1,0 +1,3 @@
+import tw from './macro'
+
+tw`selector`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -754,131 +754,6 @@ const _GlobalStyles = () => (
 * {
   --tw-shadow: 0 0 #0000; }
 
-[type='text'],[type='email'],[type='url'],[type='password'],[type='number'],[type='date'],[type='datetime-local'],[type='month'],[type='search'],[type='tel'],[type='time'],[type='week'],[multiple],textarea,select {
-appearance: none;
-background-color: #fff;
-border-color: #6b7280;
-border-width: 1px;
-border-radius: 0px;
-padding-top: 0.5rem;
-padding-right: 0.75rem;
-padding-bottom: 0.5rem;
-padding-left: 0.75rem;
-font-size: 1rem;
-line-height: 1.5rem;
-        }
-[type='text']:focus,[type='email']:focus,[type='url']:focus,[type='password']:focus,[type='number']:focus,[type='date']:focus,[type='datetime-local']:focus,[type='month']:focus,[type='search']:focus,[type='tel']:focus,[type='time']:focus,[type='week']:focus,[multiple]:focus,textarea:focus,select:focus {
-outline: 2px solid transparent;
-outline-offset: 2px;
---tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
---tw-ring-offset-width: 0px;
---tw-ring-offset-color: #fff;
---tw-ring-color: #2563eb;
---tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
---tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-border-color: #2563eb;
-        }
-input::placeholder,textarea::placeholder {
-color: #6b7280;
-opacity: 1;
-        }
-::-webkit-datetime-edit-fields-wrapper {
-padding: 0;
-        }
-::-webkit-date-and-time-value {
-min-height: 1.5em;
-        }
-select {
-background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
-background-position: right 0.5rem center;
-background-repeat: no-repeat;
-background-size: 1.5em 1.5em;
-padding-right: 2.5rem;
-color-adjust: exact;
-        }
-[multiple] {
-background-image: initial;
-background-position: initial;
-background-repeat: unset;
-background-size: initial;
-padding-right: 0.75rem;
-color-adjust: unset;
-        }
-[type='checkbox'],[type='radio'] {
-appearance: none;
-padding: 0;
-color-adjust: exact;
-display: inline-block;
-vertical-align: middle;
-background-origin: border-box;
-user-select: none;
-flex-shrink: 0;
-height: 1rem;
-width: 1rem;
-color: #2563eb;
-background-color: #fff;
-border-color: #6b7280;
-border-width: 1px;
-        }
-[type='checkbox'] {
-border-radius: 0px;
-        }
-[type='radio'] {
-border-radius: 100%;
-        }
-[type='checkbox']:focus,[type='radio']:focus {
-outline: 2px solid transparent;
-outline-offset: 2px;
---tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
---tw-ring-offset-width: 2px;
---tw-ring-offset-color: #fff;
---tw-ring-color: #2563eb;
---tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
---tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-        }
-[type='checkbox']:checked,[type='radio']:checked {
-border-color: transparent;
-background-color: currentColor;
-background-size: 100% 100%;
-background-position: center;
-background-repeat: no-repeat;
-        }
-[type='checkbox']:checked {
-background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-        }
-[type='radio']:checked {
-background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
-        }
-[type='checkbox']:checked:hover,[type='checkbox']:checked:focus,[type='radio']:checked:hover,[type='radio']:checked:focus {
-border-color: transparent;
-background-color: currentColor;
-        }
-[type='checkbox']:indeterminate {
-background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
-border-color: transparent;
-background-color: currentColor;
-background-size: 100% 100%;
-background-position: center;
-background-repeat: no-repeat;
-        }
-[type='checkbox']:indeterminate:hover,[type='checkbox']:indeterminate:focus {
-border-color: transparent;
-background-color: currentColor;
-        }
-[type='file'] {
-background: unset;
-border-color: inherit;
-border-width: 0;
-border-radius: 0;
-padding: 0;
-font-size: unset;
-line-height: inherit;
-        }
-[type='file']:focus {
-outline: 1px auto -webkit-focus-ring-color;
-        }
 .base-selector {
 content: 'test selector format is retained';
         }
@@ -1083,7 +958,6 @@ const addComponentsTest = tw\`btn btn-blue btn-red\`
 const addComponentsTestMedia = tw\`xl:btn sm:btn-blue lg:btn-red\`
 const addComponentsTestVariants = tw\`hover:active:btn hocus:before:btn-blue even:visited:btn-red\`
 
-const addComponentsTestMediaQueriesVariants = tw\`fluid-container ml-10\`
 const addComponentsTestElementPrefixes = tw\`prefixes\`
 const addComponentsTestElementScreenReplacements = tw\`screenies\`
 
@@ -1206,39 +1080,13 @@ const addComponentsTestVariants = {
     },
   },
 }
-const addComponentsTestMediaQueriesVariants = {
-  marginLeft: '2.5rem',
-  marginRight: 'auto',
-  width: '100%',
-  ':focus': {
-    marginLeft: '10rem',
-    marginRight: '11rem',
-    width: '100%',
-  },
-  '@media (min-width: 1440px)': {
-    display: 'block',
-    width: '75%',
-    backgroundColor: 'black',
-  },
-  '@media (min-width: 768px)': {
-    ':hover': {
-      width: '25%',
-    },
-    ':focus': {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '100%',
-    },
-  },
-  '@media only screen and (max-width: 540px)': {
-    width: '33%',
-    backgroundColor: 'red',
-  },
-}
 const addComponentsTestElementPrefixes = {
   h1: {
     margin: 'auto',
     marginRight: '10px',
+  },
+  ':focus': {
+    display: 'none',
   },
   'h2:hover': {
     color: 'red',
@@ -1249,19 +1097,16 @@ const addComponentsTestElementPrefixes = {
   'h3:active': {
     color: 'green',
   },
-  ':focus': {
-    display: 'none',
-  },
 }
 const addComponentsTestElementScreenReplacements = {
-  '@media (min-width: 768px)': {
-    display: 'flex',
-  },
   '@media (min-width: 640px)': {
     display: 'block',
   },
   '@media (min-width: 1024px)': {
     display: 'inline-block',
+  },
+  '@media (min-width: 768px)': {
+    display: 'flex',
   },
   '@media (min-width: 1280px)': {
     h1: {
@@ -7622,6 +7467,47 @@ tw\`order-none\`
 
 `;
 
+exports[`twin.macro fluidContainer.js: fluidContainer.js 1`] = `
+
+import tw from './macro'
+
+tw\`fluid-container ml-10\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  marginLeft: '2.5rem',
+  marginRight: 'auto',
+  width: '100%',
+  ':focus': {
+    marginLeft: '10rem',
+    marginRight: '11rem',
+    width: '100%',
+  },
+  '@media (min-width: 1440px)': {
+    width: '75%',
+    backgroundColor: 'black',
+    display: 'block',
+  },
+  '@media only screen and (max-width: 540px)': {
+    width: '33%',
+    backgroundColor: 'red',
+  },
+  '@media (min-width: 768px)': {
+    ':focus': {
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      width: '100%',
+    },
+    ':hover': {
+      width: '25%',
+    },
+  },
+})
+
+
+`;
+
 exports[`twin.macro globalStyles.js: globalStyles.js 1`] = `
 
 import { GlobalStyles } from './macro'
@@ -12671,6 +12557,461 @@ tw\`z-auto\`
 
 `;
 
+exports[`twin.macro pluginForms.js: pluginForms.js 1`] = `
+
+import { GlobalStyles } from './macro'
+
+;<GlobalStyles />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { css as _css } from '@emotion/react'
+import { Global as _globalImport } from '@emotion/react'
+
+const _GlobalStyles = () => (
+  <_globalImport
+    styles={_css\`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  :root {
+    -moz-tab-size: 4;
+    tab-size: 4;
+  }
+
+  html {
+    line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  body {
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+  }
+
+  abbr[title] {
+    text-decoration: underline dotted;
+  }
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  button,
+  select {
+    text-transform: none;
+  }
+
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    -webkit-appearance: button;
+  }
+
+  ::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  :-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  legend {
+    padding: 0;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [type='search'] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  button {
+    background-color: transparent;
+    background-image: none;
+  }
+
+  button:focus {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    line-height: 1.5;
+  }
+
+  body {
+    font-family: inherit;
+    line-height: inherit;
+  }
+
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: #e5e7eb;
+  }
+
+  hr {
+    border-top-width: 1px;
+  }
+
+  img {
+    border-style: solid;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: #9ca3af;
+  }
+
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    padding: 0;
+    line-height: inherit;
+    color: inherit;
+  }
+
+  pre,
+  code,
+  kbd,
+  samp {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  }
+
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+
+      @keyframes spin {
+          to { 
+            transform: rotate(360deg);
+          }
+        }
+      @keyframes ping {
+          75%, 100% { 
+            transform: scale(2); opacity: 0;
+          }
+        }
+      @keyframes pulse {
+          50% { 
+            opacity: .5;
+          }
+        }
+      @keyframes bounce {
+          0%, 100% { 
+            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
+          }
+        
+          50% { 
+            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
+          }
+        }
+* {
+    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: #fff;
+    --tw-ring-color: rgba(59, 130, 246, 0.5);
+    --tw-ring-offset-shadow: 0 0 #0000;
+    --tw-ring-shadow: 0 0 #0000;
+  }
+* {
+  --tw-shadow: 0 0 #0000; }
+
+select {
+background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+background-position: right 0.5rem center;
+background-repeat: no-repeat;
+background-size: 1.5em 1.5em;
+padding-right: 2.5rem;
+color-adjust: exact;
+        }
+[multiple] {
+background-image: initial;
+background-position: initial;
+background-repeat: unset;
+background-size: initial;
+padding-right: 0.75rem;
+color-adjust: unset;
+        }
+[type='file'] {
+background: unset;
+border-color: inherit;
+border-width: 0;
+border-radius: 0;
+padding: 0;
+font-size: unset;
+line-height: inherit;
+        }
+[type='radio'] {
+border-radius: 100%;
+        }
+[type='checkbox'] {
+border-radius: 0px;
+        }
+[type='file']:focus {
+outline: 1px auto -webkit-focus-ring-color;
+        }
+[type='radio']:checked {
+background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+        }
+[type='checkbox']:checked {
+background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+        }
+::-webkit-date-and-time-value {
+min-height: 1.5em;
+        }
+[type='checkbox']:indeterminate {
+background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+border-color: transparent;
+background-color: currentColor;
+background-size: 100% 100%;
+background-position: center;
+background-repeat: no-repeat;
+        }
+[type='checkbox'],[type='radio'] {
+appearance: none;
+padding: 0;
+color-adjust: exact;
+display: inline-block;
+vertical-align: middle;
+background-origin: border-box;
+user-select: none;
+flex-shrink: 0;
+height: 1rem;
+width: 1rem;
+color: #2563eb;
+background-color: #fff;
+border-color: #6b7280;
+border-width: 1px;
+        }
+::-webkit-datetime-edit-fields-wrapper {
+padding: 0;
+        }
+input::placeholder,textarea::placeholder {
+color: #6b7280;
+opacity: 1;
+        }
+[type='checkbox']:focus,[type='radio']:focus {
+outline: 2px solid transparent;
+outline-offset: 2px;
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 2px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: #2563eb;
+--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+        }
+[type='checkbox']:checked,[type='radio']:checked {
+border-color: transparent;
+background-color: currentColor;
+background-size: 100% 100%;
+background-position: center;
+background-repeat: no-repeat;
+        }
+[type='checkbox']:indeterminate:hover,[type='checkbox']:indeterminate:focus {
+border-color: transparent;
+background-color: currentColor;
+        }
+[type='checkbox']:checked:hover,[type='checkbox']:checked:focus,[type='radio']:checked:hover,[type='radio']:checked:focus {
+border-color: transparent;
+background-color: currentColor;
+        }
+[type='text'],[type='email'],[type='url'],[type='password'],[type='number'],[type='date'],[type='datetime-local'],[type='month'],[type='search'],[type='tel'],[type='time'],[type='week'],[multiple],textarea,select {
+appearance: none;
+background-color: #fff;
+border-color: #6b7280;
+border-width: 1px;
+border-radius: 0px;
+padding-top: 0.5rem;
+padding-right: 0.75rem;
+padding-bottom: 0.5rem;
+padding-left: 0.75rem;
+font-size: 1rem;
+line-height: 1.5rem;
+        }
+[type='text']:focus,[type='email']:focus,[type='url']:focus,[type='password']:focus,[type='number']:focus,[type='date']:focus,[type='datetime-local']:focus,[type='month']:focus,[type='search']:focus,[type='tel']:focus,[type='time']:focus,[type='week']:focus,[multiple]:focus,textarea:focus,select:focus {
+outline: 2px solid transparent;
+outline-offset: 2px;
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 0px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: #2563eb;
+--tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+--tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+border-color: #2563eb;
+        }\`}
+  />
+)
+
+;<_GlobalStyles />
+
+
+`;
+
 exports[`twin.macro pluginGapFallback.js: pluginGapFallback.js 1`] = `
 
 import tw from './macro'
@@ -12792,19 +13133,19 @@ tw\`test-2\`
 })
 ;({
   background: '5px',
-  '.a-class & .some-class': {
-    margin: '10px',
-  },
   '.a-class & > *': {
     margin: '20px',
+  },
+  '.a-class & .some-class': {
+    margin: '10px',
   },
 })
 ;({
-  '.a-class & .some-class': {
-    margin: '10px',
-  },
   '.a-class & > *': {
     margin: '20px',
+  },
+  '.a-class & .some-class': {
+    margin: '10px',
   },
 })
 
@@ -12829,96 +13170,20 @@ tw\`rich-text\`
   maxWidth: '65ch',
   fontSize: '1rem',
   lineHeight: '1.75',
-  '[class~="lead"]': {
-    color: '#4b5563',
-    fontSize: '1.25em',
-    lineHeight: '1.6',
-    marginTop: '1.2em',
-    marginBottom: '1.2em',
-  },
   a: {
     color: '#111827',
     textDecoration: 'underline',
     fontWeight: '500',
   },
-  strong: {
-    color: '#111827',
-    fontWeight: '600',
-  },
-  'ol[type="A"]': {
-    '--list-counter-style': 'upper-alpha',
-  },
-  'ol[type="a"]': {
-    '--list-counter-style': 'lower-alpha',
-  },
-  'ol[type="A s"]': {
-    '--list-counter-style': 'upper-alpha',
-  },
-  'ol[type="a s"]': {
-    '--list-counter-style': 'lower-alpha',
-  },
-  'ol[type="I"]': {
-    '--list-counter-style': 'upper-roman',
-  },
-  'ol[type="i"]': {
-    '--list-counter-style': 'lower-roman',
-  },
-  'ol[type="I s"]': {
-    '--list-counter-style': 'upper-roman',
-  },
-  'ol[type="i s"]': {
-    '--list-counter-style': 'lower-roman',
-  },
-  'ol[type="1"]': {
-    '--list-counter-style': 'decimal',
-  },
-  'ol > li': {
-    position: 'relative',
-    paddingLeft: '1.75em',
-  },
-  'ol > li::before': {
-    content: 'counter(list-item, var(--list-counter-style, decimal)) "."',
-    position: 'absolute',
-    fontWeight: '400',
-    color: '#6b7280',
-    left: '0',
-  },
-  'ul > li': {
-    position: 'relative',
-    paddingLeft: '1.75em',
-  },
-  'ul > li::before': {
-    content: '""',
-    position: 'absolute',
-    backgroundColor: '#d1d5db',
-    borderRadius: '50%',
-    width: '0.375em',
-    height: '0.375em',
-    top: 'calc(0.875em - 0.1875em)',
-    left: '0.25em',
+  p: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
   hr: {
     borderColor: '#e5e7eb',
     borderTopWidth: '1px',
     marginTop: '3em',
     marginBottom: '3em',
-  },
-  blockquote: {
-    fontWeight: '500',
-    fontStyle: 'italic',
-    color: '#111827',
-    borderLeftWidth: '0.25rem',
-    borderLeftColor: '#e5e7eb',
-    quotes: '"\\\\201C""\\\\201D""\\\\2018""\\\\2019"',
-    marginTop: '1.6em',
-    marginBottom: '1.6em',
-    paddingLeft: '1em',
-  },
-  'blockquote p:first-of-type::before': {
-    content: 'open-quote',
-  },
-  'blockquote p:last-of-type::after': {
-    content: 'close-quote',
   },
   h1: {
     color: '#111827',
@@ -12951,25 +13216,17 @@ tw\`rich-text\`
     marginBottom: '0.5em',
     lineHeight: '1.5',
   },
-  'figure figcaption': {
-    color: '#6b7280',
-    fontSize: '0.875em',
-    lineHeight: '1.4285714',
-    marginTop: '0.8571429em',
+  ol: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
-  code: {
-    color: '#111827',
-    fontWeight: '600',
-    fontSize: '0.875em',
+  ul: {
+    marginTop: '1.25em',
+    marginBottom: '1.25em',
   },
-  'code::before': {
-    content: '"\`"',
-  },
-  'code::after': {
-    content: '"\`"',
-  },
-  'a code': {
-    color: '#111827',
+  li: {
+    marginTop: '0.5em',
+    marginBottom: '0.5em',
   },
   pre: {
     color: '#e5e7eb',
@@ -12985,22 +13242,14 @@ tw\`rich-text\`
     paddingBottom: '0.8571429em',
     paddingLeft: '1.1428571em',
   },
-  'pre code': {
-    backgroundColor: 'transparent',
-    borderWidth: '0',
-    borderRadius: '0',
-    padding: '0',
-    fontWeight: '400',
-    color: 'inherit',
-    fontSize: 'inherit',
-    fontFamily: 'inherit',
-    lineHeight: 'inherit',
+  img: {
+    marginTop: '2em',
+    marginBottom: '2em',
   },
-  'pre code::before': {
-    content: 'none',
-  },
-  'pre code::after': {
-    content: 'none',
+  code: {
+    color: '#111827',
+    fontWeight: '600',
+    fontSize: '0.875em',
   },
   table: {
     width: '100%',
@@ -13017,6 +13266,58 @@ tw\`rich-text\`
     borderBottomWidth: '1px',
     borderBottomColor: '#d1d5db',
   },
+  video: {
+    marginTop: '2em',
+    marginBottom: '2em',
+  },
+  strong: {
+    color: '#111827',
+    fontWeight: '600',
+  },
+  'a code': {
+    color: '#111827',
+  },
+  figure: {
+    marginTop: '2em',
+    marginBottom: '2em',
+  },
+  'hr + *': {
+    marginTop: '0',
+  },
+  'h2 + *': {
+    marginTop: '0',
+  },
+  'h3 + *': {
+    marginTop: '0',
+  },
+  'h4 + *': {
+    marginTop: '0',
+  },
+  'ol > li': {
+    position: 'relative',
+    paddingLeft: '1.75em',
+  },
+  'ul > li': {
+    position: 'relative',
+    paddingLeft: '1.75em',
+  },
+  'h2 code': {
+    fontSize: '0.875em',
+  },
+  'h3 code': {
+    fontSize: '0.9em',
+  },
+  'pre code': {
+    backgroundColor: 'transparent',
+    borderWidth: '0',
+    borderRadius: '0',
+    padding: '0',
+    fontWeight: '400',
+    color: 'inherit',
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    lineHeight: 'inherit',
+  },
   'thead th': {
     verticalAlign: 'bottom',
     paddingRight: '0.5714286em',
@@ -13027,9 +13328,6 @@ tw\`rich-text\`
     borderBottomWidth: '1px',
     borderBottomColor: '#e5e7eb',
   },
-  'tbody tr:last-child': {
-    borderBottomWidth: '0',
-  },
   'tbody td': {
     verticalAlign: 'top',
     paddingTop: '0.5714286em',
@@ -13037,59 +13335,132 @@ tw\`rich-text\`
     paddingBottom: '0.5714286em',
     paddingLeft: '0.5714286em',
   },
-  p: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  img: {
-    marginTop: '2em',
-    marginBottom: '2em',
-  },
-  video: {
-    marginTop: '2em',
-    marginBottom: '2em',
-  },
-  figure: {
-    marginTop: '2em',
-    marginBottom: '2em',
+  blockquote: {
+    fontWeight: '500',
+    fontStyle: 'italic',
+    color: '#111827',
+    borderLeftWidth: '0.25rem',
+    borderLeftColor: '#e5e7eb',
+    quotes: '"\\\\201C""\\\\201D""\\\\2018""\\\\2019"',
+    marginTop: '1.6em',
+    marginBottom: '1.6em',
+    paddingLeft: '1em',
   },
   'figure > *': {
     marginTop: '0',
     marginBottom: '0',
   },
-  'h2 code': {
-    fontSize: '0.875em',
-  },
-  'h3 code': {
-    fontSize: '0.9em',
-  },
-  ol: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  ul: {
-    marginTop: '1.25em',
-    marginBottom: '1.25em',
-  },
-  li: {
-    marginTop: '0.5em',
-    marginBottom: '0.5em',
+  'code::after': {
+    content: '"\`"',
   },
   '> ul > li p': {
     marginTop: '0.75em',
     marginBottom: '0.75em',
   },
-  '> ul > li > *:first-child': {
-    marginTop: '1.25em',
+  'ol[type="A"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="I"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  'ol[type="1"]': {
+    '--list-counter-style': 'decimal',
+  },
+  'code::before': {
+    content: '"\`"',
+  },
+  '> :last-child': {
+    marginBottom: '0',
+  },
+  'ol[type="A s"]': {
+    '--list-counter-style': 'upper-alpha',
+  },
+  'ol[type="a s"]': {
+    '--list-counter-style': 'lower-alpha',
+  },
+  'ol[type="I s"]': {
+    '--list-counter-style': 'upper-roman',
+  },
+  'ol[type="i s"]': {
+    '--list-counter-style': 'lower-roman',
+  },
+  '> :first-child': {
+    marginTop: '0',
+  },
+  '[class~="lead"]': {
+    color: '#4b5563',
+    fontSize: '1.25em',
+    lineHeight: '1.6',
+    marginTop: '1.2em',
+    marginBottom: '1.2em',
+  },
+  'ol > li::before': {
+    content: 'counter(list-item, var(--list-counter-style, decimal)) "."',
+    position: 'absolute',
+    fontWeight: '400',
+    color: '#6b7280',
+    left: '0',
+  },
+  'ul > li::before': {
+    content: '""',
+    position: 'absolute',
+    backgroundColor: '#d1d5db',
+    borderRadius: '50%',
+    width: '0.375em',
+    height: '0.375em',
+    top: 'calc(0.875em - 0.1875em)',
+    left: '0.25em',
+  },
+  'pre code::after': {
+    content: 'none',
+  },
+  'pre code::before': {
+    content: 'none',
+  },
+  'figure figcaption': {
+    color: '#6b7280',
+    fontSize: '0.875em',
+    lineHeight: '1.4285714',
+    marginTop: '0.8571429em',
+  },
+  'tbody tr:last-child': {
+    borderBottomWidth: '0',
+  },
+  'thead th:last-child': {
+    paddingRight: '0',
+  },
+  'tbody td:last-child': {
+    paddingRight: '0',
+  },
+  'thead th:first-child': {
+    paddingLeft: '0',
+  },
+  'tbody td:first-child': {
+    paddingLeft: '0',
   },
   '> ul > li > *:last-child': {
     marginBottom: '1.25em',
   },
+  '> ol > li > *:last-child': {
+    marginBottom: '1.25em',
+  },
+  '> ul > li > *:first-child': {
+    marginTop: '1.25em',
+  },
   '> ol > li > *:first-child': {
     marginTop: '1.25em',
   },
-  '> ol > li > *:last-child': {
-    marginBottom: '1.25em',
+  'blockquote p:last-of-type::after': {
+    content: 'close-quote',
+  },
+  'blockquote p:first-of-type::before': {
+    content: 'open-quote',
   },
   'ul ul': {
     marginTop: '0.75em',
@@ -13107,53 +13478,12 @@ tw\`rich-text\`
     marginTop: '0.75em',
     marginBottom: '0.75em',
   },
-  'hr + *': {
-    marginTop: '0',
-  },
-  'h2 + *': {
-    marginTop: '0',
-  },
-  'h3 + *': {
-    marginTop: '0',
-  },
-  'h4 + *': {
-    marginTop: '0',
-  },
-  'thead th:first-child': {
-    paddingLeft: '0',
-  },
-  'thead th:last-child': {
-    paddingRight: '0',
-  },
-  'tbody td:first-child': {
-    paddingLeft: '0',
-  },
-  'tbody td:last-child': {
-    paddingRight: '0',
-  },
-  '> :first-child': {
-    marginTop: '0',
-  },
-  '> :last-child': {
-    marginBottom: '0',
-  },
   '@media (min-width: 640px)': {
     fontSize: '0.875rem',
     lineHeight: '1.7142857',
     p: {
       marginTop: '1.1428571em',
       marginBottom: '1.1428571em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2857143em',
-      lineHeight: '1.5555556',
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
-    },
-    blockquote: {
-      marginTop: '1.3333333em',
-      marginBottom: '1.3333333em',
-      paddingLeft: '1.1111111em',
     },
     h1: {
       fontSize: '2.1428571em',
@@ -13178,47 +13508,6 @@ tw\`rich-text\`
       marginBottom: '0.5714286em',
       lineHeight: '1.4285714',
     },
-    img: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    video: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    figure: {
-      marginTop: '1.7142857em',
-      marginBottom: '1.7142857em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.8571429em',
-      lineHeight: '1.3333333',
-      marginTop: '0.6666667em',
-    },
-    code: {
-      fontSize: '0.8571429em',
-    },
-    'h2 code': {
-      fontSize: '0.9em',
-    },
-    'h3 code': {
-      fontSize: '0.8888889em',
-    },
-    pre: {
-      fontSize: '0.8571429em',
-      lineHeight: '1.6666667',
-      marginTop: '1.6666667em',
-      marginBottom: '1.6666667em',
-      borderRadius: '0.25rem',
-      paddingTop: '0.6666667em',
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
     ol: {
       marginTop: '1.1428571em',
       marginBottom: '1.1428571em',
@@ -13231,14 +13520,102 @@ tw\`rich-text\`
       marginTop: '0.2857143em',
       marginBottom: '0.2857143em',
     },
+    hr: {
+      marginTop: '2.8571429em',
+      marginBottom: '2.8571429em',
+    },
+    img: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    pre: {
+      fontSize: '0.8571429em',
+      lineHeight: '1.6666667',
+      marginTop: '1.6666667em',
+      marginBottom: '1.6666667em',
+      borderRadius: '0.25rem',
+      paddingTop: '0.6666667em',
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    code: {
+      fontSize: '0.8571429em',
+    },
+    video: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    table: {
+      fontSize: '0.8571429em',
+      lineHeight: '1.5',
+    },
+    figure: {
+      marginTop: '1.7142857em',
+      marginBottom: '1.7142857em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    'h2 code': {
+      fontSize: '0.9em',
+    },
+    'h3 code': {
+      fontSize: '0.8888889em',
+    },
     'ol > li': {
       paddingLeft: '1.5714286em',
     },
-    'ol > li::before': {
-      left: '0',
-    },
     'ul > li': {
       paddingLeft: '1.5714286em',
+    },
+    'thead th': {
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    'tbody td': {
+      paddingTop: '0.6666667em',
+      paddingRight: '1em',
+      paddingBottom: '0.6666667em',
+      paddingLeft: '1em',
+    },
+    blockquote: {
+      marginTop: '1.3333333em',
+      marginBottom: '1.3333333em',
+      paddingLeft: '1.1111111em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    '> ul > li p': {
+      marginTop: '0.5714286em',
+      marginBottom: '0.5714286em',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2857143em',
+      lineHeight: '1.5555556',
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    'ol > li::before': {
+      left: '0',
     },
     'ul > li::before': {
       height: '0.3571429em',
@@ -13246,21 +13623,34 @@ tw\`rich-text\`
       top: 'calc(0.8571429em - 0.1785714em)',
       left: '0.2142857em',
     },
-    '> ul > li p': {
-      marginTop: '0.5714286em',
-      marginBottom: '0.5714286em',
+    'figure figcaption': {
+      fontSize: '0.8571429em',
+      lineHeight: '1.3333333',
+      marginTop: '0.6666667em',
     },
-    '> ul > li > *:first-child': {
-      marginTop: '1.1428571em',
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
     },
     '> ul > li > *:last-child': {
       marginBottom: '1.1428571em',
     },
-    '> ol > li > *:first-child': {
-      marginTop: '1.1428571em',
-    },
     '> ol > li > *:last-child': {
       marginBottom: '1.1428571em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.1428571em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.1428571em',
     },
     'ul ul': {
       marginTop: '0.5714286em',
@@ -13278,55 +13668,6 @@ tw\`rich-text\`
       marginTop: '0.5714286em',
       marginBottom: '0.5714286em',
     },
-    hr: {
-      marginTop: '2.8571429em',
-      marginBottom: '2.8571429em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.8571429em',
-      lineHeight: '1.5',
-    },
-    'thead th': {
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.6666667em',
-      paddingRight: '1em',
-      paddingBottom: '0.6666667em',
-      paddingLeft: '1em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
-    },
   },
   '@media (min-width: 1024px)': {
     fontSize: '1.125rem',
@@ -13334,17 +13675,6 @@ tw\`rich-text\`
     p: {
       marginTop: '1.3333333em',
       marginBottom: '1.3333333em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2222222em',
-      lineHeight: '1.4545455',
-      marginTop: '1.0909091em',
-      marginBottom: '1.0909091em',
-    },
-    blockquote: {
-      marginTop: '1.6666667em',
-      marginBottom: '1.6666667em',
-      paddingLeft: '1em',
     },
     h1: {
       fontSize: '2.6666667em',
@@ -13369,47 +13699,6 @@ tw\`rich-text\`
       marginBottom: '0.4444444em',
       lineHeight: '1.5555556',
     },
-    img: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    video: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    figure: {
-      marginTop: '1.7777778em',
-      marginBottom: '1.7777778em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.8888889em',
-      lineHeight: '1.5',
-      marginTop: '1em',
-    },
-    code: {
-      fontSize: '0.8888889em',
-    },
-    'h2 code': {
-      fontSize: '0.8666667em',
-    },
-    'h3 code': {
-      fontSize: '0.875em',
-    },
-    pre: {
-      fontSize: '0.8888889em',
-      lineHeight: '1.75',
-      marginTop: '2em',
-      marginBottom: '2em',
-      borderRadius: '0.375rem',
-      paddingTop: '1em',
-      paddingRight: '1.5em',
-      paddingBottom: '1em',
-      paddingLeft: '1.5em',
-    },
     ol: {
       marginTop: '1.3333333em',
       marginBottom: '1.3333333em',
@@ -13422,14 +13711,102 @@ tw\`rich-text\`
       marginTop: '0.6666667em',
       marginBottom: '0.6666667em',
     },
+    hr: {
+      marginTop: '3.1111111em',
+      marginBottom: '3.1111111em',
+    },
+    img: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    pre: {
+      fontSize: '0.8888889em',
+      lineHeight: '1.75',
+      marginTop: '2em',
+      marginBottom: '2em',
+      borderRadius: '0.375rem',
+      paddingTop: '1em',
+      paddingRight: '1.5em',
+      paddingBottom: '1em',
+      paddingLeft: '1.5em',
+    },
+    code: {
+      fontSize: '0.8888889em',
+    },
+    video: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    table: {
+      fontSize: '0.8888889em',
+      lineHeight: '1.5',
+    },
+    figure: {
+      marginTop: '1.7777778em',
+      marginBottom: '1.7777778em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    'h2 code': {
+      fontSize: '0.8666667em',
+    },
+    'h3 code': {
+      fontSize: '0.875em',
+    },
     'ol > li': {
       paddingLeft: '1.6666667em',
     },
-    'ol > li::before': {
-      left: '0',
-    },
     'ul > li': {
       paddingLeft: '1.6666667em',
+    },
+    'thead th': {
+      paddingRight: '0.75em',
+      paddingBottom: '0.75em',
+      paddingLeft: '0.75em',
+    },
+    'tbody td': {
+      paddingTop: '0.75em',
+      paddingRight: '0.75em',
+      paddingBottom: '0.75em',
+      paddingLeft: '0.75em',
+    },
+    blockquote: {
+      marginTop: '1.6666667em',
+      marginBottom: '1.6666667em',
+      paddingLeft: '1em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    '> ul > li p': {
+      marginTop: '0.8888889em',
+      marginBottom: '0.8888889em',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2222222em',
+      lineHeight: '1.4545455',
+      marginTop: '1.0909091em',
+      marginBottom: '1.0909091em',
+    },
+    'ol > li::before': {
+      left: '0',
     },
     'ul > li::before': {
       width: '0.3333333em',
@@ -13437,21 +13814,34 @@ tw\`rich-text\`
       top: 'calc(0.8888889em - 0.1666667em)',
       left: '0.2222222em',
     },
-    '> ul > li p': {
-      marginTop: '0.8888889em',
-      marginBottom: '0.8888889em',
+    'figure figcaption': {
+      fontSize: '0.8888889em',
+      lineHeight: '1.5',
+      marginTop: '1em',
     },
-    '> ul > li > *:first-child': {
-      marginTop: '1.3333333em',
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
     },
     '> ul > li > *:last-child': {
       marginBottom: '1.3333333em',
     },
-    '> ol > li > *:first-child': {
-      marginTop: '1.3333333em',
-    },
     '> ol > li > *:last-child': {
       marginBottom: '1.3333333em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.3333333em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.3333333em',
     },
     'ul ul': {
       marginTop: '0.8888889em',
@@ -13469,55 +13859,6 @@ tw\`rich-text\`
       marginTop: '0.8888889em',
       marginBottom: '0.8888889em',
     },
-    hr: {
-      marginTop: '3.1111111em',
-      marginBottom: '3.1111111em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.8888889em',
-      lineHeight: '1.5',
-    },
-    'thead th': {
-      paddingRight: '0.75em',
-      paddingBottom: '0.75em',
-      paddingLeft: '0.75em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.75em',
-      paddingRight: '0.75em',
-      paddingBottom: '0.75em',
-      paddingLeft: '0.75em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
-    },
   },
   '@media (min-width: 1280px)': {
     fontSize: '1.25rem',
@@ -13525,17 +13866,6 @@ tw\`rich-text\`
     p: {
       marginTop: '1.2em',
       marginBottom: '1.2em',
-    },
-    '[class~="lead"]': {
-      fontSize: '1.2em',
-      lineHeight: '1.5',
-      marginTop: '1em',
-      marginBottom: '1em',
-    },
-    blockquote: {
-      marginTop: '1.6em',
-      marginBottom: '1.6em',
-      paddingLeft: '1.0666667em',
     },
     h1: {
       fontSize: '2.8em',
@@ -13560,47 +13890,6 @@ tw\`rich-text\`
       marginBottom: '0.6em',
       lineHeight: '1.6',
     },
-    img: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    video: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    figure: {
-      marginTop: '2em',
-      marginBottom: '2em',
-    },
-    'figure > *': {
-      marginTop: '0',
-      marginBottom: '0',
-    },
-    'figure figcaption': {
-      fontSize: '0.9em',
-      lineHeight: '1.5555556',
-      marginTop: '1em',
-    },
-    code: {
-      fontSize: '0.9em',
-    },
-    'h2 code': {
-      fontSize: '0.8611111em',
-    },
-    'h3 code': {
-      fontSize: '0.9em',
-    },
-    pre: {
-      fontSize: '0.9em',
-      lineHeight: '1.7777778',
-      marginTop: '2em',
-      marginBottom: '2em',
-      borderRadius: '0.5rem',
-      paddingTop: '1.1111111em',
-      paddingRight: '1.3333333em',
-      paddingBottom: '1.1111111em',
-      paddingLeft: '1.3333333em',
-    },
     ol: {
       marginTop: '1.2em',
       marginBottom: '1.2em',
@@ -13613,14 +13902,102 @@ tw\`rich-text\`
       marginTop: '0.6em',
       marginBottom: '0.6em',
     },
+    hr: {
+      marginTop: '2.8em',
+      marginBottom: '2.8em',
+    },
+    img: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    pre: {
+      fontSize: '0.9em',
+      lineHeight: '1.7777778',
+      marginTop: '2em',
+      marginBottom: '2em',
+      borderRadius: '0.5rem',
+      paddingTop: '1.1111111em',
+      paddingRight: '1.3333333em',
+      paddingBottom: '1.1111111em',
+      paddingLeft: '1.3333333em',
+    },
+    code: {
+      fontSize: '0.9em',
+    },
+    video: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    table: {
+      fontSize: '0.9em',
+      lineHeight: '1.5555556',
+    },
+    figure: {
+      marginTop: '2em',
+      marginBottom: '2em',
+    },
+    'hr + *': {
+      marginTop: '0',
+    },
+    'h2 + *': {
+      marginTop: '0',
+    },
+    'h3 + *': {
+      marginTop: '0',
+    },
+    'h4 + *': {
+      marginTop: '0',
+    },
+    'h2 code': {
+      fontSize: '0.8611111em',
+    },
+    'h3 code': {
+      fontSize: '0.9em',
+    },
     'ol > li': {
       paddingLeft: '1.8em',
     },
-    'ol > li::before': {
-      left: '0',
-    },
     'ul > li': {
       paddingLeft: '1.8em',
+    },
+    'thead th': {
+      paddingRight: '0.6666667em',
+      paddingBottom: '0.8888889em',
+      paddingLeft: '0.6666667em',
+    },
+    'tbody td': {
+      paddingTop: '0.8888889em',
+      paddingRight: '0.6666667em',
+      paddingBottom: '0.8888889em',
+      paddingLeft: '0.6666667em',
+    },
+    blockquote: {
+      marginTop: '1.6em',
+      marginBottom: '1.6em',
+      paddingLeft: '1.0666667em',
+    },
+    'figure > *': {
+      marginTop: '0',
+      marginBottom: '0',
+    },
+    '> ul > li p': {
+      marginTop: '0.8em',
+      marginBottom: '0.8em',
+    },
+    '> :last-child': {
+      marginBottom: '0',
+    },
+    '> :first-child': {
+      marginTop: '0',
+    },
+    '[class~="lead"]': {
+      fontSize: '1.2em',
+      lineHeight: '1.5',
+      marginTop: '1em',
+      marginBottom: '1em',
+    },
+    'ol > li::before': {
+      left: '0',
     },
     'ul > li::before': {
       width: '0.35em',
@@ -13628,21 +14005,34 @@ tw\`rich-text\`
       top: 'calc(0.9em - 0.175em)',
       left: '0.25em',
     },
-    '> ul > li p': {
-      marginTop: '0.8em',
-      marginBottom: '0.8em',
+    'figure figcaption': {
+      fontSize: '0.9em',
+      lineHeight: '1.5555556',
+      marginTop: '1em',
     },
-    '> ul > li > *:first-child': {
-      marginTop: '1.2em',
+    'thead th:last-child': {
+      paddingRight: '0',
+    },
+    'tbody td:last-child': {
+      paddingRight: '0',
+    },
+    'thead th:first-child': {
+      paddingLeft: '0',
+    },
+    'tbody td:first-child': {
+      paddingLeft: '0',
     },
     '> ul > li > *:last-child': {
       marginBottom: '1.2em',
     },
-    '> ol > li > *:first-child': {
-      marginTop: '1.2em',
-    },
     '> ol > li > *:last-child': {
       marginBottom: '1.2em',
+    },
+    '> ul > li > *:first-child': {
+      marginTop: '1.2em',
+    },
+    '> ol > li > *:first-child': {
+      marginTop: '1.2em',
     },
     'ul ul': {
       marginTop: '0.8em',
@@ -13660,55 +14050,6 @@ tw\`rich-text\`
       marginTop: '0.8em',
       marginBottom: '0.8em',
     },
-    hr: {
-      marginTop: '2.8em',
-      marginBottom: '2.8em',
-    },
-    'hr + *': {
-      marginTop: '0',
-    },
-    'h2 + *': {
-      marginTop: '0',
-    },
-    'h3 + *': {
-      marginTop: '0',
-    },
-    'h4 + *': {
-      marginTop: '0',
-    },
-    table: {
-      fontSize: '0.9em',
-      lineHeight: '1.5555556',
-    },
-    'thead th': {
-      paddingRight: '0.6666667em',
-      paddingBottom: '0.8888889em',
-      paddingLeft: '0.6666667em',
-    },
-    'thead th:first-child': {
-      paddingLeft: '0',
-    },
-    'thead th:last-child': {
-      paddingRight: '0',
-    },
-    'tbody td': {
-      paddingTop: '0.8888889em',
-      paddingRight: '0.6666667em',
-      paddingBottom: '0.8888889em',
-      paddingLeft: '0.6666667em',
-    },
-    'tbody td:first-child': {
-      paddingLeft: '0',
-    },
-    'tbody td:last-child': {
-      paddingRight: '0',
-    },
-    '> :first-child': {
-      marginTop: '0',
-    },
-    '> :last-child': {
-      marginBottom: '0',
-    },
   },
 }) // From tailwindcss-typography
 
@@ -13716,19 +14057,32 @@ tw\`rich-text\`
   fontWeight: '400',
   fontSize: '1rem',
   lineHeight: '1.625',
-  '> * + *': {
-    marginTop: '1em',
+  a: {
+    fontWeight: '700',
+    color: '#60a5fa',
   },
   h1: {
     fontWeight: '700',
     fontSize: '3rem',
   },
+  '> * + *': {
+    marginTop: '1em',
+  },
+  'a:active': {},
   'h1 lineHeight': {
     lineHeight: '1',
   },
-  a: {
+  i: {
+    fontStyle: 'italic',
+  },
+  em: {
+    fontStyle: 'italic',
+  },
+  b: {
     fontWeight: '700',
-    color: '#60a5fa',
+  },
+  strong: {
+    fontWeight: '700',
   },
   'a:hover': {
     color: '#2563eb',
@@ -13737,19 +14091,6 @@ tw\`rich-text\`
   'a:focus': {
     color: '#2563eb',
     textDecoration: 'underline',
-  },
-  'a:active': {},
-  b: {
-    fontWeight: '700',
-  },
-  strong: {
-    fontWeight: '700',
-  },
-  i: {
-    fontStyle: 'italic',
-  },
-  em: {
-    fontStyle: 'italic',
   },
   '@media (min-width: 640px)': {
     h1: {
@@ -13952,22 +14293,22 @@ import tw from './macro'
 ;<div
   css={{
     background: '5px',
-    '.a-class & .some-class': {
-      margin: '10px',
-    },
     '.a-class & > *': {
       margin: '20px',
+    },
+    '.a-class & .some-class': {
+      margin: '10px',
     },
   }}
   data-tw="tw-test-1"
 />
 ;<div
   css={{
-    '.a-class & .some-class': {
-      margin: '10px',
-    },
     '.a-class & > *': {
       margin: '20px',
+    },
+    '.a-class & .some-class': {
+      margin: '10px',
     },
   }}
   data-tw="tw-test-2"
@@ -20718,7 +21059,7 @@ tw\`mt-5 md:(ml-5 ease-in transition) mb-5\`
 })
 ;({
   transitionProperty:
-    'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
+    'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter',
   transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)',
   transitionDuration: '150ms',
 })
@@ -20809,7 +21150,7 @@ tw\`mt-5 md:(ml-5 ease-in transition) mb-5\`
 
 ;({
   transitionProperty:
-    'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
+    'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter',
   transitionTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
   transitionDuration: '75ms',
 })
@@ -20818,7 +21159,7 @@ tw\`mt-5 md:(ml-5 ease-in transition) mb-5\`
   marginBottom: '1.25rem',
   '@media (min-width: 768px)': {
     transitionProperty:
-      'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
+      'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter',
     transitionTimingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
     transitionDuration: '150ms',
     marginLeft: '1.25rem',
@@ -22504,6 +22845,45 @@ tw\`break-all\`
 })
 ;({
   wordBreak: 'break-all',
+})
+
+
+`;
+
+exports[`twin.macro userPluginOrdering.js: userPluginOrdering.js 1`] = `
+
+import tw from './macro'
+
+tw\`selector\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  margin: '1px',
+  padding: 'padding',
+  display: 'block',
+  content: '.selector',
+  ':hover': {
+    content: '.selector:hover',
+  },
+  '.selector2': {
+    content: '.selector .selector2',
+  },
+  ':hover .selector3': {
+    content: '.selector:hover .selector3',
+  },
+  '@media (min-width: 2px)': {
+    content: '.selector @media',
+  },
+  '@media (min-width: 1px)': {
+    content: '@media .selector',
+    ':hover .selector2': {
+      content: '.selector:hover @media .selector',
+    },
+    '.selector3': {
+      content: '.selector:hover @media .selector3',
+    },
+  },
 })
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -699,52 +699,11 @@
       }
     },
     "@fullhuman/postcss-purgecss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.0.0.tgz",
-      "integrity": "sha512-cvuOgMwIVlfgWcUMqg5p33NbGUxLwMrKtDKkm3QRfOo4PRVNR6+y/xd9OyXTVZiB1bIpKNJ0ZObYPWD3DRQDtw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz",
+      "integrity": "sha512-kwOXw8fZ0Lt1QmeOOrd+o4Ibvp4UTEBFQbzvWldjlKv5n+G9sXfIPn1hh63IQIL8K8vbvv1oYMJiIUbuy9bGaA==",
       "requires": {
-        "postcss": "7.0.32",
-        "purgecss": "^3.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "purgecss": "^3.1.3"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -1039,7 +998,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
@@ -1048,14 +1006,12 @@
     "@nodelib/fs.stat": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
-      "dev": true
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
@@ -1095,9 +1051,9 @@
       }
     },
     "@tailwindcss/forms": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.2.1.tgz",
-      "integrity": "sha512-czfvEdY+J2Ogfd6RUSr/ZSUmDxTujr34M++YLnp2cCPC3oJ4kFvFMaRXA6cEXKw7F1hJuapdjXRjsXIEXGgORg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.3.2.tgz",
+      "integrity": "sha512-aj2/rJsGb2whAZ/BQWHWWQRSbhH0r/l1ozOByiv+ZNjBD84GMvb5dhAyfpeasFky+EJrAwX5eaqft8NQMZFWvA==",
       "dev": true,
       "requires": {
         "mini-svg-data-uri": "^1.2.3"
@@ -1560,7 +1516,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2106,8 +2061,7 @@
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
     "bl": {
       "version": "4.0.2",
@@ -2225,7 +2179,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -2904,8 +2857,7 @@
     "commander": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-      "dev": true
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "compare-versions": {
       "version": "3.6.0",
@@ -3740,6 +3692,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -4913,7 +4870,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
       "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -4961,7 +4917,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -5071,14 +5026,14 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       },
       "dependencies": {
         "jsonfile": {
@@ -5088,19 +5043,12 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-            }
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
       }
     },
@@ -5287,7 +5235,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -5297,7 +5244,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
           "requires": {
             "is-glob": "^2.0.0"
           }
@@ -5305,14 +5251,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -5323,7 +5267,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -5996,7 +5939,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -6040,6 +5982,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
       "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -6105,8 +6048,7 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
@@ -6126,8 +6068,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -6145,7 +6086,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -6181,8 +6121,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -7625,6 +7564,11 @@
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
+    "lodash.topath": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
+      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -7875,8 +7819,7 @@
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "microbundle": {
       "version": "0.11.0",
@@ -7936,7 +7879,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
@@ -8238,8 +8180,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -8352,9 +8293,9 @@
       }
     },
     "object-hash": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
-      "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
+      "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -8585,7 +8526,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -8596,14 +8536,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -8669,8 +8607,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "2.3.0",
@@ -9345,19 +9282,6 @@
       "requires": {
         "camelcase-css": "^2.0.1",
         "postcss": "^8.1.6"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.1.8",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.8.tgz",
-          "integrity": "sha512-hO6jFWBy0QnBBRaw+s0F4hVPKGDICec/nLNEG1D4qqw9/LBzWMkTjckqqELXAo0J42jN8GFZXtgQfezEaoG9gQ==",
-          "requires": {
-            "colorette": "^1.2.1",
-            "line-column": "^1.0.2",
-            "nanoid": "^3.1.16",
-            "source-map": "^0.6.1"
-          }
-        }
       }
     },
     "postcss-load-config": {
@@ -10165,9 +10089,9 @@
       }
     },
     "postcss-nested": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.1.tgz",
-      "integrity": "sha512-ZHNSAoHrMtbEzjq+Qs4R0gHijpXc6F1YUv4TGmGaz7rtfMvVJBbu5hMOH+CrhEaljQpEmx5N/P8i1pXTkbVAmg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.5.tgz",
+      "integrity": "sha512-GSRXYz5bccobpTzLQZXOnSOfKl6TwVr5CyAQJUPub4nuRJSOECK5AqurxVgmtxP48p0Kc/ndY/YyS1yqldX0Ew==",
       "requires": {
         "postcss-selector-parser": "^6.0.4"
       },
@@ -11399,57 +11323,34 @@
       }
     },
     "purgecss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.0.0.tgz",
-      "integrity": "sha512-t3FGCwyX9XWV3ffvnAXTw6Y3Z9kNlcgm14VImNK66xKi5sdqxSA2I0SFYxtmZbAKuIZVckPdazw5iKL/oY/2TA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.1.3.tgz",
+      "integrity": "sha512-hRSLN9mguJ2lzlIQtW4qmPS2kh6oMnA9RxdIYK8sz18QYqd6ePp4GNDl18oWHA1f2v2NEQIh51CO8s/E3YGckQ==",
       "requires": {
         "commander": "^6.0.0",
         "glob": "^7.0.0",
-        "postcss": "7.0.32",
+        "postcss": "^8.2.1",
         "postcss-selector-parser": "^6.0.2"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
         },
-        "commander": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+        "nanoid": {
+          "version": "3.1.22",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+          "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
         },
         "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+          "version": "8.2.10",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
+          "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.22",
+            "source-map": "^0.6.1"
           }
         }
       }
@@ -11475,6 +11376,11 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "randomatic": {
       "version": "3.1.1",
@@ -11582,15 +11488,14 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
       "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
     },
     "reduce-css-calc": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.7.tgz",
-      "integrity": "sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
       "requires": {
         "css-unit-converter": "^1.1.1",
         "postcss-value-parser": "^3.3.0"
@@ -11931,8 +11836,7 @@
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rgb-regex": {
       "version": "1.0.1",
@@ -13952,8 +13856,7 @@
     "run-parallel": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "dev": true
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
     "rxjs": {
       "version": "6.6.3",
@@ -15074,54 +14977,85 @@
       }
     },
     "tailwindcss": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.0.1.tgz",
-      "integrity": "sha512-57G3jdcVBWTPkHCNSAfDAo1Qp2Nkr4H6WnLD0luNFh1td+KwQp9FOVcqj0SYBH6qwVQJawzT+0/zLxzKmyznGw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.1.0.tgz",
+      "integrity": "sha512-3tsoLMOrFvwrm0VRx2Hr3cRJ158Sd/KH9BwKg5xyS96yiR/0frQBCfUbXvNsa2hxzViGN4nSWJqzBWDQb4jOSA==",
       "requires": {
-        "@fullhuman/postcss-purgecss": "^3.0.0",
+        "@fullhuman/postcss-purgecss": "^3.1.3",
         "bytes": "^3.0.0",
         "chalk": "^4.1.0",
+        "chokidar": "^3.5.1",
         "color": "^3.1.3",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.1",
-        "fs-extra": "^9.0.1",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.5",
+        "fs-extra": "^9.1.0",
         "html-tags": "^3.1.0",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
+        "lodash.topath": "^4.5.2",
         "modern-normalize": "^1.0.0",
         "node-emoji": "^1.8.1",
-        "object-hash": "^2.0.3",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.1.1",
+        "parse-glob": "^3.0.4",
         "postcss-functions": "^3",
         "postcss-js": "^3.0.3",
-        "postcss-nested": "^5.0.1",
+        "postcss-nested": "5.0.5",
         "postcss-selector-parser": "^6.0.4",
         "postcss-value-parser": "^4.1.0",
         "pretty-hrtime": "^1.0.3",
-        "reduce-css-calc": "^2.1.6",
-        "resolve": "^1.19.0"
+        "quick-lru": "^5.1.1",
+        "reduce-css-calc": "^2.1.8",
+        "resolve": "^1.20.0"
       },
       "dependencies": {
-        "color": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-          "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+        "chokidar": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.4"
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
           }
         },
-        "color-string": {
-          "version": "1.5.4",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-          "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "optional": true
+        },
+        "is-core-module": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+          "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+          "requires": {
+            "has": "^1.0.3"
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "postcss-selector-parser": {
           "version": "6.0.4",
@@ -15135,11 +15069,11 @@
           }
         },
         "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
           "requires": {
-            "is-core-module": "^2.1.0",
+            "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -15336,7 +15270,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
     "lodash.merge": "^4.6.2",
     "postcss": "^8.1.8",
     "string-similarity": "^4.0.3",
-    "tailwindcss": "^2.0.1",
+    "tailwindcss": "^2.1.0",
     "timsort": "^0.3.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.12.1",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
-    "@tailwindcss/forms": "^0.2.1",
+    "@tailwindcss/forms": "^0.3.2",
     "@tailwindcss/typography": "^0.4.0",
     "@types/react": "^17.0.0",
     "@types/styled-components": "^5.1.4",

--- a/src/handlers/userPlugins.js
+++ b/src/handlers/userPlugins.js
@@ -1,18 +1,6 @@
 import { isEmpty } from './../utils'
 import { splitPrefix } from './../prefix'
 
-const reorderAtRules = className =>
-  className &&
-  Object.entries(className)
-    .sort((a, b) => {
-      const [aKey] = a
-      const [bKey] = b
-      const A = aKey.startsWith('@') ? 1 : 0
-      const B = bKey.startsWith('@') ? 1 : 0
-      return B > A ? -1 : 0
-    })
-    .reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
-
 // If these tasks return true then the rule is matched
 const mergeChecks = [
   // Match exact selector
@@ -118,5 +106,5 @@ export default ({
     result = hasMatches ? matches : result
     return hasMatches
   })
-  return reorderAtRules(result)
+  return result
 }

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -100,29 +100,62 @@ const buildDeclaration = items => {
   )
 }
 
-const getUserPluginRules = (rules, screens, isBase) =>
-  rules.reduce((result, rule) => {
-    // Build the media queries
-    if (rule.type === 'atrule') {
-      // Remove a bunch of nodes that tailwind uses for limiting rule generation
-      // https://github.com/tailwindlabs/tailwindcss/commit/b69e46cc1b32608d779dad35121077b48089485d#diff-808341f38c6f7093a7979961a53f5922R20
-      if (['layer', 'variants', 'responsive'].includes(rule.name)) {
-        return deepMerge(
-          result,
-          ...getUserPluginRules(rule.nodes, screens, isBase)
-        )
-      }
+const ruleSorter = arr => {
+  if (!Array.isArray(arr) || arr.length === 0) return []
 
-      const atSelector = buildAtSelector(rule.name, rule.params, screens)
+  arr
+    // Tailwind supplies the classes reversed since 2.0.x
+    .reverse()
+    // Tailwind also messes up the ordering so classes need to be resorted
+    // Order selectors by length (don't know of a better way)
+    .sort((a, b) => {
+      const selectorA = a.selector ? a.selector.length : 0
+      const selectorB = b.selector ? b.selector.length : 0
+      return selectorA - selectorB
+    })
+    // Place at rules at the end '@media' etc
+    .sort((a, b) => {
+      const atRuleA = a.type === 'atrule'
+      const atRuleB = b.type === 'atrule'
+      return atRuleA - atRuleB
+    })
+    // Traverse children and reorder aswell
+    .forEach(item => {
+      if (!item.nodes || item.nodes.length === 0) return
 
-      return deepMerge(result, {
-        [atSelector]: getUserPluginRules(rule.nodes, screens, isBase),
+      item.nodes.forEach(i => {
+        if (typeof i !== 'object') return
+
+        return ruleSorter(i)
       })
+    })
+
+  return arr
+}
+
+const getUserPluginRules = (rules, screens, isBase) =>
+  ruleSorter(rules).reduce((result, rule) => {
+    // Build the media queries
+    if (rule.type !== 'atrule') {
+      const builtRules = getBuiltRules(rule, { isBase })
+
+      return deepMerge(result, builtRules)
     }
 
-    const builtRules = getBuiltRules(rule, { isBase })
+    // Remove a bunch of nodes that tailwind uses for limiting rule generation
+    // https://github.com/tailwindlabs/tailwindcss/commit/b69e46cc1b32608d779dad35121077b48089485d#diff-808341f38c6f7093a7979961a53f5922R20
+    if (['layer', 'variants', 'responsive'].includes(rule.name)) {
+      return deepMerge(
+        result,
+        ...getUserPluginRules(rule.nodes, screens, isBase)
+      )
+    }
 
-    return deepMerge(result, builtRules)
+    const atSelector = buildAtSelector(rule.name, rule.params, screens)
+
+    return deepMerge(result, {
+      [atSelector]: getUserPluginRules(rule.nodes, screens, isBase),
+    })
   }, {})
 
 const getUserPluginData = ({ config }) => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,11 +21,6 @@ module.exports = {
         xl: '7rem',
       },
     },
-    fluidContainer: {
-      DEFAULT: '10%',
-      small: '25%',
-      large: '75%',
-    },
     aspectRatio: {
       2: '2',
       4: '4',
@@ -86,11 +81,9 @@ module.exports = {
     addUtilitiesTest,
     addUtilitiesTest2,
     addComponentsTest,
-    fluidContainer,
     addComponentsTestElementPrefixes,
     addComponentsTestElementScreenReplacements,
     addComponentsTestCssVariableAsRuleProperty,
-    require('@tailwindcss/forms'),
     pluginBaseSelectors,
     baseSelectorTest,
   ],
@@ -144,66 +137,6 @@ function addComponentsTest({ addComponents }) {
   }
 
   addComponents(buttons)
-}
-
-function fluidContainer({ addComponents, theme }) {
-  const styles = [
-    {
-      '.fluid-container': {
-        marginLeft: 'auto',
-        marginRight: 'auto',
-        width: theme('fluidContainer.default', '100%'),
-      },
-    },
-    {
-      '.fluid-container:focus': {
-        marginLeft: '10rem',
-        marginRight: '11rem',
-        width: theme('fluidContainer.default', '100%'),
-      },
-    },
-    {
-      '.not-container': {
-        content: 'not-container',
-      },
-    },
-    {
-      '@media (min-width: 1440px)': {
-        '.fluid-container': {
-          display: 'block',
-        },
-      },
-    },
-    {
-      '@media (min-width: 768px)': {
-        '.fluid-container:hover': {
-          width: theme('fluidContainer.small', '100%'),
-        },
-        '.not-fluid-container': {
-          content: 'not-fluid-container:focus',
-        },
-        '.fluid-container:focus': {
-          marginLeft: 'auto',
-          marginRight: 'auto',
-          width: theme('fluidContainer.default', '100%'),
-        },
-      },
-    },
-    {
-      '.fluid-container': {
-        '@media (min-width: 1440px)': {
-          width: theme('fluidContainer.large', '100%'),
-          backgroundColor: 'black',
-        },
-        '@media only screen and (max-width: 540px)': {
-          width: '33%',
-          backgroundColor: 'red',
-        },
-      },
-    },
-  ]
-
-  addComponents(styles)
 }
 
 function addComponentsTestElementPrefixes({ addComponents }) {


### PR DESCRIPTION
After updating twin to tailwind@2.1.0 and rerunning tests I found that tailwind no longer supplies data from the user plugins in the same order. I believe this was due to an update in postcss rather than tailwind - either way I had to reorder the plugin data.

The ordering is now:

1. Base styles
2. Sub selectors - sorted by length
3. At rules - sorted by order specified

I've tested the new ordering working with the latest official tailwind typography and form plugins.