### PR TITLE
Color functions + Deeply nested classes

### DIFF
--- a/__fixtures__/!config.js
+++ b/__fixtures__/!config.js
@@ -12,6 +12,7 @@ tw`text-mycolors-a-number`
 tw`text-mycolors-array`
 tw`text-my-blue-100`
 tw`text-color-opacity`
+tw`text-color-deep-config-500`
 
 tw`bg-number`
 tw`bg-purple-hyphen`
@@ -21,3 +22,4 @@ tw`bg-mycolors-a-number`
 tw`bg-mycolors-array`
 tw`bg-my-blue-100`
 tw`bg-color-opacity`
+tw`bg-color-deep-config-500`

--- a/__fixtures__/colorFunctions/colorFunctions.js
+++ b/__fixtures__/colorFunctions/colorFunctions.js
@@ -1,0 +1,5 @@
+import tw, { GlobalStyles } from './macro' // twinImport
+
+tw`text-foreground text-opacity-40`
+tw`text-gray-300`
+;<GlobalStyles />

--- a/__fixtures__/colorFunctions/tailwind.config.js
+++ b/__fixtures__/colorFunctions/tailwind.config.js
@@ -1,0 +1,31 @@
+const color = name => ({ opacityVariable, opacityValue }) => {
+  if (opacityValue !== undefined) {
+    return `rgba(var(--twc-${name}), ${opacityValue})`
+  }
+
+  if (opacityVariable !== undefined) {
+    return `rgba(var(--twc-${name}), var(${opacityVariable}, 1))`
+  }
+
+  return `rgb(var(--twc-${name}))`
+}
+
+const colorScale = name =>
+  [50, 100, 200, 300, 400, 500, 600, 700, 800, 900].reduce(
+    (acc, step) => ({
+      ...acc,
+      [step]: color(`${name}-${step}`),
+    }),
+    {}
+  )
+
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        foreground: color('foreground'),
+        gray: colorScale('gray'),
+      },
+    },
+  },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12900,7 +12900,6 @@ tw\`z-auto\`
 exports[`twin.macro pluginForms.js: pluginForms.js 1`] = `
 
 import { GlobalStyles } from './macro'
-
 ;<GlobalStyles />
 
       ↓ ↓ ↓ ↓ ↓ ↓

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -16,6 +16,7 @@ tw\`text-mycolors-a-number\`
 tw\`text-mycolors-array\`
 tw\`text-my-blue-100\`
 tw\`text-color-opacity\`
+tw\`text-color-deep-config-500\`
 
 tw\`bg-number\`
 tw\`bg-purple-hyphen\`
@@ -25,6 +26,7 @@ tw\`bg-mycolors-a-number\`
 tw\`bg-mycolors-array\`
 tw\`bg-my-blue-100\`
 tw\`bg-color-opacity\`
+tw\`bg-color-deep-config-500\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -60,6 +62,10 @@ tw\`bg-color-opacity\`
   color: 'rgba(var(--color-primary), var(--tw-text-opacity, 1))',
 })
 ;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(7, 71, 166, var(--tw-text-opacity))',
+})
+;({
   backgroundColor: '0',
 })
 ;({
@@ -86,6 +92,10 @@ tw\`bg-color-opacity\`
 })
 ;({
   backgroundColor: 'rgba(var(--color-primary), var(--tw-bg-opacity, 1))',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(7, 71, 166, var(--tw-bg-opacity))',
 })
 
 

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -7027,6 +7027,346 @@ tw\`place-self-stretch\`
 
 `;
 
+exports[`twin.macro colorFunctions.js: colorFunctions.js 1`] = `
+
+import tw, { GlobalStyles } from './macro' // twinImport
+
+tw\`text-foreground text-opacity-40\`
+tw\`text-gray-300\`
+;<GlobalStyles />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { css as _css } from '@emotion/react'
+import { Global as _globalImport } from '@emotion/react'
+
+const _GlobalStyles = () => (
+  <_globalImport
+    styles={_css\`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  :root {
+    -moz-tab-size: 4;
+    tab-size: 4;
+  }
+
+  html {
+    line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  body {
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+  }
+
+  abbr[title] {
+    text-decoration: underline dotted;
+  }
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  button,
+  select {
+    text-transform: none;
+  }
+
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    -webkit-appearance: button;
+  }
+
+  ::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  :-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  legend {
+    padding: 0;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [type='search'] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  button {
+    background-color: transparent;
+    background-image: none;
+  }
+
+  button:focus {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    line-height: 1.5;
+  }
+
+  body {
+    font-family: inherit;
+    line-height: inherit;
+  }
+
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: rgb(var(--twc-gray-200));
+  }
+
+  hr {
+    border-top-width: 1px;
+  }
+
+  img {
+    border-style: solid;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: rgb(var(--twc-gray-400));
+  }
+
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    padding: 0;
+    line-height: inherit;
+    color: inherit;
+  }
+
+  pre,
+  code,
+  kbd,
+  samp {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  }
+
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+
+      @keyframes spin {
+          to { 
+            transform: rotate(360deg);
+          }
+        }
+      @keyframes ping {
+          75%, 100% { 
+            transform: scale(2); opacity: 0;
+          }
+        }
+      @keyframes pulse {
+          50% { 
+            opacity: .5;
+          }
+        }
+      @keyframes bounce {
+          0%, 100% { 
+            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
+          }
+        
+          50% { 
+            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
+          }
+        }
+* {
+    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: #fff;
+    --tw-ring-color: rgba(59, 130, 246, 0.5);
+    --tw-ring-offset-shadow: 0 0 #0000;
+    --tw-ring-shadow: 0 0 #0000;
+  }
+* {
+  --tw-shadow: 0 0 #0000; }
+\`}
+  />
+)
+
+// twinImport
+;({
+  color: 'rgba(var(--twc-foreground), var(--tw-text-opacity))',
+  '--tw-text-opacity': '0.4',
+})
+;({
+  color: 'rgba(var(--twc-gray-300), var(--tw-text-opacity))',
+})
+;<_GlobalStyles />
+
+
+`;
+
 exports[`twin.macro comments.js: comments.js 1`] = `
 
 import tw from './macro'

--- a/src/utils/getConfigValue.js
+++ b/src/utils/getConfigValue.js
@@ -17,8 +17,9 @@ const normalizeValue = value => {
   )
 }
 
-const matchChildKey = (from, matcher) => {
+const matchConfig = (from, matcher) => {
   if (!matcher) return
+
   for (const entry of Object.entries(from)) {
     const [key, value] = entry
 
@@ -27,12 +28,17 @@ const matchChildKey = (from, matcher) => {
     // Fixes https://github.com/ben-rogerson/twin.macro/issues/104
     if (!matcher.startsWith(key)) continue
 
-    const splitMatcher = matcher.split(key)
-    if (isEmpty(splitMatcher[1]) || !splitMatcher[1].startsWith('-')) continue
+    const newMatcher = matcher.slice(key.length)
+    if (isEmpty(newMatcher) || !newMatcher.startsWith('-')) continue
 
-    const match = stripNegative(splitMatcher[1])
+    const match = stripNegative(newMatcher)
     const objectMatch = value[match]
-    if (isEmpty(objectMatch)) continue
+
+    if (isEmpty(objectMatch)) {
+      // Support infinite nesting in tailwind.config
+      // Fixes https://github.com/ben-rogerson/twin.macro/issues/355
+      return matchConfig(value, match)
+    }
 
     const isValueReturnable =
       ['string', 'number', 'function'].includes(typeof objectMatch) ||
@@ -40,9 +46,9 @@ const matchChildKey = (from, matcher) => {
 
     throwIf(!isValueReturnable, () =>
       logGeneralError(
-        `The tailwind config is nested too deep\nReplace this with a string, number or array:\n${JSON.stringify(
+        `The config value "${JSON.stringify(
           objectMatch
-        )}`
+        )}" is unsupported - try a string, function, array, or number`
       )
     )
 
@@ -52,7 +58,6 @@ const matchChildKey = (from, matcher) => {
 
 /**
  * Searches the tailwindConfig
- * Maximum of two levels deep
  */
 const getConfigValue = (from, matcher) => {
   if (!from) return
@@ -76,8 +81,8 @@ const getConfigValue = (from, matcher) => {
     return normalizeValue(defaultMatch)
   }
 
-  const firstChildKey = matchChildKey(from, matcher)
-  if (firstChildKey) return firstChildKey
+  const configMatch = matchConfig(from, matcher)
+  if (configMatch) return configMatch
 }
 
 export default getConfigValue

--- a/src/utils/getConfigValue.js
+++ b/src/utils/getConfigValue.js
@@ -35,8 +35,7 @@ const matchChildKey = (from, matcher) => {
     if (isEmpty(objectMatch)) continue
 
     const isValueReturnable =
-      typeof objectMatch === 'string' ||
-      typeof objectMatch === 'number' ||
+      ['string', 'number', 'function'].includes(typeof objectMatch) ||
       Array.isArray(objectMatch)
 
     throwIf(!isValueReturnable, () =>
@@ -47,7 +46,7 @@ const matchChildKey = (from, matcher) => {
       )
     )
 
-    return String(objectMatch)
+    return typeof objectMatch === 'function' ? objectMatch : String(objectMatch)
   }
 }
 

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -37,6 +37,10 @@ function transformThemeValue(themeSection) {
     return value => (Array.isArray(value) ? value.join(', ') : value)
   }
 
+  if (themeSection === 'colors') {
+    return value => (typeof value === 'function' ? value({}) : value)
+  }
+
   return value => value
 }
 

--- a/src/utils/withAlpha.js
+++ b/src/utils/withAlpha.js
@@ -17,7 +17,10 @@ function toRgba(color) {
 export default ({ color, property, variable, important }) => {
   if (typeof color === 'function') {
     return {
-      [property]: `${color({ opacityVariable: variable })}${important}`,
+      [property]: `${color({
+        opacityVariable: variable,
+        opacityValue: `var(${variable})`,
+      })}${important}`,
     }
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,13 @@ module.exports = {
         },
         'color-opacity': ({ opacityVariable }) =>
           `rgba(var(--color-primary), var(${opacityVariable}, 1))`,
+        color: {
+          deep: {
+            config: {
+              500: '#0747A6',
+            },
+          },
+        },
       },
       fontWeight: {
         customFontWeightAsString: '700',


### PR DESCRIPTION
## Color functions

`opacityValue` is now passed to color functions so the [tailwind-css-variable-text-opacity-demo](https://github.com/adamwathan/tailwind-css-variable-text-opacity-demo) now works:

```js
// tailwind.config.js
module.exports = {
  theme: {
    colors: {
      primary: ({ opacityVariable, opacityValue }) => {
        if (opacityValue !== undefined) {
          return `rgba(var(--color-primary), ${opacityValue})`
        }
        if (opacityVariable !== undefined) {
          return `rgba(var(--color-primary), var(${opacityVariable}, 1))`
        }
        return `rgb(var(--color-primary))`
      },
    },
  },
  // ...
}
```

Fixes #354 

## Deep nested classes

Support for deeply nested classes in the tailwind config has been added. 
It was limited to 3 levels before, so you can now work with complex nesting like this: 

```js
// tailwind.config.js
module.exports = {
  theme: {
    extend: {
      colors: {
        color: {
          deep: {
            config: {
              500: "#0747A6",
            },
          },
        },
      },
    },
  },
};
```

Fixes #355 