### PR TITLE
Screen import

### DIFF
--- a/__fixtures__/screenImport/screenImport.js
+++ b/__fixtures__/screenImport/screenImport.js
@@ -1,0 +1,105 @@
+import tw, { styled, screen } from './macro'
+
+// Media query only
+screen`sm`
+screen.md // Can't work with screen values that begin with a number, eg: screen.2xl
+screen('lg')
+screen(`xl`)
+
+// Constructed media queries
+;`
+    ${screen`sm`} {
+        display: block;
+        ${tw`inline`}
+    }
+`
+;({ [screen`sm`]: `display: block; ${tw`inline`}` })
+;({ [screen`sm`]: { display: 'block', ...tw`inline` } })
+
+// Media queries with styles
+screen.sm({ color: `red` })
+screen`md`({ color: `red` })
+screen('lg')({ color: `red` })
+screen(`xl`)({ color: `red` })
+screen.sm`color: red;`
+screen`md``color: red;`
+screen('lg')`color: red;`
+screen(`xl`)`color: red;`
+
+screen.xl(tw`inline`)
+screen.xl({ ...tw`inline` })
+screen.xl({ ...tw`inline`, display: 'block' })
+screen.xl`
+    ${tw`inline`}
+    display: block;
+`
+screen.xl`color: ${true && 'blue'};`
+
+// Within template literals
+;`${screen.lg}`
+;`${screen`xl`}`
+;`${screen(`xl`)}`
+;`${screen('xl')}`
+
+// Screen keys
+;<div
+  css={{
+    [screen.xl]: { color: 'red' },
+  }}
+/>
+;<div
+  css={`
+    ${{ [screen.xl]: { color: 'red' } }}
+  `}
+/>
+;<div css={[{ [screen.xl]: { color: 'red' } }]} />
+;<div
+  css={`
+    ${screen.xl} {
+      color: red;
+    }
+  `}
+/>
+
+styled.div`
+  ${{ [screen.xl]: { color: 'red' } }}
+`
+styled.div([{ [screen.xl]: { color: 'red' } }])
+
+// Logical expressions
+;<div
+  css={{
+    [true && screen.xl]: { color: 'red' },
+  }}
+/>
+styled.div([{ [true && screen.xl]: { color: 'red' } }])
+
+// Conditional expressions
+;<div
+  css={{
+    // eslint-disable-next-line no-constant-condition
+    [true ? screen.xl : screen.sm]: { color: 'red' },
+  }}
+/>
+styled.div`
+  ${{
+    // eslint-disable-next-line no-constant-condition
+    [true ? screen.xl : screen.sm]: { color: 'red' },
+  }}
+`
+
+// Screen with values
+;<div css={screen.xl({ color: 'red' })} />
+;<div css={[screen.xl({ color: 'red' })]} />
+;<div
+  css={`
+    ${screen.xl({ color: 'red' })}
+  `}
+/>
+;<div css={screen.xl`color: red;`} />
+;<div css={[screen.xl`color: red;`]} />
+;<div
+  css={`
+    ${screen.xl`color: red;`}
+  `}
+/>

--- a/__fixtures__/screenImport/tailwind.config.js
+++ b/__fixtures__/screenImport/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  theme: {
+    screens: {
+      sm: '100px',
+      md: '200px',
+      lg: '300px',
+      xl: '400px',
+    },
+  },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -16022,6 +16022,322 @@ tw\`my-class3\`
 
 `;
 
+exports[`twin.macro screenImport.js: screenImport.js 1`] = `
+
+import tw, { styled, screen } from './macro'
+
+// Media query only
+screen\`sm\`
+screen.md // Can't work with screen values that begin with a number, eg: screen.2xl
+screen('lg')
+screen(\`xl\`)
+
+// Constructed media queries
+;\`
+    \${screen\`sm\`} {
+        display: block;
+        \${tw\`inline\`}
+    }
+\`
+;({ [screen\`sm\`]: \`display: block; \${tw\`inline\`}\` })
+;({ [screen\`sm\`]: { display: 'block', ...tw\`inline\` } })
+
+// Media queries with styles
+screen.sm({ color: \`red\` })
+screen\`md\`({ color: \`red\` })
+screen('lg')({ color: \`red\` })
+screen(\`xl\`)({ color: \`red\` })
+screen.sm\`color: red;\`
+screen\`md\`\`color: red;\`
+screen('lg')\`color: red;\`
+screen(\`xl\`)\`color: red;\`
+
+screen.xl(tw\`inline\`)
+screen.xl({ ...tw\`inline\` })
+screen.xl({ ...tw\`inline\`, display: 'block' })
+screen.xl\`
+    \${tw\`inline\`}
+    display: block;
+\`
+screen.xl\`color: \${true && 'blue'};\`
+
+// Within template literals
+;\`\${screen.lg}\`
+;\`\${screen\`xl\`}\`
+;\`\${screen(\`xl\`)}\`
+;\`\${screen('xl')}\`
+
+// Screen keys
+;<div
+  css={{
+    [screen.xl]: { color: 'red' },
+  }}
+/>
+;<div
+  css={\`
+    \${{ [screen.xl]: { color: 'red' } }}
+  \`}
+/>
+;<div css={[{ [screen.xl]: { color: 'red' } }]} />
+;<div
+  css={\`
+    \${screen.xl} {
+      color: red;
+    }
+  \`}
+/>
+
+styled.div\`
+  \${{ [screen.xl]: { color: 'red' } }}
+\`
+styled.div([{ [screen.xl]: { color: 'red' } }])
+
+// Logical expressions
+;<div
+  css={{
+    [true && screen.xl]: { color: 'red' },
+  }}
+/>
+styled.div([{ [true && screen.xl]: { color: 'red' } }])
+
+// Conditional expressions
+;<div
+  css={{
+    // eslint-disable-next-line no-constant-condition
+    [true ? screen.xl : screen.sm]: { color: 'red' },
+  }}
+/>
+styled.div\`
+  \${{
+    // eslint-disable-next-line no-constant-condition
+    [true ? screen.xl : screen.sm]: { color: 'red' },
+  }}
+\`
+
+// Screen with values
+;<div css={screen.xl({ color: 'red' })} />
+;<div css={[screen.xl({ color: 'red' })]} />
+;<div
+  css={\`
+    \${screen.xl({ color: 'red' })}
+  \`}
+/>
+;<div css={screen.xl\`color: red;\`} />
+;<div css={[screen.xl\`color: red;\`]} />
+;<div
+  css={\`
+    \${screen.xl\`color: red;\`}
+  \`}
+/>
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from '@emotion/styled'
+// Media query only
+;('@media (min-width: 100px)')
+;('@media (min-width: 200px)') // Can't work with screen values that begin with a number, eg: screen.2xl
+
+;('@media (min-width: 300px)')
+;('@media (min-width: 400px)') // Constructed media queries
+;\`
+    \${'@media (min-width: 100px)'} {
+        display: block;
+        \${{
+          display: 'inline',
+        }}
+    }
+\`
+;({
+  '@media (min-width: 100px)': \`display: block; \${{
+    display: 'inline',
+  }}\`,
+})
+;({
+  '@media (min-width: 100px)': {
+    display: 'block',
+    ...{
+      display: 'inline',
+    },
+  },
+}) // Media queries with styles
+
+;({
+  '@media (min-width: 100px)': {
+    color: \`red\`,
+  },
+})
+;({
+  '@media (min-width: 200px)': {
+    color: \`red\`,
+  },
+})
+;({
+  '@media (min-width: 300px)': {
+    color: \`red\`,
+  },
+})
+;({
+  '@media (min-width: 400px)': {
+    color: \`red\`,
+  },
+})
+;\`@media (min-width: 100px) { \${\`color: red;\`} }\`
+;\`@media (min-width: 200px) { \${\`color: red;\`} }\`
+;\`@media (min-width: 300px) { \${\`color: red;\`} }\`
+;\`@media (min-width: 400px) { \${\`color: red;\`} }\`
+;({
+  '@media (min-width: 400px)': {
+    display: 'inline',
+  },
+})
+;({
+  '@media (min-width: 400px)': {
+    ...{
+      display: 'inline',
+    },
+  },
+})
+;({
+  '@media (min-width: 400px)': {
+    ...{
+      display: 'inline',
+    },
+    display: 'block',
+  },
+})
+;\`@media (min-width: 400px) { \${\`
+    \${{
+      display: 'inline',
+    }}
+    display: block;
+\`} }\`
+;\`@media (min-width: 400px) { \${\`color: \${true && 'blue'};\`} }\` // Within template literals
+;\`\${'@media (min-width: 300px)'}\`
+;\`\${'@media (min-width: 400px)'}\`
+;\`\${'@media (min-width: 400px)'}\`
+;\`\${'@media (min-width: 400px)'}\` // Screen keys
+;<div
+  css={{
+    '@media (min-width: 400px)': {
+      color: 'red',
+    },
+  }}
+/>
+;<div
+  css={\`
+    \${{
+      '@media (min-width: 400px)': {
+        color: 'red',
+      },
+    }}
+  \`}
+/>
+;<div
+  css={[
+    {
+      '@media (min-width: 400px)': {
+        color: 'red',
+      },
+    },
+  ]}
+/>
+;<div
+  css={\`
+    \${'@media (min-width: 400px)'} {
+      color: red;
+    }
+  \`}
+/>
+_styled.div\`
+  \${{
+    '@media (min-width: 400px)': {
+      color: 'red',
+    },
+  }}
+\`
+
+_styled.div([
+  {
+    '@media (min-width: 400px)': {
+      color: 'red',
+    },
+  },
+]) // Logical expressions
+
+;<div
+  css={{
+    [true && '@media (min-width: 400px)']: {
+      color: 'red',
+    },
+  }}
+/>
+
+_styled.div([
+  {
+    [true && '@media (min-width: 400px)']: {
+      color: 'red',
+    },
+  },
+]) // Conditional expressions
+
+;<div
+  css={{
+    // eslint-disable-next-line no-constant-condition
+    [true ? '@media (min-width: 400px)' : '@media (min-width: 100px)']: {
+      color: 'red',
+    },
+  }}
+/>
+_styled.div\`
+  \${{
+    // eslint-disable-next-line no-constant-condition
+    [true ? '@media (min-width: 400px)' : '@media (min-width: 100px)']: {
+      color: 'red',
+    },
+  }}
+\` // Screen with values
+;<div
+  css={{
+    '@media (min-width: 400px)': {
+      color: 'red',
+    },
+  }}
+/>
+;<div
+  css={[
+    {
+      '@media (min-width: 400px)': {
+        color: 'red',
+      },
+    },
+  ]}
+/>
+;<div
+  css={\`
+    \${{
+      '@media (min-width: 400px)': {
+        color: 'red',
+      },
+    }}
+  \`}
+/>
+;<div
+  css={\`
+    @media (min-width: 400px) {
+      \${\`color: red;\`}
+    }
+  \`}
+/>
+;<div css={[\`@media (min-width: 400px) { \${\`color: red;\`} }\`]} />
+;<div
+  css={\`
+    \${\`@media (min-width: 400px) { \${\`color: red;\`} }\`}
+  \`}
+/>
+
+
+`;
+
 exports[`twin.macro shortCss.js: shortCss.js 1`] = `
 
 import tw from './macro'

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 
 - [The prop styling guide](https://github.com/ben-rogerson/twin.macro/blob/master/docs/prop-styling-guide.md)
 - [Styled component guide](https://github.com/ben-rogerson/twin.macro/blob/master/docs/styled-component-guide.md)
+- [The screen import](https://github.com/ben-rogerson/twin.macro/blob/master/docs/screen-import.md)
 
 [](#configuration)
 

--- a/docs/screen-import.md
+++ b/docs/screen-import.md
@@ -1,0 +1,114 @@
+# Screen import
+
+The screen import creates media queries for custom css that sync with your tailwind config screen values (sm, md, lg, etc).
+
+**Usage with the css prop**
+
+```js
+import tw, { screen, css } from 'twin.macro'
+
+const styles = [
+  // Add styles with object syntax
+  screen`sm`({ display: 'block', ...tw`inline` }),
+  // Or add styles with template literals
+  screen`md``display: block; ${css(tw`inline`)}`,
+]
+
+<div css={styles} />
+```
+
+**Usage with styled components**
+
+```js
+import tw, { styled, screen, css } from 'twin.macro'
+
+const Component = styled.div(() => [
+  // Add styles with object syntax
+  screen`sm`({ display: 'block', ...tw`inline` }),
+  // Or add styles with template literals
+  screen`md``display: block; ${css(tw`inline`)}`,
+])
+
+<Component />
+```
+
+## Screen as a key
+
+Without the styles, the screen import just creates a media query, so you can use it as a key:
+
+```js
+<div
+  css={{
+    [screen`2xl`]: { display: 'block' },
+  }}
+/>
+
+// ↓ ↓ ↓ ↓ ↓ ↓
+
+<div
+  css={{
+    '@media (min-width: 1536px)': { display: 'block' },
+  }}
+/>
+```
+
+## Relaxed usage
+
+The screen import can be used in different ways:
+
+```js
+screen`sm`({ ... })
+screen('sm')({ ... })
+screen(`sm`)({ ... })
+screen.sm({ ... }) // Dot syntax can’t be used when the screen begins with a number, eg: screen.2xl
+```
+
+## Custom media queries
+
+Since the screen import always adds a min-width query, it’s not suitable for constructing custom media queries.
+
+So to add custom media queries, use the theme import instead.
+
+**With the css prop**
+
+```js
+import tw, { theme } from 'twin.macro'
+
+const styles = {
+  // Object styles
+  [`@media (max-width: ${theme`screens.sm`})`]: {
+    display: 'block',
+    ...tw`inline`,
+  },
+  // Template literal styles
+  [`@media (max-width: ${theme`screens.md`})`]: `
+    display: block;
+  `,
+}
+
+<div css={styles} />
+```
+
+**With a styled component**
+
+```js
+import tw, { styled, theme } from 'twin.macro'
+
+const Component = styled.div({
+  // Object styles
+  [`@media (max-width: ${theme`screens.sm`})`]: {
+    display: 'block',
+    ...tw`inline`,
+  },
+  // Template literal styles
+  [`@media (max-width: ${theme`screens.md`})`]: `
+    display: block;
+  `,
+})
+
+<Component />
+```
+
+---
+
+[&lsaquo; Documentation](https://github.com/ben-rogerson/twin.macro/blob/master/docs/index.md)

--- a/src/macro.js
+++ b/src/macro.js
@@ -23,6 +23,7 @@ import {
   addStyledImport,
 } from './macro/styled'
 import { handleThemeFunction } from './macro/theme'
+import { handleScreenFunction } from './macro/screen'
 import { handleGlobalStylesFunction } from './macro/globalStyles'
 import { handleTwProperty, handleTwFunction } from './macro/tw'
 import { handleCsProperty } from './macro/cs'
@@ -170,6 +171,9 @@ const twinMacro = ({ babel: { types: t }, references, state, config }) => {
   ) {
     maybeAddCssProperty({ program, t })
   }
+
+  // Screen import
+  handleScreenFunction({ references, program, t, state, config })
 
   program.scope.crawl()
 }

--- a/src/macro/debug.js
+++ b/src/macro/debug.js
@@ -68,12 +68,22 @@ const addDataPropToExistingPath = ({
     try {
       // Existing data prop
       if (dataProperty.node.value.value) {
-        dataProperty.node.value.value = `${dataProperty.node.value.value} | ${rawClasses}`
+        dataProperty.node.value.value = `${[
+          dataProperty.node.value.value,
+          rawClasses,
+        ]
+          .filter(Boolean)
+          .join(' | ')}`
         return
       }
 
       // New data prop
-      dataProperty.node.value.expression.value = `${dataProperty.node.value.expression.value} | ${rawClasses}`
+      dataProperty.node.value.expression.value = `${[
+        dataProperty.node.value.expression.value,
+        rawClasses,
+      ]
+        .filter(Boolean)
+        .join(' | ')}`
     } catch (_) {}
 
     return

--- a/src/macro/screen.js
+++ b/src/macro/screen.js
@@ -1,0 +1,116 @@
+import {
+  replaceWithLocation,
+  astify,
+  getFunctionValue,
+  getTaggedTemplateValue,
+  getMemberExpression,
+} from './../macroHelpers'
+import { getTheme, throwIf } from './../utils'
+import { logBadGood } from './../logging'
+
+const getDirectReplacement = ({ mediaQuery, parent, t }) => ({
+  newPath: parent,
+  replacement: astify(mediaQuery, t),
+})
+
+const handleDefinition = ({ mediaQuery, parent, type, t }) =>
+  ({
+    TaggedTemplateExpression: () => {
+      const newPath = parent.findParent(x => x.isTaggedTemplateExpression())
+      const query = [`${mediaQuery} { `, ` }`]
+      const quasis = [
+        t.templateElement({ raw: query[0], cooked: query[0] }, false),
+        t.templateElement({ raw: query[1], cooked: query[1] }, true),
+      ]
+      const expressions = [newPath.get('quasi').node]
+      const replacement = t.templateLiteral(quasis, expressions)
+      return { newPath, replacement }
+    },
+    CallExpression: () => {
+      const newPath = parent.findParent(x => x.isCallExpression())
+      const value = newPath.get('arguments')[0].node
+      const replacement = t.objectExpression([
+        t.objectProperty(t.stringLiteral(mediaQuery), value),
+      ])
+      return { newPath, replacement }
+    },
+    ObjectProperty: () => {
+      // Remove brackets around keys so merges work with tailwind screens
+      // styled.div({ [screen`2xl`]: tw`block`, ...tw`2xl:inline` })
+      // https://github.com/ben-rogerson/twin.macro/issues/379
+      parent.parent.computed = false
+
+      return getDirectReplacement({ mediaQuery, parent, t })
+    },
+    ExpressionStatement: () => getDirectReplacement({ mediaQuery, parent, t }),
+    ArrowFunctionExpression: () =>
+      getDirectReplacement({ mediaQuery, parent, t }),
+    ArrayExpression: () => getDirectReplacement({ mediaQuery, parent, t }),
+    BinaryExpression: () => getDirectReplacement({ mediaQuery, parent, t }),
+    LogicalExpression: () => getDirectReplacement({ mediaQuery, parent, t }),
+    ConditionalExpression: () =>
+      getDirectReplacement({ mediaQuery, parent, t }),
+    VariableDeclarator: () => getDirectReplacement({ mediaQuery, parent, t }),
+    TemplateLiteral: () => getDirectReplacement({ mediaQuery, parent, t }),
+    TSAsExpression: () => getDirectReplacement({ mediaQuery, parent, t }),
+  }[type])
+
+const validateScreenValue = ({ screen, screens, value }) =>
+  throwIf(!screen, () =>
+    logBadGood(
+      `${
+        value
+          ? `“${value}” wasn’t found in your`
+          : 'Specify a screen value from your'
+      } tailwind config`,
+      `Try one of these:\n\n${Object.entries(screens)
+        .map(([k, v]) => `screen.${k}\`...\` (${v})`)
+        .join('\n')}`
+    )
+  )
+
+const getMediaQuery = ({ input, screens }) => {
+  validateScreenValue({ screen: screens[input], screens, value: input })
+  const mediaQuery = `@media (min-width: ${screens[input]})`
+  return { mediaQuery }
+}
+
+const handleScreenFunction = ({ references, t, state }) => {
+  if (!references.screen) return
+
+  const theme = getTheme(state.config.theme)
+  const screens = theme('screens')
+
+  references.screen.forEach(path => {
+    const { input, parent } =
+      getTaggedTemplateValue(path) || // screen.lg``
+      getFunctionValue(path) || // screen.lg({ })
+      getMemberExpression(path) || // screen`lg`
+      ''
+
+    const { mediaQuery, hasStyles } = getMediaQuery({ input, screens })
+
+    const definition = handleDefinition({
+      type: parent.parent.type,
+      hasStyles,
+      mediaQuery,
+      parent,
+      t,
+    })
+
+    throwIf(!definition, () =>
+      logBadGood(
+        `The screen import doesn’t support that syntax`,
+        `Try something like this:\n\n${[...Object.keys(screens)]
+          .map(f => `screen.${f}`)
+          .join(', ')}`
+      )
+    )
+
+    const { newPath, replacement } = definition()
+
+    replaceWithLocation(newPath, replacement)
+  })
+}
+
+export { handleScreenFunction }

--- a/src/macro/theme.js
+++ b/src/macro/theme.js
@@ -1,30 +1,11 @@
-import { replaceWithLocation, astify } from './../macroHelpers'
+import {
+  replaceWithLocation,
+  astify,
+  getFunctionValue,
+  getTaggedTemplateValue,
+} from './../macroHelpers'
 import { getTheme, throwIf, get } from './../utils'
 import { logGeneralError, themeErrorNotFound } from './../logging'
-
-const getFunctionValue = path => {
-  if (path.parent.type !== 'CallExpression') return
-
-  const parent = path.findParent(x => x.isCallExpression())
-  if (!parent) return
-
-  const argument = parent.get('arguments')[0] || ''
-
-  return {
-    parent,
-    input: argument.evaluate && argument.evaluate().value,
-  }
-}
-
-const getTaggedTemplateValue = path => {
-  if (path.parent.type !== 'TaggedTemplateExpression') return
-
-  const parent = path.findParent(x => x.isTaggedTemplateExpression())
-  if (!parent) return
-  if (parent.node.tag.type !== 'Identifier') return
-
-  return { parent, input: parent.get('quasi').evaluate().value }
-}
 
 const trimInput = themeValue => {
   const arrayValues = themeValue

--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -228,6 +228,7 @@ const validImports = new Set([
   'styled',
   'css',
   'theme',
+  'screen',
   'TwStyle',
   'ThemeStyle',
   'GlobalStyles',
@@ -246,7 +247,7 @@ const validateImports = imports => {
   })
   throwIf(unsupportedImport, () =>
     logGeneralError(
-      `Twin doesn't recognize { ${unsupportedImport} }\n\nTry one of these imports:\nimport tw, { styled, css, theme } from 'twin.macro'`
+      `Twin doesn't recognize { ${unsupportedImport} }\n\nTry one of these imports:\nimport tw, { styled, css, theme, screen, GlobalStyles } from 'twin.macro'`
     )
   )
 }
@@ -270,6 +271,39 @@ const getCssAttributeData = attributes => {
   return { index, hasCssAttribute: index >= 0, attribute: attributes[index] }
 }
 
+const getFunctionValue = path => {
+  if (path.parent.type !== 'CallExpression') return
+
+  const parent = path.findParent(x => x.isCallExpression())
+  if (!parent) return
+
+  const argument = parent.get('arguments')[0] || ''
+
+  return {
+    parent,
+    input: argument.evaluate && argument.evaluate().value,
+  }
+}
+
+const getTaggedTemplateValue = path => {
+  if (path.parent.type !== 'TaggedTemplateExpression') return
+
+  const parent = path.findParent(x => x.isTaggedTemplateExpression())
+  if (!parent) return
+  if (parent.node.tag.type !== 'Identifier') return
+
+  return { parent, input: parent.get('quasi').evaluate().value }
+}
+
+const getMemberExpression = path => {
+  if (path.parent.type !== 'MemberExpression') return
+
+  const parent = path.findParent(x => x.isMemberExpression())
+  if (!parent) return
+
+  return { parent, input: parent.get('property').node.name }
+}
+
 export {
   SPREAD_ID,
   COMPUTED_ID,
@@ -285,4 +319,7 @@ export {
   getParentJSX,
   getAttributeNames,
   getCssAttributeData,
+  getFunctionValue,
+  getTaggedTemplateValue,
+  getMemberExpression,
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,6 +20,10 @@ export type ThemeSearchTaggedFn<R> = (
 
 export type ThemeFn = <T = string>(arg?: string | TemplateStringsArray) => T
 
+export type ScreenFn = <T = string>(
+  screenValue: string | TemplateStringsArray
+) => (styles?: string | TemplateStringsArray | TwStyle) => T
+
 export type TwComponent<K extends keyof JSX.IntrinsicElements> = (
   props: JSX.IntrinsicElements[K]
 ) => JSX.Element
@@ -55,4 +59,6 @@ declare global {
 }
 
 declare const theme: ThemeFn
-export { theme }
+declare const screen: ScreenFn
+
+export { theme, screen }


### PR DESCRIPTION
This PR adds a `screen` import, making it easier to use tailwind screen breakpoints outside of tailwind.

## Before and after the screen import

### Before

Before the screen import, custom breakpoints needed to be manually constructed to mimic the tailwind breakpoints:

```js
import { styled, theme } from "twin.macro";

// Manual breakpoints with the css prop
<div css={{ 
	[`@media (min-width: ${theme('screens.sm')})`]: { display: "block", ...tw`inline` },
	[`@media (min-width: ${theme('screens.2xl')})`]: `display: block; ${tw`inline`}`,
}} />;

// Manual breakpoints with the styled import
styled.div({
	[`@media (min-width: ${theme('screens.sm')})`]: { display: "block", ...tw`inline` },
	[`@media (min-width: ${theme('screens.2xl')})`]: `display: block; ${tw`inline`}`,
});
```

### After

Using the screen import, twin will create the same "min-width" breakpoints tailwind uses:

```js
import { styled, screen } from "twin.macro";

// Screen breakpoints with the css prop
<div
  css={{
    [screen`sm`]: { display: "block", ...tw`inline` },
    [screen`2xl`]: `display: block; ${tw`inline`}`,
  }}
/>;

// Screen breakpoints with the styled import
styled.div({
    [screen`sm`]: { display: "block", ...tw`inline` },
    [screen`2xl`]: `display: block; ${tw`inline`}`,
});
```

## Screen styling shorthand

The screen import can also add styles when they are attached as a suffix:

```js
const styles = css(
  screen.xl({
    ":root": {
      "--gutter": "15px"
    },
  })
);
```

## Relaxed usage

The screen import can be added in a few different ways:

```js
screen`sm`({ ... })
screen('sm')({ ... })
screen(`sm`)({ ... })
screen.sm({ ... }) // Dot syntax can’t be used when the screen begins with a number, eg: screen.2xl
```