### PR TITLE
Disable short css

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -37,6 +37,7 @@ You can add these options in your twin config:
 | debugPlugins          | `false`                | Display generated class information in your terminal from your plugins.                                                                                              |
 | debug                 | `false`                | Display information in your terminal about the Tailwind class conversions.                                                                                           |
 | disableColorVariables | `false`                | Disable css variables in colors (not gradients).                                                                                                                     |
+| disableShortCss       | `false`                | Disable converting short css within the tw import/prop.                                                                                                              |
 | includeClassNames     | `false`                | Look in className props for tailwind classes to convert.                                                                                                             |
 | dataCsProp            | `true`                 | Add a prop to your elements in development so you can see the original cs prop classes, eg: `<div data-cs="maxWidth[1em]" />`.                                       |
 | disableCsProp         | `false`                | Disable twin from reading values specified in the cs prop.                                                                                                           |
@@ -171,6 +172,16 @@ tw`bg-gradient-to-b from-gray-100 to-gray-200`
   '--gradient-to-color': '#edf2f7',
 })
 ```
+
+### disableShortCss
+
+```js
+disableShortCss: true, // Disable converting short css within the tw import/prop
+```
+
+When set to `true`, this will throw an error if short css is added within the tw import or tw prop.
+
+If you want to disable short css completely, you’ll also need to set `dataCsProp: false`.
 
 ### includeClassNames
 

--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -13,6 +13,7 @@ const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
   includeClassNames: false, // Look in the className props for tailwind classes to convert
   dataCsProp: isDev, // During development, add a data-cs="" prop containing your short css classes for backtracing
   disableCsProp: false, // Disable converting css styles in the cs prop
+  disableShortCss: false, // Disable converting css written using short css
   ...(isStyledComponents && configDefaultsStyledComponents),
   ...(isGoober && configDefaultsGoober),
 })

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -10,6 +10,7 @@ import {
   logNotFoundVariant,
   logNotFoundClass,
   debug,
+  logBadGood,
 } from './logging'
 import { orderByScreens } from './screens'
 import { orderGridProperty } from './grid'
@@ -82,6 +83,7 @@ export default (
   const classesMismatched = []
 
   // Merge styles into a single css object
+  /* eslint-disable-next-line complexity */
   const styles = classes.reduce((results, classNameRaw) => {
     const pieces = getPieces({ classNameRaw, state })
     const { hasPrefix, className, hasVariants } = pieces
@@ -119,6 +121,20 @@ export default (
       classesMismatched.push(classNameRaw)
       return results
     }
+
+    // Error if short css is used and disabled
+    const isShortCssDisabled =
+      state.configTwin.disableShortCss && type === 'css' && !isCsOnly
+    throwIf(isShortCssDisabled, () =>
+      logBadGood(
+        `Short css has been disabled in the config so “${classNameRaw}” won’t work${
+          !state.configTwin.disableCsProp ? ' outside the cs prop' : ''
+        }.`,
+        !state.configTwin.disableCsProp
+          ? `Add short css with the cs prop: <div cs="${classNameRaw}" />`
+          : ''
+      )
+    )
 
     // Kick off suggestions when no class matches
     throwIf(!hasMatches && !hasUserPlugins, () =>

--- a/src/logging.js
+++ b/src/logging.js
@@ -45,7 +45,11 @@ const logNotAllowed = ({ className, error }) =>
   spaced(warning(`${color.errorLight(`${className}`)} ${error}`))
 
 const logBadGood = (bad, good) =>
-  spaced(`${color.error('✕ Bad:')} ${bad}\n${color.success('✓ Good:')} ${good}`)
+  good
+    ? spaced(
+        `${color.error('✕ Bad:')} ${bad}\n${color.success('✓ Good:')} ${good}`
+      )
+    : logGeneralError(bad)
 
 const logErrorFix = (error, good) =>
   `${color.error(error)}\n${color.success('Fix:')} ${good}`


### PR DESCRIPTION
This pr adds an option to disable short css within the tw import and the tw prop.

Just add this to your twin config:

```js
"babelMacros": {
  "twin": {
    "disableShortCss": true
  }
},
```