### PR TITLE
Fix negative css variables

### DIFF
--- a/__fixtures__/variables.js
+++ b/__fixtures__/variables.js
@@ -1,7 +1,7 @@
 import tw from './macro'
 
-/**
- * Test a user created css class with a css variable as a rule property
- */
-
+// Test a user created css class with a css variable as a rule property
 tw`css-class-with-variable-as-rule-property`
+
+// Test negative css variables
+tw`-mx-gutter-1/2`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -23041,19 +23041,22 @@ exports[`twin.macro variables.js: variables.js 1`] = `
 
 import tw from './macro'
 
-/**
- * Test a user created css class with a css variable as a rule property
- */
-
+// Test a user created css class with a css variable as a rule property
 tw\`css-class-with-variable-as-rule-property\`
+
+// Test negative css variables
+tw\`-mx-gutter-1/2\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-/**
- * Test a user created css class with a css variable as a rule property
- */
+// Test a user created css class with a css variable as a rule property
 ;({
   '--some-css-variable-as-rule-prop': 'blue',
+}) // Test negative css variables
+
+;({
+  marginLeft: 'calc(var(--gutter-half) * -1)',
+  marginRight: 'calc(var(--gutter-half) * -1)',
 })
 
 

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -1,20 +1,20 @@
 import getConfigValue from './../utils/getConfigValue'
-import { throwIf, stripNegative } from './../utils'
+import { throwIf, isNumeric } from './../utils'
 import { errorSuggestions } from './../logging'
 
-// Convert an array of objects into a single object
+const maybeAddNegative = (value, negative) => {
+  if (!negative) return value
+
+  return isNumeric(value.slice(0, 1)) ? `${negative}${value}` : value
+}
+
 const styleify = ({ property, value, negative }) => {
   value = Array.isArray(value)
     ? value.join(', ')
-    : negative
-    ? stripNegative(value)
-    : value
+    : maybeAddNegative(value, negative)
   return Array.isArray(property)
-    ? property.reduce(
-        (results, item) => ({ ...results, [item]: `${negative}${value}` }),
-        {}
-      )
-    : { [property]: `${negative}${value}` }
+    ? property.reduce((results, item) => ({ ...results, [item]: value }), {})
+    : { [property]: value }
 }
 
 export default ({ theme, pieces, state, dynamicKey, dynamicConfig }) => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ export {
   stripNegative,
   get,
   camelize,
+  isNumeric,
 } from './misc'
 export { default as withAlpha } from './withAlpha'
 export { toRgba } from './withAlpha'

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -60,4 +60,19 @@ const stripNegative = string =>
 const camelize = string =>
   string && string.replace(/\W+(.)/g, (match, chr) => chr.toUpperCase())
 
-export { throwIf, isEmpty, addPxTo0, getTheme, stripNegative, get, camelize }
+const isNumeric = str => {
+  /* eslint-disable-next-line eqeqeq */
+  if (typeof str != 'string') return false
+  return !Number.isNaN(str) && !Number.isNaN(Number.parseFloat(str))
+}
+
+export {
+  throwIf,
+  isEmpty,
+  addPxTo0,
+  getTheme,
+  stripNegative,
+  get,
+  camelize,
+  isNumeric,
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,9 @@ module.exports = {
           },
         ],
       },
+      spacing: {
+        'gutter-1/2': 'var(--gutter-half)',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
This PR fixes the display of negative css variables. 

```js
// tailwind.config.js
module.exports = {
  theme: {
    extend: {
      spacing: {
        "gutter-1/2": "var(--gutter-half)",
      },
    },
  },
};

```

```js
// app.js
import tw from "twin.macro";

tw`-mx-gutter-1/2`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "marginLeft": "calc(var(--gutter-half) * -1)",
  "marginRight": "calc(var(--gutter-half) * -1)"
});
```

Prior to this change, negative css variables rendered like this:

```js
({
  "marginLeft": "-calc(var(--gutter-half) * -1)",
  "marginRight": "-calc(var(--gutter-half) * -1)"
});
```

Fixes #410 