### PR TITLE
Fix hypenated dynamic + plugin matching

### DIFF
--- a/__fixtures__/config/config.js
+++ b/__fixtures__/config/config.js
@@ -1,10 +1,11 @@
 import tw from './macro'
 
 /**
- * Test the config nesting is working correctly
+ * Test the config matching is working correctly
  */
 
 tw`text-number`
+tw`text-purple`
 tw`text-purple-hyphen`
 tw`text-mycolors`
 tw`text-mycolors-a-purple`
@@ -15,6 +16,7 @@ tw`text-color-opacity`
 tw`text-color-deep-config-500`
 
 tw`bg-number`
+tw`bg-purple`
 tw`bg-purple-hyphen`
 tw`bg-mycolors`
 tw`bg-mycolors-a-purple`
@@ -23,3 +25,12 @@ tw`bg-mycolors-array`
 tw`bg-my-blue-100`
 tw`bg-color-opacity`
 tw`bg-color-deep-config-500`
+
+tw`bg-blue`
+tw`bg-blue-gray`
+tw`bg-blue-gray-200`
+tw`bg-blue-gray-green`
+tw`bg-blue-gray-green-200`
+tw`bg-blue-gray-green-deep-dish`
+tw`bg-blue-gray-green-deep-dish-200`
+tw`bg-blue-gray-green-pink`

--- a/__fixtures__/config/tailwind.config.js
+++ b/__fixtures__/config/tailwind.config.js
@@ -1,0 +1,46 @@
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        number: 0,
+        purple: 'purple',
+        'purple-hyphen': 'purple-hyphen',
+        mycolors: {
+          DEFAULT: 'blue',
+          'a-purple': 'purple',
+          'a-number': 0,
+          array: ['blue', 'purple', 'orange'],
+        },
+        'my-blue': {
+          100: 'blue',
+        },
+        'color-opacity': ({ opacityVariable }) =>
+          `rgba(var(--color-primary), var(${opacityVariable}, 1))`,
+        color: {
+          deep: {
+            config: {
+              500: '#0747A6',
+            },
+          },
+        },
+        blue: {
+          DEFAULT: 'blue-default',
+          gray: { 200: "this-gets-trumped by 'blue-gray: {200}'" },
+        },
+        'blue-gray': {
+          DEFAULT: 'blue-gray-default',
+          200: 'blue-gray-200',
+        },
+        'blue-gray-green': {
+          DEFAULT: 'blue-gray-green-default',
+          200: 'blue-gray-green-200',
+          'deep-dish': {
+            DEFAULT: 'blue-gray-green-deep-dish-default',
+            200: 'blue-gray-green-deep-dish-200',
+          },
+        },
+        'blue-gray-green-pink': 'blue-gray-green-pink',
+      },
+    },
+  },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1,106 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`twin.macro !config.js: !config.js 1`] = `
-
-import tw from './macro'
-
-/**
- * Test the config nesting is working correctly
- */
-
-tw\`text-number\`
-tw\`text-purple-hyphen\`
-tw\`text-mycolors\`
-tw\`text-mycolors-a-purple\`
-tw\`text-mycolors-a-number\`
-tw\`text-mycolors-array\`
-tw\`text-my-blue-100\`
-tw\`text-color-opacity\`
-tw\`text-color-deep-config-500\`
-
-tw\`bg-number\`
-tw\`bg-purple-hyphen\`
-tw\`bg-mycolors\`
-tw\`bg-mycolors-a-purple\`
-tw\`bg-mycolors-a-number\`
-tw\`bg-mycolors-array\`
-tw\`bg-my-blue-100\`
-tw\`bg-color-opacity\`
-tw\`bg-color-deep-config-500\`
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-/**
- * Test the config nesting is working correctly
- */
-;({
-  color: '0',
-})
-;({
-  '--tw-text-opacity': '1',
-  color: 'rgba(128, 0, 128, var(--tw-text-opacity))',
-})
-;({
-  '--tw-text-opacity': '1',
-  color: 'rgba(0, 0, 255, var(--tw-text-opacity))',
-})
-;({
-  '--tw-text-opacity': '1',
-  color: 'rgba(128, 0, 128, var(--tw-text-opacity))',
-})
-;({
-  color: '0',
-})
-;({
-  color: 'blue,purple,orange',
-})
-;({
-  '--tw-text-opacity': '1',
-  color: 'rgba(0, 0, 255, var(--tw-text-opacity))',
-})
-;({
-  color: 'rgba(var(--color-primary), var(--tw-text-opacity, 1))',
-})
-;({
-  '--tw-text-opacity': '1',
-  color: 'rgba(7, 71, 166, var(--tw-text-opacity))',
-})
-;({
-  backgroundColor: '0',
-})
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(128, 0, 128, var(--tw-bg-opacity))',
-})
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(0, 0, 255, var(--tw-bg-opacity))',
-})
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(128, 0, 128, var(--tw-bg-opacity))',
-})
-;({
-  backgroundColor: '0',
-})
-;({
-  backgroundColor: 'blue,purple,orange',
-})
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(0, 0, 255, var(--tw-bg-opacity))',
-})
-;({
-  backgroundColor: 'rgba(var(--color-primary), var(--tw-bg-opacity, 1))',
-})
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(7, 71, 166, var(--tw-bg-opacity))',
-})
-
-
-`;
-
 exports[`twin.macro !custom.js: !custom.js 1`] = `
 
 import tw from './macro'
@@ -7514,6 +7413,148 @@ hum
     'relative lg:( /*** helloworld /****/ //*** flex text-5xl border-yellow-500 /****/ )!'
   }
 />
+
+
+`;
+
+exports[`twin.macro config.js: config.js 1`] = `
+
+import tw from './macro'
+
+/**
+ * Test the config matching is working correctly
+ */
+
+tw\`text-number\`
+tw\`text-purple\`
+tw\`text-purple-hyphen\`
+tw\`text-mycolors\`
+tw\`text-mycolors-a-purple\`
+tw\`text-mycolors-a-number\`
+tw\`text-mycolors-array\`
+tw\`text-my-blue-100\`
+tw\`text-color-opacity\`
+tw\`text-color-deep-config-500\`
+
+tw\`bg-number\`
+tw\`bg-purple\`
+tw\`bg-purple-hyphen\`
+tw\`bg-mycolors\`
+tw\`bg-mycolors-a-purple\`
+tw\`bg-mycolors-a-number\`
+tw\`bg-mycolors-array\`
+tw\`bg-my-blue-100\`
+tw\`bg-color-opacity\`
+tw\`bg-color-deep-config-500\`
+
+tw\`bg-blue\`
+tw\`bg-blue-gray\`
+tw\`bg-blue-gray-200\`
+tw\`bg-blue-gray-green\`
+tw\`bg-blue-gray-green-200\`
+tw\`bg-blue-gray-green-deep-dish\`
+tw\`bg-blue-gray-green-deep-dish-200\`
+tw\`bg-blue-gray-green-pink\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+/**
+ * Test the config matching is working correctly
+ */
+;({
+  color: '0',
+})
+;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(128, 0, 128, var(--tw-text-opacity))',
+})
+;({
+  color: 'purple-hyphen',
+})
+;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(0, 0, 255, var(--tw-text-opacity))',
+})
+;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(128, 0, 128, var(--tw-text-opacity))',
+})
+;({
+  color: '0',
+})
+;({
+  color: 'blue,purple,orange',
+})
+;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(0, 0, 255, var(--tw-text-opacity))',
+})
+;({
+  color: 'rgba(var(--color-primary), var(--tw-text-opacity, 1))',
+})
+;({
+  '--tw-text-opacity': '1',
+  color: 'rgba(7, 71, 166, var(--tw-text-opacity))',
+})
+;({
+  backgroundColor: '0',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(128, 0, 128, var(--tw-bg-opacity))',
+})
+;({
+  backgroundColor: 'purple-hyphen',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(0, 0, 255, var(--tw-bg-opacity))',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(128, 0, 128, var(--tw-bg-opacity))',
+})
+;({
+  backgroundColor: '0',
+})
+;({
+  backgroundColor: 'blue,purple,orange',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(0, 0, 255, var(--tw-bg-opacity))',
+})
+;({
+  backgroundColor: 'rgba(var(--color-primary), var(--tw-bg-opacity, 1))',
+})
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(7, 71, 166, var(--tw-bg-opacity))',
+})
+;({
+  backgroundColor: 'blue-default',
+})
+;({
+  backgroundColor: 'blue-gray-default',
+})
+;({
+  backgroundColor: 'blue-gray-200',
+})
+;({
+  backgroundColor: 'blue-gray-green-default',
+})
+;({
+  backgroundColor: 'blue-gray-green-200',
+})
+;({
+  backgroundColor: 'blue-gray-green-deep-dish-default',
+})
+;({
+  backgroundColor: 'blue-gray-green-deep-dish-200',
+})
+;({
+  backgroundColor: 'blue-gray-green-pink',
+})
 
 
 `;

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -3,7 +3,11 @@ import { throwIf, isEmpty, getTheme } from './utils'
 import { getProperties } from './getProperties'
 import getPieces from './utils/getPieces'
 import { astify } from './macroHelpers'
-import doPrechecks, { precheckGroup, preCheckPrefix } from './prechecks'
+import doPrechecks, {
+  precheckGroup,
+  preCheckPrefix,
+  preCheckNoHyphenSuffix,
+} from './prechecks'
 import {
   logGeneralError,
   errorSuggestions,
@@ -94,7 +98,7 @@ export default (
 
     // Avoid prechecks on silent mode as they'll error loudly
     !silentMismatches &&
-      doPrechecks([precheckGroup, preCheckPrefix], {
+      doPrechecks([precheckGroup, preCheckPrefix, preCheckNoHyphenSuffix], {
         pieces,
         classNameRaw,
         state,

--- a/src/logging.js
+++ b/src/logging.js
@@ -146,7 +146,7 @@ const errorSuggestions = properties => {
     return spaced(
       `${color.highlight(
         className
-      )} isn’t valid “short css”.\n\nThe syntax is like this: maxWidth[100vw]\nRead more at https://twinredirect.page.link/cs-classes`
+      )} isn’t valid “short css”.\n\nThe syntax is like this: max-width[100vw]\nRead more at https://twinredirect.page.link/cs-classes`
     )
 
   checkDarkLightClasses(className)

--- a/src/prechecks.js
+++ b/src/prechecks.js
@@ -32,10 +32,26 @@ const preCheckPrefix = ({ pieces: { className, hasPrefix }, state }) => {
   )
 }
 
+const preCheckNoHyphenSuffix = ({ pieces: { className, classNameRaw } }) => {
+  if (isCssClass(className)) return
+
+  throwIf(classNameRaw.endsWith('-'), () =>
+    logBadGood(
+      `“${className}” should not have a '-' suffix`,
+      `Change it to “${className.replace(/-*$/, '')}”`
+    )
+  )
+}
+
 const doPrechecks = (prechecks, context) => {
   for (const precheck of prechecks) {
     precheck(context)
   }
 }
 
-export { doPrechecks as default, precheckGroup, preCheckPrefix }
+export {
+  doPrechecks as default,
+  precheckGroup,
+  preCheckPrefix,
+  preCheckNoHyphenSuffix,
+}

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -74,7 +74,8 @@ const normalizeDynamicConfig = ({ config, input, dynamicKey, hasNegative }) => {
 
   const filteredResults = results.filter(
     item =>
-      !item.target.includes('-array-') && typeof item.rating === 'undefined'
+      !item.target.includes('-array-') &&
+      (input.rating ? typeof item.rating !== 'undefined' : true)
   )
 
   return filteredResults

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,17 +33,6 @@ module.exports = {
         'object-min-max': { min: '1200px', max: '1600px' },
       },
       colors: {
-        number: 0,
-        'purple-hyphen': 'purple',
-        mycolors: {
-          DEFAULT: 'blue',
-          'a-purple': 'purple',
-          'a-number': 0,
-          array: ['blue', 'purple', 'orange'],
-        },
-        'my-blue': {
-          100: 'blue',
-        },
         electric: ({ opacityVariable, opacityValue }) => {
           if (opacityValue !== undefined) {
             return `rgba(219, 0, 255, ${opacityValue})`
@@ -54,15 +43,6 @@ module.exports = {
           }
 
           return `rgb(219, 0, 255)`
-        },
-        'color-opacity': ({ opacityVariable }) =>
-          `rgba(var(--color-primary), var(${opacityVariable}, 1))`,
-        color: {
-          deep: {
-            config: {
-              500: '#0747A6',
-            },
-          },
         },
       },
       fontWeight: {


### PR DESCRIPTION
This PR fixes some issues around matching both dynamic and plugin classes that have a hyphen in their name.

Eg: `bg-blue-gray-200`

```js
module.exports = {
  theme: {
    colors: {
      "blue-gray": {
        200: "blue-gray-200",
      },
    },
  },
};
``` 

Previous to 2.4.0, the config was limited to 2 levels deep - now that it's unlimited, twin needed a better way to match these types of classes. The issue before was that a `-` dash symbolised a traversal to a sub-object rather than a "dash space" within the class name, there was a band-aid fix for this but it was limited to objects 2 levels deep.

Also improved in this PR were the class suggestions around hyphenated classes.

Fixes #414 