### PR TITLE
Pluck classes from the addBase layer

### DIFF
--- a/__fixtures__/addBase/addBase.js
+++ b/__fixtures__/addBase/addBase.js
@@ -1,0 +1,4 @@
+import tw, { GlobalStyles } from './macro'
+
+tw`base-selector`
+;<GlobalStyles />

--- a/__fixtures__/addBase/tailwind.config.js
+++ b/__fixtures__/addBase/tailwind.config.js
@@ -1,0 +1,32 @@
+function addBasePlugin({ addBase }) {
+  const baseStyles = {
+    body: {
+      marginTop: '20rem',
+      backgroundColor: 'black',
+    },
+    '.base-selector': {
+      display: 'block',
+    },
+    'section .base-selector': {
+      display: 'block',
+      '@screen sm': {
+        '&:hover': {
+          marginTop: '50px',
+        },
+      },
+    },
+    '[type="button"] .base-selector': {
+      display: 'block',
+      '@screen sm': {
+        '&:hover': {
+          marginTop: '5rem',
+        },
+      },
+    },
+  }
+  addBase(baseStyles)
+}
+
+module.exports = {
+  plugins: [addBasePlugin],
+}

--- a/__fixtures__/pluginTypographyClassStrategy/pluginTypography.js
+++ b/__fixtures__/pluginTypographyClassStrategy/pluginTypography.js
@@ -1,0 +1,6 @@
+import tw from './macro'
+
+tw`form-input`
+tw`form-textarea`
+tw`form-select`
+tw`form-multiselect`

--- a/__fixtures__/pluginTypographyClassStrategy/tailwind.config.js
+++ b/__fixtures__/pluginTypographyClassStrategy/tailwind.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('@tailwindcss/forms')({ strategy: 'class' })],
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -662,18 +662,7 @@ const _GlobalStyles = () => (
   }
 * {
   --tw-shadow: 0 0 #0000; }
-
-.base-selector {
-content: 'test selector format is retained';
-        }
-.base-selector2,.base-selector3 {
-content: 'test selector format is retained';
-        }
-@media (min-width: 640px) {
-.base-selector2:hover,.base-selector3:hover {
-margin-top: 50px;
-        }
-        }\`}
+\`}
   />
 )
 
@@ -1957,6 +1946,358 @@ tw\`not-sr-only\`
   clip: 'auto',
   whiteSpace: 'normal',
 })
+
+
+`;
+
+exports[`twin.macro addBase.js: addBase.js 1`] = `
+
+import tw, { GlobalStyles } from './macro'
+
+tw\`base-selector\`
+;<GlobalStyles />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { css as _css } from '@emotion/react'
+import { Global as _globalImport } from '@emotion/react'
+
+const _GlobalStyles = () => (
+  <_globalImport
+    styles={_css\`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+  
+  :root {
+    -moz-tab-size: 4;
+    tab-size: 4;
+  }
+
+  html {
+    line-height: 1.15;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  body {
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+  }
+
+  abbr[title] {
+    text-decoration: underline dotted;
+  }
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  button,
+  select {
+    text-transform: none;
+  }
+
+  button,
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
+    -webkit-appearance: button;
+  }
+
+  ::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  :-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  legend {
+    padding: 0;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [type='search'] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  button {
+    background-color: transparent;
+    background-image: none;
+  }
+
+  button:focus {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
+  fieldset {
+    margin: 0;
+    padding: 0;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    line-height: 1.5;
+  }
+
+  body {
+    font-family: inherit;
+    line-height: inherit;
+  }
+
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
+    border-color: #e5e7eb;
+  }
+
+  hr {
+    border-top-width: 1px;
+  }
+
+  img {
+    border-style: solid;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: #9ca3af;
+  }
+
+  button,
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    padding: 0;
+    line-height: inherit;
+    color: inherit;
+  }
+
+  pre,
+  code,
+  kbd,
+  samp {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  }
+
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+
+      @keyframes spin {
+          to { 
+            transform: rotate(360deg);
+          }
+        }
+      @keyframes ping {
+          75%, 100% { 
+            transform: scale(2); opacity: 0;
+          }
+        }
+      @keyframes pulse {
+          50% { 
+            opacity: .5;
+          }
+        }
+      @keyframes bounce {
+          0%, 100% { 
+            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
+          }
+        
+          50% { 
+            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
+          }
+        }
+* {
+    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: #fff;
+    --tw-ring-color: rgba(59, 130, 246, 0.5);
+    --tw-ring-offset-shadow: 0 0 #0000;
+    --tw-ring-shadow: 0 0 #0000;
+  }
+* {
+  --tw-shadow: 0 0 #0000; }
+
+body {
+margin-top: 20rem;
+background-color: black;
+        }\`}
+  />
+)
+
+;({
+  display: 'block',
+  'section &': {
+    display: 'block',
+  },
+  '[type="button"] &': {
+    display: 'block',
+  },
+  '@media (min-width: 640px)': {
+    '[type="button"] &:hover': {
+      marginTop: '5rem',
+    },
+    'section &:hover': {
+      marginTop: '50px',
+    },
+  },
+})
+;<_GlobalStyles />
 
 
 `;
@@ -15254,6 +15595,147 @@ tw\`rich-text\`
     'h1 lineHeight': {
       lineHeight: '1',
     },
+  },
+})
+
+
+`;
+
+exports[`twin.macro pluginTypography.js: pluginTypography.js 2`] = `
+
+import tw from './macro'
+
+tw\`form-input\`
+tw\`form-textarea\`
+tw\`form-select\`
+tw\`form-multiselect\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  '::-webkit-date-and-time-value': {
+    minHeight: '1.5em',
+  },
+  '::-webkit-datetime-edit-fields-wrapper': {
+    padding: '0',
+  },
+  '::placeholder': {
+    color: '#6b7280',
+    opacity: '1',
+  },
+  appearance: 'none',
+  backgroundColor: '#fff',
+  borderColor: '#6b7280',
+  borderWidth: '1px',
+  borderRadius: '0px',
+  paddingTop: '0.5rem',
+  paddingRight: '0.75rem',
+  paddingBottom: '0.5rem',
+  paddingLeft: '0.75rem',
+  fontSize: '1rem',
+  lineHeight: '1.5rem',
+  ':focus': {
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': '#2563eb',
+    '--tw-ring-offset-shadow':
+      'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+    '--tw-ring-shadow':
+      'var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+    boxShadow:
+      'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+    borderColor: '#2563eb',
+  },
+})
+;({
+  '::placeholder': {
+    color: '#6b7280',
+    opacity: '1',
+  },
+  appearance: 'none',
+  backgroundColor: '#fff',
+  borderColor: '#6b7280',
+  borderWidth: '1px',
+  borderRadius: '0px',
+  paddingTop: '0.5rem',
+  paddingRight: '0.75rem',
+  paddingBottom: '0.5rem',
+  paddingLeft: '0.75rem',
+  fontSize: '1rem',
+  lineHeight: '1.5rem',
+  ':focus': {
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': '#2563eb',
+    '--tw-ring-offset-shadow':
+      'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+    '--tw-ring-shadow':
+      'var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+    boxShadow:
+      'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+    borderColor: '#2563eb',
+  },
+})
+;({
+  appearance: 'none',
+  backgroundColor: '#fff',
+  borderColor: '#6b7280',
+  borderWidth: '1px',
+  borderRadius: '0px',
+  paddingTop: '0.5rem',
+  paddingRight: '0.75rem',
+  paddingBottom: '0.5rem',
+  paddingLeft: '0.75rem',
+  fontSize: '1rem',
+  lineHeight: '1.5rem',
+  ':focus': {
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': '#2563eb',
+    '--tw-ring-offset-shadow':
+      'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+    '--tw-ring-shadow':
+      'var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+    boxShadow:
+      'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+    borderColor: '#2563eb',
+  },
+})
+;({
+  appearance: 'none',
+  backgroundColor: '#fff',
+  borderColor: '#6b7280',
+  borderWidth: '1px',
+  borderRadius: '0px',
+  paddingTop: '0.5rem',
+  paddingRight: '0.75rem',
+  paddingBottom: '0.5rem',
+  paddingLeft: '0.75rem',
+  fontSize: '1rem',
+  lineHeight: '1.5rem',
+  ':focus': {
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': '#2563eb',
+    '--tw-ring-offset-shadow':
+      'var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color)',
+    '--tw-ring-shadow':
+      'var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color)',
+    boxShadow:
+      'var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)',
+    borderColor: '#2563eb',
   },
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twin.macro",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twin.macro",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Twin blends the magic of Tailwind with the flexibility of css-in-js",
   "main": "macro.js",
   "types": "types/index.d.ts",

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -8,14 +8,13 @@ const stripLeadingDot = string =>
 const replaceSelectorWithParent = (string, replacement) =>
   string.replace(replacement, `{{${stripLeadingDot(replacement)}}}`)
 
-const parseSelector = (selector, { isBase }) => {
+const parseSelector = selector => {
   if (!selector) return
 
   const matches = selector.trim().match(/^(\S+)(\s+.*?)?$/)
   if (matches === null) return
 
   let match = matches[0]
-  if (isBase) return match
 
   // Fix spacing that goes missing when provided by tailwindcss
   // Unfortunately this removes the ability to have classes on the same element
@@ -60,12 +59,13 @@ const buildAtSelector = (name, values, screens) => {
 }
 
 const getBuiltRules = (rule, { isBase }) => {
+  if (!rule.selector) return null
   // Prep comma spaced selectors for parsing
   const selectorArray = rule.selector.split(',')
 
   // Validate each selector
   const selectorParsed = selectorArray
-    .map(s => parseSelector(s, { isBase }))
+    .map(s => parseSelector(s))
     .filter(Boolean)
 
   // Join them back into a string

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,6 +7,8 @@ export {
   get,
   camelize,
   isNumeric,
+  isClass,
+  isMediaQuery,
 } from './misc'
 export { default as withAlpha } from './withAlpha'
 export { toRgba } from './withAlpha'

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -62,13 +62,17 @@ const stripNegative = string =>
     : string
 
 const camelize = string =>
-  string && string.replace(/\W+(.)/g, (match, chr) => chr.toUpperCase())
+  string && string.replace(/\W+(.)/g, (_, chr) => chr.toUpperCase())
 
 const isNumeric = str => {
   /* eslint-disable-next-line eqeqeq */
   if (typeof str != 'string') return false
   return !Number.isNaN(str) && !Number.isNaN(Number.parseFloat(str))
 }
+
+const isClass = str => new RegExp(/(\s*\.|{{)\w/).test(str)
+
+const isMediaQuery = str => str.startsWith('@media')
 
 export {
   throwIf,
@@ -79,4 +83,6 @@ export {
   get,
   camelize,
   isNumeric,
+  isClass,
+  isMediaQuery,
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 // Used for tests (see '/__fixtures__/-plugins.js')
 
 module.exports = {
@@ -75,7 +74,6 @@ module.exports = {
     addComponentsTestElementScreenReplacements,
     addComponentsTestCssVariableAsRuleProperty,
     pluginBaseSelectors,
-    baseSelectorTest,
   ],
 }
 
@@ -202,21 +200,4 @@ function pluginBaseSelectors({ addComponents, theme, e }) {
     .join(',\n')
 
   addComponents([{ [baseSelectors]: { content: 'test' } }])
-}
-
-function baseSelectorTest({ addBase }) {
-  const newBaseSelector = {
-    '.base-selector': {
-      content: "'test selector format is retained'",
-    },
-    '.base-selector2, .base-selector3': {
-      content: "'test selector format is retained'",
-      '@screen sm': {
-        '&:hover': {
-          marginTop: '50px',
-        },
-      },
-    },
-  }
-  addBase(newBaseSelector)
 }


### PR DESCRIPTION
This PR adds the ability for twin to grab classes from the global (addBase) layer that's defined in your plugins.

```js
// tailwind.config.js

module.exports = {
  theme: {},
  plugins: [
    addBasePlugin
  ],
};

function addBasePlugin({ addBase }) {
  const baseStyles = {
    ".my-class": {
      display: "block",
    },
    "section .my-class": {
      marginTop: "5px",
    },
    '[type="button"] .my-class': {
      backgroundColor: "black",
    },
  };
  addBase(baseStyles);
}
```

```js
// Usage

tw`my-class`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "display": "block",
  "section &": {
    "marginTop": "5px"
  },
  "[type=\"button\"] &": {
    "backgroundColor": "black"
  }
});
```

This means the [class strategy](https://github.com/tailwindlabs/tailwindcss-forms#using-classes-instead-of-element-selectors) from `@tailwindcss/forms` can be used:

```js
module.exports = {
  plugins: [
    require("@tailwindcss/forms")({
      strategy: "class",
    }),
  ],
};
```

```js
// Usage

tw`form-input`
tw`form-textarea`
tw`form-multiselect`
tw`form-checkbox`
tw`form-radio`
```

Fixes #433 
Fixes #384 