### PR TITLE
Important prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ const Input = () => <input css={css({ color: theme`colors.purple.500` })} />
 
 See more examples [using the theme import →](https://github.com/ben-rogerson/twin.macro/pull/106)
 
-**💥 Add !important to any class with a trailing bang!**
+**💥 Add !important to any class with a trailing or leading bang!**
 
 ```js
-<div tw="hidden!" />
+<div tw="hidden!" /> || <div tw="!hidden" />
 // ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
 <div css={{ "display": "none !important" }} />
 ```

--- a/__fixtures__/!general.js
+++ b/__fixtures__/!general.js
@@ -15,23 +15,6 @@ const MediaColorProperty = tw.div`lg:text-red-500`
 const ElementMediaColorProperty = tw(Box)`lg:bg-blue-500`
 const MediaPropertyDuplicates = tw`lg:bg-blue-500 lg:bg-black`
 
-// Important
-
-const Important = tw`lg:uppercase!`
-const MediaImportant = tw.div`lg:text-red-500!`
-const ElementMediaImportant = tw(Box)`lg:bg-blue-500!`
-
-const PlaceholderImportant = tw.input`placeholder-red-500!`
-const StateImportant = tw.input`hover:text-red-500!`
-const StatePlaceholderImportant = tw.input`hover:placeholder-red-500!`
-const StateStatePlaceholderImportant = tw.input`active:hover:placeholder-red-500!`
-const StateMultiplePropertiesImportant = tw.input`hover:truncate!`
-const MediaStateMultiplePropertiesImportant = tw.input`lg:hover:truncate!`
-const ElementMediaStateMultiplePropertiesImportant = tw(Box)`lg:hover:truncate!`
-
-const JsxPlaceholder = () => <input tw="placeholder-red-500" />
-const JsxPlaceholderImportant = () => <input tw="placeholder-green-500!" />
-
 // Only basic evaluations supported
 // No functions or "beyond basic" conditionals.
 const plainConditional = true && 'red'

--- a/__fixtures__/!important.js
+++ b/__fixtures__/!important.js
@@ -1,0 +1,35 @@
+import tw from './macro'
+
+const Box = tw.div`text-red-500`
+
+const Important = tw`lg:uppercase!`
+const MediaImportant = tw.div`lg:text-red-500!`
+const ElementMediaImportant = tw(Box)`lg:bg-blue-500!`
+
+const PlaceholderImportant = tw.input`placeholder-red-500!`
+const StateImportant = tw.input`hover:text-red-500!`
+const StatePlaceholderImportant = tw.input`hover:placeholder-red-500!`
+const StateStatePlaceholderImportant = tw.input`active:hover:placeholder-red-500!`
+const StateMultiplePropertiesImportant = tw.input`hover:truncate!`
+const MediaStateMultiplePropertiesImportant = tw.input`lg:hover:truncate!`
+const ElementMediaStateMultiplePropertiesImportant = tw(Box)`lg:hover:truncate!`
+
+const JsxPlaceholderImportant = () => <input tw="placeholder-green-500!" />
+
+const ImportantPrefixPrefix = tw`lg:!uppercase`
+const MediaImportantPrefix = tw.div`lg:!text-red-500`
+const ElementMediaImportantPrefix = tw(Box)`lg:!bg-blue-500`
+
+const PlaceholderImportantPrefix = tw.input`!placeholder-red-500`
+const StateImportantPrefix = tw.input`hover:!text-red-500`
+const StatePlaceholderImportantPrefix = tw.input`hover:!placeholder-red-500`
+const StateStatePlaceholderImportantPrefix = tw.input`active:hover:!placeholder-red-500`
+const StateMultiplePropertiesImportantPrefix = tw.input`hover:!truncate`
+const MediaStateMultiplePropertiesImportantPrefix = tw.input`lg:hover:!truncate`
+const ElementMediaStateMultiplePropertiesImportantPrefix = tw(
+  Box
+)`lg:hover:!truncate`
+
+const JsxPlaceholderImportantPrefix = () => (
+  <input tw="!placeholder-green-500" />
+)

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -84,23 +84,6 @@ const MediaColorProperty = tw.div\`lg:text-red-500\`
 const ElementMediaColorProperty = tw(Box)\`lg:bg-blue-500\`
 const MediaPropertyDuplicates = tw\`lg:bg-blue-500 lg:bg-black\`
 
-// Important
-
-const Important = tw\`lg:uppercase!\`
-const MediaImportant = tw.div\`lg:text-red-500!\`
-const ElementMediaImportant = tw(Box)\`lg:bg-blue-500!\`
-
-const PlaceholderImportant = tw.input\`placeholder-red-500!\`
-const StateImportant = tw.input\`hover:text-red-500!\`
-const StatePlaceholderImportant = tw.input\`hover:placeholder-red-500!\`
-const StateStatePlaceholderImportant = tw.input\`active:hover:placeholder-red-500!\`
-const StateMultiplePropertiesImportant = tw.input\`hover:truncate!\`
-const MediaStateMultiplePropertiesImportant = tw.input\`lg:hover:truncate!\`
-const ElementMediaStateMultiplePropertiesImportant = tw(Box)\`lg:hover:truncate!\`
-
-const JsxPlaceholder = () => <input tw="placeholder-red-500" />
-const JsxPlaceholderImportant = () => <input tw="placeholder-green-500!" />
-
 // Only basic evaluations supported
 // No functions or "beyond basic" conditionals.
 const plainConditional = true && 'red'
@@ -153,7 +136,65 @@ const MediaPropertyDuplicates = {
     '--tw-bg-opacity': '1',
     backgroundColor: 'rgba(0, 0, 0, var(--tw-bg-opacity))',
   },
-} // Important
+} // Only basic evaluations supported
+// No functions or "beyond basic" conditionals.
+
+const plainConditional = true && 'red'
+const plainVariable = \`bg-\${plainConditional}-500\`
+;({
+  '--tw-bg-opacity': '1',
+  backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+})
+
+
+`;
+
+exports[`twin.macro !important.js: !important.js 1`] = `
+
+import tw from './macro'
+
+const Box = tw.div\`text-red-500\`
+
+const Important = tw\`lg:uppercase!\`
+const MediaImportant = tw.div\`lg:text-red-500!\`
+const ElementMediaImportant = tw(Box)\`lg:bg-blue-500!\`
+
+const PlaceholderImportant = tw.input\`placeholder-red-500!\`
+const StateImportant = tw.input\`hover:text-red-500!\`
+const StatePlaceholderImportant = tw.input\`hover:placeholder-red-500!\`
+const StateStatePlaceholderImportant = tw.input\`active:hover:placeholder-red-500!\`
+const StateMultiplePropertiesImportant = tw.input\`hover:truncate!\`
+const MediaStateMultiplePropertiesImportant = tw.input\`lg:hover:truncate!\`
+const ElementMediaStateMultiplePropertiesImportant = tw(Box)\`lg:hover:truncate!\`
+
+const JsxPlaceholderImportant = () => <input tw="placeholder-green-500!" />
+
+const ImportantPrefixPrefix = tw\`lg:!uppercase\`
+const MediaImportantPrefix = tw.div\`lg:!text-red-500\`
+const ElementMediaImportantPrefix = tw(Box)\`lg:!bg-blue-500\`
+
+const PlaceholderImportantPrefix = tw.input\`!placeholder-red-500\`
+const StateImportantPrefix = tw.input\`hover:!text-red-500\`
+const StatePlaceholderImportantPrefix = tw.input\`hover:!placeholder-red-500\`
+const StateStatePlaceholderImportantPrefix = tw.input\`active:hover:!placeholder-red-500\`
+const StateMultiplePropertiesImportantPrefix = tw.input\`hover:!truncate\`
+const MediaStateMultiplePropertiesImportantPrefix = tw.input\`lg:hover:!truncate\`
+const ElementMediaStateMultiplePropertiesImportantPrefix = tw(
+  Box
+)\`lg:hover:!truncate\`
+
+const JsxPlaceholderImportantPrefix = () => (
+  <input tw="!placeholder-green-500" />
+)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from '@emotion/styled'
+
+const Box = _styled.div({
+  '--tw-text-opacity': '1',
+  color: 'rgba(239, 68, 68, var(--tw-text-opacity))',
+})
 
 const Important = {
   '@media (min-width: 1024px)': {
@@ -237,17 +278,6 @@ const ElementMediaStateMultiplePropertiesImportant = _styled(Box)({
   },
 })
 
-const JsxPlaceholder = () => (
-  <input
-    css={{
-      '::placeholder': {
-        '--tw-placeholder-opacity': '1',
-        color: 'rgba(239, 68, 68, var(--tw-placeholder-opacity))',
-      },
-    }}
-  />
-)
-
 const JsxPlaceholderImportant = () => (
   <input
     css={{
@@ -257,15 +287,100 @@ const JsxPlaceholderImportant = () => (
       },
     }}
   />
-) // Only basic evaluations supported
-// No functions or "beyond basic" conditionals.
+)
 
-const plainConditional = true && 'red'
-const plainVariable = \`bg-\${plainConditional}-500\`
-;({
-  '--tw-bg-opacity': '1',
-  backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
+const ImportantPrefixPrefix = {
+  '@media (min-width: 1024px)': {
+    textTransform: 'uppercase !important',
+  },
+}
+
+const MediaImportantPrefix = _styled.div({
+  '@media (min-width: 1024px)': {
+    '--tw-text-opacity': '1',
+    color: 'rgba(239, 68, 68, var(--tw-text-opacity)) !important',
+  },
 })
+
+const ElementMediaImportantPrefix = _styled(Box)({
+  '@media (min-width: 1024px)': {
+    '--tw-bg-opacity': '1',
+    backgroundColor: 'rgba(59, 130, 246, var(--tw-bg-opacity)) !important',
+  },
+})
+
+const PlaceholderImportantPrefix = _styled.input({
+  '::placeholder': {
+    '--tw-placeholder-opacity': '1',
+    color: 'rgba(239, 68, 68, var(--tw-placeholder-opacity)) !important',
+  },
+})
+
+const StateImportantPrefix = _styled.input({
+  ':hover': {
+    '--tw-text-opacity': '1',
+    color: 'rgba(239, 68, 68, var(--tw-text-opacity)) !important',
+  },
+})
+
+const StatePlaceholderImportantPrefix = _styled.input({
+  ':hover': {
+    '::placeholder': {
+      '--tw-placeholder-opacity': '1',
+      color: 'rgba(239, 68, 68, var(--tw-placeholder-opacity)) !important',
+    },
+  },
+})
+
+const StateStatePlaceholderImportantPrefix = _styled.input({
+  ':active': {
+    ':hover': {
+      '::placeholder': {
+        '--tw-placeholder-opacity': '1',
+        color: 'rgba(239, 68, 68, var(--tw-placeholder-opacity)) !important',
+      },
+    },
+  },
+})
+
+const StateMultiplePropertiesImportantPrefix = _styled.input({
+  ':hover': {
+    overflow: 'hidden !important',
+    textOverflow: 'ellipsis !important',
+    whiteSpace: 'nowrap !important',
+  },
+})
+
+const MediaStateMultiplePropertiesImportantPrefix = _styled.input({
+  '@media (min-width: 1024px)': {
+    ':hover': {
+      overflow: 'hidden !important',
+      textOverflow: 'ellipsis !important',
+      whiteSpace: 'nowrap !important',
+    },
+  },
+})
+
+const ElementMediaStateMultiplePropertiesImportantPrefix = _styled(Box)({
+  '@media (min-width: 1024px)': {
+    ':hover': {
+      overflow: 'hidden !important',
+      textOverflow: 'ellipsis !important',
+      whiteSpace: 'nowrap !important',
+    },
+  },
+})
+
+const JsxPlaceholderImportantPrefix = () => (
+  <input
+    css={{
+      '::placeholder': {
+        '--tw-placeholder-opacity': '1',
+        color: 'rgba(16, 185, 129, var(--tw-placeholder-opacity)) !important',
+      },
+    }}
+  />
+)
 
 
 `;

--- a/src/important.js
+++ b/src/important.js
@@ -21,10 +21,12 @@ const mergeImportant = (style, hasImportant) => {
  * Split the important from the className
  */
 const splitImportant = ({ className }) => {
-  const lastCharacter = className.slice(-1)
-  const hasImportant = lastCharacter === '!'
+  const hasPrefix = className.slice(0, 1) === '!'
+  const hasSuffix = className.slice(-1) === '!'
+  const hasImportant = hasSuffix || hasPrefix
+
   if (hasImportant) {
-    className = className.slice(0, -1)
+    className = hasSuffix ? className.slice(0, -1) : className.slice(1)
   }
 
   const important = hasImportant ? ' !important' : ''


### PR DESCRIPTION
Twin now supports a prefixed `!` on classes to mark as `!important` as introduced with [Tailwind's new JIT mode](https://tailwindcss.com/docs/just-in-time-mode#built-in-important-modifier).
This works with singular classes _but not_ with class groups at this stage.

```js
tw`!block`;

// ↓ ↓ ↓ ↓ ↓ ↓

;({ "display": "block !important" })
```