### PR TITLE
Improved stitches support

### DIFF
--- a/__fixtures__/stitches/config.json
+++ b/__fixtures__/stitches/config.json
@@ -1,0 +1,5 @@
+{
+  "preset": "stitches",
+  "config": "__fixtures__/stitches/tailwind.config.js",
+  "stitchesConfig": "__fixtures__/stitches/stitches.config.js"
+}

--- a/__fixtures__/stitches/stitches.config.js
+++ b/__fixtures__/stitches/stitches.config.js
@@ -1,0 +1,1 @@
+// just for show

--- a/__fixtures__/stitches/stitchesDotSyntax.js
+++ b/__fixtures__/stitches/stitchesDotSyntax.js
@@ -1,0 +1,8 @@
+import tw, { styled } from './macro'
+
+tw.div`block`
+styled.div(tw`block`)
+styled.div({ display: 'block' })
+
+// Classic syntax
+styled('div', tw`block`)

--- a/__fixtures__/stitches/stitchesGlobals.js
+++ b/__fixtures__/stitches/stitchesGlobals.js
@@ -1,0 +1,9 @@
+import { globalStyles } from './macro'
+import { global } from './stitches.config'
+
+const globals = global(globalStyles)
+
+export function App() {
+  globals()
+  // ...
+}

--- a/__fixtures__/stitches/stitchesImports.js
+++ b/__fixtures__/stitches/stitchesImports.js
@@ -1,0 +1,5 @@
+import tw, { css, styled } from './macro'
+
+css(tw`block`)
+tw.div`block`
+styled.div(tw`block`)

--- a/__fixtures__/stitches/stitchesProps.js
+++ b/__fixtures__/stitches/stitchesProps.js
@@ -1,0 +1,15 @@
+import tw from './macro'
+// tw prop
+;<div tw="block" />
+
+// tw + css prop
+;<div tw="block" css={{ color: 'black' }} />
+;<div tw="block" css={tw`text-black`} />
+;<div css={{ color: 'black' }} tw="block" />
+;<div css={{ color: 'black' }} tw="block" thisShouldBePreserved="yup" />
+
+// Extracted styles
+const styles = {
+  container: ({ isInline }) => ({ ...tw`block`, ...(isInline && tw`inline`) }),
+}
+;<div css={styles.container({ isInline: true })} />

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -469,315 +469,197 @@ import { Global as _globalImport } from '@emotion/react'
 
 const _GlobalStyles = () => (
   <_globalImport
-    styles={_css\`
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-  
-  :root {
-    -moz-tab-size: 4;
-    tab-size: 4;
-  }
-
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-
-  body {
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  }
-
-  hr {
-    height: 0;
-    color: inherit;
-  }
-
-  abbr[title] {
-    text-decoration: underline dotted;
-  }
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: 1em;
-  }
-
-  small {
-    font-size: 80%;
-  }
-
-  sub,
-  sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  sub {
-    bottom: -0.25em;
-  }
-
-  sup {
-    top: -0.5em;
-  }
-
-  table {
-    text-indent: 0;
-    border-color: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit;
-    font-size: 100%;
-    line-height: 1.15;
-    margin: 0;
-  }
-
-  button,
-  select {
-    text-transform: none;
-  }
-
-  button,
-  [type='button'],
-  [type='reset'],
-  [type='submit'] {
-    -webkit-appearance: button;
-  }
-
-  ::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  :-moz-focusring {
-    outline: 1px dotted ButtonText;
-  }
-
-  :-moz-ui-invalid {
-    box-shadow: none;
-  }
-
-  legend {
-    padding: 0;
-  }
-
-  progress {
-    vertical-align: baseline;
-  }
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    height: auto;
-  }
-
-  [type='search'] {
-    -webkit-appearance: textfield;
-    outline-offset: -2px;
-  }
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button;
-    font: inherit;
-  }
-
-  summary {
-    display: list-item;
-  }
-
-
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
-    margin: 0;
-  }
-
-  button {
-    background-color: transparent;
-    background-image: none;
-  }
-
-  button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-  }
-
-  fieldset {
-    margin: 0;
-    padding: 0;
-  }
-
-  ol,
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    line-height: 1.5;
-  }
-
-  body {
-    font-family: inherit;
-    line-height: inherit;
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: #e5e7eb;
-  }
-
-  hr {
-    border-top-width: 1px;
-  }
-
-  img {
-    border-style: solid;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: #9ca3af;
-  }
-
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  table {
-    border-collapse: collapse;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: inherit;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    padding: 0;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  pre,
-  code,
-  kbd,
-  samp {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  }
-
-  img,
-  svg,
-  video,
-  canvas,
-  audio,
-  iframe,
-  embed,
-  object {
-    display: block;
-    vertical-align: middle;
-  }
-
-  img,
-  video {
-    max-width: 100%;
-    height: auto;
-  }
-
-
-      @keyframes spin {
-          to { 
-            transform: rotate(360deg);
-          }
+    styles={_css\`*, *::before, *::after {
+box-sizing: border-box;
         }
-      @keyframes ping {
-          75%, 100% { 
-            transform: scale(2); opacity: 0;
-          }
+html {
+line-height: 1.5;
+-webkit-text-size-adjust: 100%;
+-moz-tab-size: 4;
+tab-size: 4;
+font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
         }
-      @keyframes pulse {
-          50% { 
-            opacity: .5;
-          }
+body {
+margin: 0;
+font-family: inherit;
+line-height: inherit;
         }
-      @keyframes bounce {
-          0%, 100% { 
-            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
-          }
-        
-          50% { 
-            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
-          }
+hr {
+height: 0;
+color: inherit;
+border-top-width: 1px;
+        }
+abbr[title] {
+text-decoration: underline dotted;
+        }
+b, strong {
+font-weight: bolder;
+        }
+code, kbd, samp, pre {
+font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+font-size: 1em;
+        }
+small {
+font-size: 80%;
+        }
+sub, sup {
+font-size: 75%;
+line-height: 0;
+position: relative;
+vertical-align: baseline;
+        }
+sub {
+bottom: -0.25em;
+        }
+sup {
+top: -0.5em;
+        }
+table {
+text-indent: 0;
+border-color: inherit;
+border-collapse: collapse;
+        }
+button, input, optgroup, select, textarea {
+font-family: inherit;
+font-size: 100%;
+line-height: inherit;
+margin: 0;
+padding: 0;
+color: inherit;
+        }
+button, select {
+text-transform: none;
+        }
+button, [type='button'], [type='reset'], [type='submit'] {
+-webkit-appearance: button;
+        }
+::-moz-focus-inner {
+border-style: none;
+padding: 0;
+        }
+:-moz-focusring {
+outline: 1px dotted ButtonText;
+        }
+:-moz-ui-invalid {
+box-shadow: none;
+        }
+legend {
+padding: 0;
+        }
+progress {
+vertical-align: baseline;
+        }
+::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+height: auto;
+        }
+[type='search'] {
+-webkit-appearance: textfield;
+outline-offset: -2px;
+        }
+::-webkit-search-decoration {
+-webkit-appearance: none;
+        }
+::-webkit-file-upload-button {
+-webkit-appearance: button;
+font: inherit;
+        }
+summary {
+display: list-item;
+        }
+blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
+margin: 0;
+        }
+button {
+background-color: transparent;
+background-image: none;
+        }
+button:focus:not(/**/) {
+outline: 1px dotted;
+        }
+button:focus {
+outline: 5px auto -webkit-focus-ring-color;
+        }
+fieldset {
+margin: 0;
+padding: 0;
+        }
+ol, ul {
+list-style: none;
+margin: 0;
+padding: 0;
+        }
+*, ::before, ::after {
+box-sizing: border-box;
+border-width: 0;
+border-style: solid;
+border-color: #e5e7eb;
+        }
+img {
+border-style: solid;
+        }
+textarea {
+resize: vertical;
+        }
+input::placeholder, textarea::placeholder {
+color: #9ca3af;
+        }
+button, [role="button"] {
+cursor: pointer;
+        }
+h1, h2, h3, h4, h5, h6 {
+font-size: inherit;
+font-weight: inherit;
+        }
+a {
+color: inherit;
+text-decoration: inherit;
+        }
+pre, code, kbd, samp {
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+img, svg, video, canvas, audio, iframe, embed, object {
+display: block;
+vertical-align: middle;
+        }
+img, video {
+max-width: 100%;
+height: auto;
+        }
+@keyframes spin {
+to {
+transform: rotate(360deg);
+        }
+        }
+@keyframes ping {
+75%, 100% {
+transform: scale(2);
+opacity: 0;
+        }
+        }
+@keyframes pulse {
+50% {
+opacity: .5;
+        }
+        }
+@keyframes bounce {
+0%, 100% {
+transform: translateY(-25%);
+animation-timing-function: cubic-bezier(0.8,0,1,1);
+        }
+50% {
+transform: none;
+animation-timing-function: cubic-bezier(0,0,0.2,1);
+        }
         }
 * {
-    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-    --tw-ring-offset-width: 0px;
-    --tw-ring-offset-color: #fff;
-    --tw-ring-color: rgba(59, 130, 246, 0.5);
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-  }
-* {
-  --tw-shadow: 0 0 #0000; }
-\`}
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 0px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: rgba(59, 130, 246, 0.5);
+--tw-ring-offset-shadow: 0 0 #0000;
+--tw-ring-shadow: 0 0 #0000;
+--tw-shadow: 0 0 #0000;
+        }\`}
   />
 )
 
@@ -2079,318 +1961,198 @@ import { Global as _globalImport } from '@emotion/react'
 
 const _GlobalStyles = () => (
   <_globalImport
-    styles={_css\`
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-  
-  :root {
-    -moz-tab-size: 4;
-    tab-size: 4;
-  }
-
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-
-  body {
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  }
-
-  hr {
-    height: 0;
-    color: inherit;
-  }
-
-  abbr[title] {
-    text-decoration: underline dotted;
-  }
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: 1em;
-  }
-
-  small {
-    font-size: 80%;
-  }
-
-  sub,
-  sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  sub {
-    bottom: -0.25em;
-  }
-
-  sup {
-    top: -0.5em;
-  }
-
-  table {
-    text-indent: 0;
-    border-color: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit;
-    font-size: 100%;
-    line-height: 1.15;
-    margin: 0;
-  }
-
-  button,
-  select {
-    text-transform: none;
-  }
-
-  button,
-  [type='button'],
-  [type='reset'],
-  [type='submit'] {
-    -webkit-appearance: button;
-  }
-
-  ::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  :-moz-focusring {
-    outline: 1px dotted ButtonText;
-  }
-
-  :-moz-ui-invalid {
-    box-shadow: none;
-  }
-
-  legend {
-    padding: 0;
-  }
-
-  progress {
-    vertical-align: baseline;
-  }
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    height: auto;
-  }
-
-  [type='search'] {
-    -webkit-appearance: textfield;
-    outline-offset: -2px;
-  }
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button;
-    font: inherit;
-  }
-
-  summary {
-    display: list-item;
-  }
-
-
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
-    margin: 0;
-  }
-
-  button {
-    background-color: transparent;
-    background-image: none;
-  }
-
-  button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-  }
-
-  fieldset {
-    margin: 0;
-    padding: 0;
-  }
-
-  ol,
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    line-height: 1.5;
-  }
-
-  body {
-    font-family: inherit;
-    line-height: inherit;
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: #e5e7eb;
-  }
-
-  hr {
-    border-top-width: 1px;
-  }
-
-  img {
-    border-style: solid;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: #9ca3af;
-  }
-
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  table {
-    border-collapse: collapse;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: inherit;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    padding: 0;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  pre,
-  code,
-  kbd,
-  samp {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  }
-
-  img,
-  svg,
-  video,
-  canvas,
-  audio,
-  iframe,
-  embed,
-  object {
-    display: block;
-    vertical-align: middle;
-  }
-
-  img,
-  video {
-    max-width: 100%;
-    height: auto;
-  }
-
-
-      @keyframes spin {
-          to { 
-            transform: rotate(360deg);
-          }
+    styles={_css\`*, *::before, *::after {
+box-sizing: border-box;
         }
-      @keyframes ping {
-          75%, 100% { 
-            transform: scale(2); opacity: 0;
-          }
+html {
+line-height: 1.5;
+-webkit-text-size-adjust: 100%;
+-moz-tab-size: 4;
+tab-size: 4;
+font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
         }
-      @keyframes pulse {
-          50% { 
-            opacity: .5;
-          }
-        }
-      @keyframes bounce {
-          0%, 100% { 
-            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
-          }
-        
-          50% { 
-            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
-          }
-        }
-* {
-    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-    --tw-ring-offset-width: 0px;
-    --tw-ring-offset-color: #fff;
-    --tw-ring-color: rgba(59, 130, 246, 0.5);
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-  }
-* {
-  --tw-shadow: 0 0 #0000; }
-
 body {
+margin: 0;
+font-family: inherit;
+line-height: inherit;
 margin-top: 20rem;
 background-color: black;
+        }
+hr {
+height: 0;
+color: inherit;
+border-top-width: 1px;
+        }
+abbr[title] {
+text-decoration: underline dotted;
+        }
+b, strong {
+font-weight: bolder;
+        }
+code, kbd, samp, pre {
+font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+font-size: 1em;
+        }
+small {
+font-size: 80%;
+        }
+sub, sup {
+font-size: 75%;
+line-height: 0;
+position: relative;
+vertical-align: baseline;
+        }
+sub {
+bottom: -0.25em;
+        }
+sup {
+top: -0.5em;
+        }
+table {
+text-indent: 0;
+border-color: inherit;
+border-collapse: collapse;
+        }
+button, input, optgroup, select, textarea {
+font-family: inherit;
+font-size: 100%;
+line-height: inherit;
+margin: 0;
+padding: 0;
+color: inherit;
+        }
+button, select {
+text-transform: none;
+        }
+button, [type='button'], [type='reset'], [type='submit'] {
+-webkit-appearance: button;
+        }
+::-moz-focus-inner {
+border-style: none;
+padding: 0;
+        }
+:-moz-focusring {
+outline: 1px dotted ButtonText;
+        }
+:-moz-ui-invalid {
+box-shadow: none;
+        }
+legend {
+padding: 0;
+        }
+progress {
+vertical-align: baseline;
+        }
+::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+height: auto;
+        }
+[type='search'] {
+-webkit-appearance: textfield;
+outline-offset: -2px;
+        }
+::-webkit-search-decoration {
+-webkit-appearance: none;
+        }
+::-webkit-file-upload-button {
+-webkit-appearance: button;
+font: inherit;
+        }
+summary {
+display: list-item;
+        }
+blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
+margin: 0;
+        }
+button {
+background-color: transparent;
+background-image: none;
+        }
+button:focus:not(/**/) {
+outline: 1px dotted;
+        }
+button:focus {
+outline: 5px auto -webkit-focus-ring-color;
+        }
+fieldset {
+margin: 0;
+padding: 0;
+        }
+ol, ul {
+list-style: none;
+margin: 0;
+padding: 0;
+        }
+*, ::before, ::after {
+box-sizing: border-box;
+border-width: 0;
+border-style: solid;
+border-color: #e5e7eb;
+        }
+img {
+border-style: solid;
+        }
+textarea {
+resize: vertical;
+        }
+input::placeholder, textarea::placeholder {
+color: #9ca3af;
+        }
+button, [role="button"] {
+cursor: pointer;
+        }
+h1, h2, h3, h4, h5, h6 {
+font-size: inherit;
+font-weight: inherit;
+        }
+a {
+color: inherit;
+text-decoration: inherit;
+        }
+pre, code, kbd, samp {
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+img, svg, video, canvas, audio, iframe, embed, object {
+display: block;
+vertical-align: middle;
+        }
+img, video {
+max-width: 100%;
+height: auto;
+        }
+@keyframes spin {
+to {
+transform: rotate(360deg);
+        }
+        }
+@keyframes ping {
+75%, 100% {
+transform: scale(2);
+opacity: 0;
+        }
+        }
+@keyframes pulse {
+50% {
+opacity: .5;
+        }
+        }
+@keyframes bounce {
+0%, 100% {
+transform: translateY(-25%);
+animation-timing-function: cubic-bezier(0.8,0,1,1);
+        }
+50% {
+transform: none;
+animation-timing-function: cubic-bezier(0,0,0.2,1);
+        }
+        }
+* {
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 0px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: rgba(59, 130, 246, 0.5);
+--tw-ring-offset-shadow: 0 0 #0000;
+--tw-ring-shadow: 0 0 #0000;
+--tw-shadow: 0 0 #0000;
         }\`}
   />
 )
@@ -7865,315 +7627,197 @@ import { Global as _globalImport } from '@emotion/react'
 
 const _GlobalStyles = () => (
   <_globalImport
-    styles={_css\`
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-  
-  :root {
-    -moz-tab-size: 4;
-    tab-size: 4;
-  }
-
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-
-  body {
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  }
-
-  hr {
-    height: 0;
-    color: inherit;
-  }
-
-  abbr[title] {
-    text-decoration: underline dotted;
-  }
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: 1em;
-  }
-
-  small {
-    font-size: 80%;
-  }
-
-  sub,
-  sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  sub {
-    bottom: -0.25em;
-  }
-
-  sup {
-    top: -0.5em;
-  }
-
-  table {
-    text-indent: 0;
-    border-color: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit;
-    font-size: 100%;
-    line-height: 1.15;
-    margin: 0;
-  }
-
-  button,
-  select {
-    text-transform: none;
-  }
-
-  button,
-  [type='button'],
-  [type='reset'],
-  [type='submit'] {
-    -webkit-appearance: button;
-  }
-
-  ::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  :-moz-focusring {
-    outline: 1px dotted ButtonText;
-  }
-
-  :-moz-ui-invalid {
-    box-shadow: none;
-  }
-
-  legend {
-    padding: 0;
-  }
-
-  progress {
-    vertical-align: baseline;
-  }
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    height: auto;
-  }
-
-  [type='search'] {
-    -webkit-appearance: textfield;
-    outline-offset: -2px;
-  }
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button;
-    font: inherit;
-  }
-
-  summary {
-    display: list-item;
-  }
-
-
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
-    margin: 0;
-  }
-
-  button {
-    background-color: transparent;
-    background-image: none;
-  }
-
-  button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-  }
-
-  fieldset {
-    margin: 0;
-    padding: 0;
-  }
-
-  ol,
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    line-height: 1.5;
-  }
-
-  body {
-    font-family: inherit;
-    line-height: inherit;
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: rgb(var(--twc-gray-200));
-  }
-
-  hr {
-    border-top-width: 1px;
-  }
-
-  img {
-    border-style: solid;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: rgb(var(--twc-gray-400));
-  }
-
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  table {
-    border-collapse: collapse;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: inherit;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    padding: 0;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  pre,
-  code,
-  kbd,
-  samp {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  }
-
-  img,
-  svg,
-  video,
-  canvas,
-  audio,
-  iframe,
-  embed,
-  object {
-    display: block;
-    vertical-align: middle;
-  }
-
-  img,
-  video {
-    max-width: 100%;
-    height: auto;
-  }
-
-
-      @keyframes spin {
-          to { 
-            transform: rotate(360deg);
-          }
+    styles={_css\`*, *::before, *::after {
+box-sizing: border-box;
         }
-      @keyframes ping {
-          75%, 100% { 
-            transform: scale(2); opacity: 0;
-          }
+html {
+line-height: 1.5;
+-webkit-text-size-adjust: 100%;
+-moz-tab-size: 4;
+tab-size: 4;
+font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
         }
-      @keyframes pulse {
-          50% { 
-            opacity: .5;
-          }
+body {
+margin: 0;
+font-family: inherit;
+line-height: inherit;
         }
-      @keyframes bounce {
-          0%, 100% { 
-            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
-          }
-        
-          50% { 
-            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
-          }
+hr {
+height: 0;
+color: inherit;
+border-top-width: 1px;
+        }
+abbr[title] {
+text-decoration: underline dotted;
+        }
+b, strong {
+font-weight: bolder;
+        }
+code, kbd, samp, pre {
+font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+font-size: 1em;
+        }
+small {
+font-size: 80%;
+        }
+sub, sup {
+font-size: 75%;
+line-height: 0;
+position: relative;
+vertical-align: baseline;
+        }
+sub {
+bottom: -0.25em;
+        }
+sup {
+top: -0.5em;
+        }
+table {
+text-indent: 0;
+border-color: inherit;
+border-collapse: collapse;
+        }
+button, input, optgroup, select, textarea {
+font-family: inherit;
+font-size: 100%;
+line-height: inherit;
+margin: 0;
+padding: 0;
+color: inherit;
+        }
+button, select {
+text-transform: none;
+        }
+button, [type='button'], [type='reset'], [type='submit'] {
+-webkit-appearance: button;
+        }
+::-moz-focus-inner {
+border-style: none;
+padding: 0;
+        }
+:-moz-focusring {
+outline: 1px dotted ButtonText;
+        }
+:-moz-ui-invalid {
+box-shadow: none;
+        }
+legend {
+padding: 0;
+        }
+progress {
+vertical-align: baseline;
+        }
+::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+height: auto;
+        }
+[type='search'] {
+-webkit-appearance: textfield;
+outline-offset: -2px;
+        }
+::-webkit-search-decoration {
+-webkit-appearance: none;
+        }
+::-webkit-file-upload-button {
+-webkit-appearance: button;
+font: inherit;
+        }
+summary {
+display: list-item;
+        }
+blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
+margin: 0;
+        }
+button {
+background-color: transparent;
+background-image: none;
+        }
+button:focus:not(/**/) {
+outline: 1px dotted;
+        }
+button:focus {
+outline: 5px auto -webkit-focus-ring-color;
+        }
+fieldset {
+margin: 0;
+padding: 0;
+        }
+ol, ul {
+list-style: none;
+margin: 0;
+padding: 0;
+        }
+*, ::before, ::after {
+box-sizing: border-box;
+border-width: 0;
+border-style: solid;
+border-color: rgb(var(--twc-gray-200));
+        }
+img {
+border-style: solid;
+        }
+textarea {
+resize: vertical;
+        }
+input::placeholder, textarea::placeholder {
+color: rgb(var(--twc-gray-400));
+        }
+button, [role="button"] {
+cursor: pointer;
+        }
+h1, h2, h3, h4, h5, h6 {
+font-size: inherit;
+font-weight: inherit;
+        }
+a {
+color: inherit;
+text-decoration: inherit;
+        }
+pre, code, kbd, samp {
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+img, svg, video, canvas, audio, iframe, embed, object {
+display: block;
+vertical-align: middle;
+        }
+img, video {
+max-width: 100%;
+height: auto;
+        }
+@keyframes spin {
+to {
+transform: rotate(360deg);
+        }
+        }
+@keyframes ping {
+75%, 100% {
+transform: scale(2);
+opacity: 0;
+        }
+        }
+@keyframes pulse {
+50% {
+opacity: .5;
+        }
+        }
+@keyframes bounce {
+0%, 100% {
+transform: translateY(-25%);
+animation-timing-function: cubic-bezier(0.8,0,1,1);
+        }
+50% {
+transform: none;
+animation-timing-function: cubic-bezier(0,0,0.2,1);
+        }
         }
 * {
-    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-    --tw-ring-offset-width: 0px;
-    --tw-ring-offset-color: #fff;
-    --tw-ring-color: rgba(59, 130, 246, 0.5);
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-  }
-* {
-  --tw-shadow: 0 0 #0000; }
-\`}
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 0px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: rgba(59, 130, 246, 0.5);
+--tw-ring-offset-shadow: 0 0 #0000;
+--tw-ring-shadow: 0 0 #0000;
+--tw-shadow: 0 0 #0000;
+        }\`}
   />
 )
 
@@ -9593,40 +9237,30 @@ const _GlobalStyles = () => (
       *::after {
         box-sizing: border-box;
       }
-
-      :root {
+      html {
+        line-height: 1.5;
+        -webkit-text-size-adjust: 100%;
         -moz-tab-size: 4;
         tab-size: 4;
+        font-family: testSans, testSans2;
       }
-
-      html {
-        line-height: 1.15;
-        -webkit-text-size-adjust: 100%;
-      }
-
       body {
         margin: 0;
+        font-family: inherit;
+        line-height: inherit;
       }
-
-      body {
-        font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica,
-          Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-      }
-
       hr {
         height: 0;
         color: inherit;
+        border-top-width: 1px;
       }
-
       abbr[title] {
         text-decoration: underline dotted;
       }
-
       b,
       strong {
         font-weight: bolder;
       }
-
       code,
       kbd,
       samp,
@@ -9635,11 +9269,9 @@ const _GlobalStyles = () => (
           Menlo, monospace;
         font-size: 1em;
       }
-
       small {
         font-size: 80%;
       }
-
       sub,
       sup {
         font-size: 75%;
@@ -9647,20 +9279,17 @@ const _GlobalStyles = () => (
         position: relative;
         vertical-align: baseline;
       }
-
       sub {
         bottom: -0.25em;
       }
-
       sup {
         top: -0.5em;
       }
-
       table {
         text-indent: 0;
         border-color: inherit;
+        border-collapse: collapse;
       }
-
       button,
       input,
       optgroup,
@@ -9668,66 +9297,55 @@ const _GlobalStyles = () => (
       textarea {
         font-family: inherit;
         font-size: 100%;
-        line-height: 1.15;
+        line-height: inherit;
         margin: 0;
+        padding: 0;
+        color: inherit;
       }
-
       button,
       select {
         text-transform: none;
       }
-
       button,
       [type='button'],
       [type='reset'],
       [type='submit'] {
         -webkit-appearance: button;
       }
-
       ::-moz-focus-inner {
         border-style: none;
         padding: 0;
       }
-
       :-moz-focusring {
         outline: 1px dotted ButtonText;
       }
-
       :-moz-ui-invalid {
         box-shadow: none;
       }
-
       legend {
         padding: 0;
       }
-
       progress {
         vertical-align: baseline;
       }
-
       ::-webkit-inner-spin-button,
       ::-webkit-outer-spin-button {
         height: auto;
       }
-
       [type='search'] {
         -webkit-appearance: textfield;
         outline-offset: -2px;
       }
-
       ::-webkit-search-decoration {
         -webkit-appearance: none;
       }
-
       ::-webkit-file-upload-button {
         -webkit-appearance: button;
         font: inherit;
       }
-
       summary {
         display: list-item;
       }
-
       blockquote,
       dl,
       dd,
@@ -9743,39 +9361,26 @@ const _GlobalStyles = () => (
       pre {
         margin: 0;
       }
-
       button {
         background-color: transparent;
         background-image: none;
       }
-
-      button:focus {
+      button:focus:not(/**/) {
         outline: 1px dotted;
+      }
+      button:focus {
         outline: 5px auto -webkit-focus-ring-color;
       }
-
       fieldset {
         margin: 0;
         padding: 0;
       }
-
       ol,
       ul {
         list-style: none;
         margin: 0;
         padding: 0;
       }
-
-      html {
-        font-family: testSans, testSans2;
-        line-height: 1.5;
-      }
-
-      body {
-        font-family: inherit;
-        line-height: inherit;
-      }
-
       *,
       ::before,
       ::after {
@@ -9784,33 +9389,20 @@ const _GlobalStyles = () => (
         border-style: solid;
         border-color: blueish;
       }
-
-      hr {
-        border-top-width: 1px;
-      }
-
       img {
         border-style: solid;
       }
-
       textarea {
         resize: vertical;
       }
-
       input::placeholder,
       textarea::placeholder {
         color: grayish;
       }
-
       button,
       [role='button'] {
         cursor: pointer;
       }
-
-      table {
-        border-collapse: collapse;
-      }
-
       h1,
       h2,
       h3,
@@ -9820,29 +9412,16 @@ const _GlobalStyles = () => (
         font-size: inherit;
         font-weight: inherit;
       }
-
       a {
         color: inherit;
         text-decoration: inherit;
       }
-
-      button,
-      input,
-      optgroup,
-      select,
-      textarea {
-        padding: 0;
-        line-height: inherit;
-        color: inherit;
-      }
-
       pre,
       code,
       kbd,
       samp {
         font-family: testMono, testMono2;
       }
-
       img,
       svg,
       video,
@@ -9854,13 +9433,11 @@ const _GlobalStyles = () => (
         display: block;
         vertical-align: middle;
       }
-
       img,
       video {
         max-width: 100%;
         height: auto;
       }
-
       @keyframes spin {
         to {
           transform: rotate(360deg);
@@ -9882,12 +9459,11 @@ const _GlobalStyles = () => (
         0%,
         100% {
           transform: translateY(-25%);
-          animationtimingfunction: cubic-bezier(0.8, 0, 1, 1);
+          animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
         }
-
         50% {
           transform: none;
-          animationtimingfunction: cubic-bezier(0, 0, 0.2, 1);
+          animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
         }
       }
       * {
@@ -9897,8 +9473,6 @@ const _GlobalStyles = () => (
         --tw-ring-color: rgba(59, 130, 246, 0.5);
         --tw-ring-offset-shadow: 0 0 #0000;
         --tw-ring-shadow: 0 0 #0000;
-      }
-      * {
         --tw-shadow: 0 0 #0000;
       }
     \`}
@@ -14639,315 +14213,197 @@ import { Global as _globalImport } from '@emotion/react'
 
 const _GlobalStyles = () => (
   <_globalImport
-    styles={_css\`
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-  
-  :root {
-    -moz-tab-size: 4;
-    tab-size: 4;
-  }
-
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-
-  body {
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  }
-
-  hr {
-    height: 0;
-    color: inherit;
-  }
-
-  abbr[title] {
-    text-decoration: underline dotted;
-  }
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: 1em;
-  }
-
-  small {
-    font-size: 80%;
-  }
-
-  sub,
-  sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  sub {
-    bottom: -0.25em;
-  }
-
-  sup {
-    top: -0.5em;
-  }
-
-  table {
-    text-indent: 0;
-    border-color: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit;
-    font-size: 100%;
-    line-height: 1.15;
-    margin: 0;
-  }
-
-  button,
-  select {
-    text-transform: none;
-  }
-
-  button,
-  [type='button'],
-  [type='reset'],
-  [type='submit'] {
-    -webkit-appearance: button;
-  }
-
-  ::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  :-moz-focusring {
-    outline: 1px dotted ButtonText;
-  }
-
-  :-moz-ui-invalid {
-    box-shadow: none;
-  }
-
-  legend {
-    padding: 0;
-  }
-
-  progress {
-    vertical-align: baseline;
-  }
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    height: auto;
-  }
-
-  [type='search'] {
-    -webkit-appearance: textfield;
-    outline-offset: -2px;
-  }
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button;
-    font: inherit;
-  }
-
-  summary {
-    display: list-item;
-  }
-
-
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
-    margin: 0;
-  }
-
-  button {
-    background-color: transparent;
-    background-image: none;
-  }
-
-  button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-  }
-
-  fieldset {
-    margin: 0;
-    padding: 0;
-  }
-
-  ol,
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    line-height: 1.5;
-  }
-
-  body {
-    font-family: inherit;
-    line-height: inherit;
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: #e5e7eb;
-  }
-
-  hr {
-    border-top-width: 1px;
-  }
-
-  img {
-    border-style: solid;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: #9ca3af;
-  }
-
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  table {
-    border-collapse: collapse;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: inherit;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    padding: 0;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  pre,
-  code,
-  kbd,
-  samp {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  }
-
-  img,
-  svg,
-  video,
-  canvas,
-  audio,
-  iframe,
-  embed,
-  object {
-    display: block;
-    vertical-align: middle;
-  }
-
-  img,
-  video {
-    max-width: 100%;
-    height: auto;
-  }
-
-
-      @keyframes spin {
-          to { 
-            transform: rotate(360deg);
-          }
+    styles={_css\`*, *::before, *::after {
+box-sizing: border-box;
         }
-      @keyframes ping {
-          75%, 100% { 
-            transform: scale(2); opacity: 0;
-          }
+html {
+line-height: 1.5;
+-webkit-text-size-adjust: 100%;
+-moz-tab-size: 4;
+tab-size: 4;
+font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
         }
-      @keyframes pulse {
-          50% { 
-            opacity: .5;
-          }
+body {
+margin: 0;
+font-family: inherit;
+line-height: inherit;
         }
-      @keyframes bounce {
-          0%, 100% { 
-            transform: translateY(-25%); animationTimingFunction: cubic-bezier(0.8,0,1,1);
-          }
-        
-          50% { 
-            transform: none; animationTimingFunction: cubic-bezier(0,0,0.2,1);
-          }
+hr {
+height: 0;
+color: inherit;
+border-top-width: 1px;
+        }
+abbr[title] {
+text-decoration: underline dotted;
+        }
+b, strong {
+font-weight: bolder;
+        }
+code, kbd, samp, pre {
+font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+font-size: 1em;
+        }
+small {
+font-size: 80%;
+        }
+sub, sup {
+font-size: 75%;
+line-height: 0;
+position: relative;
+vertical-align: baseline;
+        }
+sub {
+bottom: -0.25em;
+        }
+sup {
+top: -0.5em;
+        }
+table {
+text-indent: 0;
+border-color: inherit;
+border-collapse: collapse;
+        }
+button, input, optgroup, select, textarea {
+font-family: inherit;
+font-size: 100%;
+line-height: inherit;
+margin: 0;
+padding: 0;
+color: inherit;
+        }
+button, select {
+text-transform: none;
+        }
+button, [type='button'], [type='reset'], [type='submit'] {
+-webkit-appearance: button;
+        }
+::-moz-focus-inner {
+border-style: none;
+padding: 0;
+        }
+:-moz-focusring {
+outline: 1px dotted ButtonText;
+        }
+:-moz-ui-invalid {
+box-shadow: none;
+        }
+legend {
+padding: 0;
+        }
+progress {
+vertical-align: baseline;
+        }
+::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+height: auto;
+        }
+[type='search'] {
+-webkit-appearance: textfield;
+outline-offset: -2px;
+        }
+::-webkit-search-decoration {
+-webkit-appearance: none;
+        }
+::-webkit-file-upload-button {
+-webkit-appearance: button;
+font: inherit;
+        }
+summary {
+display: list-item;
+        }
+blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre {
+margin: 0;
+        }
+button {
+background-color: transparent;
+background-image: none;
+        }
+button:focus:not(/**/) {
+outline: 1px dotted;
+        }
+button:focus {
+outline: 5px auto -webkit-focus-ring-color;
+        }
+fieldset {
+margin: 0;
+padding: 0;
+        }
+ol, ul {
+list-style: none;
+margin: 0;
+padding: 0;
+        }
+*, ::before, ::after {
+box-sizing: border-box;
+border-width: 0;
+border-style: solid;
+border-color: #e5e7eb;
+        }
+img {
+border-style: solid;
+        }
+textarea {
+resize: vertical;
+        }
+input::placeholder, textarea::placeholder {
+color: #9ca3af;
+        }
+button, [role="button"] {
+cursor: pointer;
+        }
+h1, h2, h3, h4, h5, h6 {
+font-size: inherit;
+font-weight: inherit;
+        }
+a {
+color: inherit;
+text-decoration: inherit;
+        }
+pre, code, kbd, samp {
+font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+img, svg, video, canvas, audio, iframe, embed, object {
+display: block;
+vertical-align: middle;
+        }
+img, video {
+max-width: 100%;
+height: auto;
+        }
+@keyframes spin {
+to {
+transform: rotate(360deg);
+        }
+        }
+@keyframes ping {
+75%, 100% {
+transform: scale(2);
+opacity: 0;
+        }
+        }
+@keyframes pulse {
+50% {
+opacity: .5;
+        }
+        }
+@keyframes bounce {
+0%, 100% {
+transform: translateY(-25%);
+animation-timing-function: cubic-bezier(0.8,0,1,1);
+        }
+50% {
+transform: none;
+animation-timing-function: cubic-bezier(0,0,0.2,1);
+        }
         }
 * {
-    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-    --tw-ring-offset-width: 0px;
-    --tw-ring-offset-color: #fff;
-    --tw-ring-color: rgba(59, 130, 246, 0.5);
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-  }
-* {
-  --tw-shadow: 0 0 #0000; }
-
+--tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+--tw-ring-offset-width: 0px;
+--tw-ring-offset-color: #fff;
+--tw-ring-color: rgba(59, 130, 246, 0.5);
+--tw-ring-offset-shadow: 0 0 #0000;
+--tw-ring-shadow: 0 0 #0000;
+--tw-shadow: 0 0 #0000;
+        }
 select {
 background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
 background-position: right 0.5rem center;
@@ -22368,6 +21824,386 @@ tw\`space-y-12 -space-y-reverse\`
     marginBottom: 'calc(3rem * var(--tw-space-y-reverse))',
   },
 })
+
+
+`;
+
+exports[`twin.macro stitchesDotSyntax.js: stitchesDotSyntax.js 1`] = `
+
+import tw, { styled } from './macro'
+
+tw.div\`block\`
+styled.div(tw\`block\`)
+styled.div({ display: 'block' })
+
+// Classic syntax
+styled('div', tw\`block\`)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { styled as _styled } from '__fixtures__/stitches/stitches.config.js'
+
+_styled('div', {
+  display: 'block',
+})
+
+_styled('div', {
+  display: 'block',
+})
+
+_styled('div', {
+  display: 'block',
+}) // Classic syntax
+
+_styled('div', {
+  display: 'block',
+})
+
+
+`;
+
+exports[`twin.macro stitchesGlobals.js: stitchesGlobals.js 1`] = `
+
+import { globalStyles } from './macro'
+import { global } from './stitches.config'
+
+const globals = global(globalStyles)
+
+export function App() {
+  globals()
+  // ...
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { global } from './stitches.config'
+const globals = global({
+  '*, *::before, *::after': {
+    boxSizing: 'border-box',
+  },
+  html: {
+    lineHeight: '1.5',
+    WebkitTextSizeAdjust: '100%',
+    MozTabSize: '4',
+    tabSize: '4',
+    fontFamily:
+      'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+  },
+  body: {
+    margin: '0',
+    fontFamily: 'inherit',
+    lineHeight: 'inherit',
+  },
+  hr: {
+    height: '0',
+    color: 'inherit',
+    borderTopWidth: '1px',
+  },
+  'abbr[title]': {
+    textDecoration: 'underline dotted',
+  },
+  'b, strong': {
+    fontWeight: 'bolder',
+  },
+  'code, kbd, samp, pre': {
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+    fontSize: '1em',
+  },
+  small: {
+    fontSize: '80%',
+  },
+  'sub, sup': {
+    fontSize: '75%',
+    lineHeight: '0',
+    position: 'relative',
+    verticalAlign: 'baseline',
+  },
+  sub: {
+    bottom: '-0.25em',
+  },
+  sup: {
+    top: '-0.5em',
+  },
+  table: {
+    textIndent: '0',
+    borderColor: 'inherit',
+    borderCollapse: 'collapse',
+  },
+  'button, input, optgroup, select, textarea': {
+    fontFamily: 'inherit',
+    fontSize: '100%',
+    lineHeight: 'inherit',
+    margin: '0',
+    padding: '0',
+    color: 'inherit',
+  },
+  'button, select': {
+    textTransform: 'none',
+  },
+  "button, [type='button'], [type='reset'], [type='submit']": {
+    WebkitAppearance: 'button',
+  },
+  '::-moz-focus-inner': {
+    borderStyle: 'none',
+    padding: '0',
+  },
+  ':-moz-focusring': {
+    outline: '1px dotted ButtonText',
+  },
+  ':-moz-ui-invalid': {
+    boxShadow: 'none',
+  },
+  legend: {
+    padding: '0',
+  },
+  progress: {
+    verticalAlign: 'baseline',
+  },
+  '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
+    height: 'auto',
+  },
+  "[type='search']": {
+    WebkitAppearance: 'textfield',
+    outlineOffset: '-2px',
+  },
+  '::-webkit-search-decoration': {
+    WebkitAppearance: 'none',
+  },
+  '::-webkit-file-upload-button': {
+    WebkitAppearance: 'button',
+    font: 'inherit',
+  },
+  summary: {
+    display: 'list-item',
+  },
+  'blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre': {
+    margin: '0',
+  },
+  button: {
+    backgroundColor: 'transparent',
+    backgroundImage: 'none',
+  },
+  'button:focus:not(/**/)': {
+    outline: '1px dotted',
+  },
+  'button:focus': {
+    outline: '5px auto -webkit-focus-ring-color',
+  },
+  fieldset: {
+    margin: '0',
+    padding: '0',
+  },
+  'ol, ul': {
+    listStyle: 'none',
+    margin: '0',
+    padding: '0',
+  },
+  '*, ::before, ::after': {
+    boxSizing: 'border-box',
+    borderWidth: '0',
+    borderStyle: 'solid',
+    borderColor: '#e5e7eb',
+  },
+  img: {
+    borderStyle: 'solid',
+  },
+  textarea: {
+    resize: 'vertical',
+  },
+  'input::placeholder, textarea::placeholder': {
+    color: '#9ca3af',
+  },
+  'button, [role="button"]': {
+    cursor: 'pointer',
+  },
+  'h1, h2, h3, h4, h5, h6': {
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
+  },
+  a: {
+    color: 'inherit',
+    textDecoration: 'inherit',
+  },
+  'pre, code, kbd, samp': {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  },
+  'img, svg, video, canvas, audio, iframe, embed, object': {
+    display: 'block',
+    verticalAlign: 'middle',
+  },
+  'img, video': {
+    maxWidth: '100%',
+    height: 'auto',
+  },
+  '@keyframes spin': {
+    to: {
+      transform: 'rotate(360deg)',
+    },
+  },
+  '@keyframes ping': {
+    '75%, 100%': {
+      transform: 'scale(2)',
+      opacity: '0',
+    },
+  },
+  '@keyframes pulse': {
+    '50%': {
+      opacity: '.5',
+    },
+  },
+  '@keyframes bounce': {
+    '0%, 100%': {
+      transform: 'translateY(-25%)',
+      animationTimingFunction: 'cubic-bezier(0.8,0,1,1)',
+    },
+    '50%': {
+      transform: 'none',
+      animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
+    },
+  },
+  '*': {
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': 'rgba(59, 130, 246, 0.5)',
+    '--tw-ring-offset-shadow': '0 0 #0000',
+    '--tw-ring-shadow': '0 0 #0000',
+    '--tw-shadow': '0 0 #0000',
+  },
+})
+export function App() {
+  globals() // ...
+}
+
+
+`;
+
+exports[`twin.macro stitchesImports.js: stitchesImports.js 1`] = `
+
+import tw, { css, styled } from './macro'
+
+css(tw\`block\`)
+tw.div\`block\`
+styled.div(tw\`block\`)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { css as _css } from '__fixtures__/stitches/stitches.config.js'
+import { styled as _styled } from '__fixtures__/stitches/stitches.config.js'
+
+_css({
+  display: 'block',
+})
+
+_styled('div', {
+  display: 'block',
+})
+
+_styled('div', {
+  display: 'block',
+})
+
+
+`;
+
+exports[`twin.macro stitchesProps.js: stitchesProps.js 1`] = `
+
+import tw from './macro'
+// tw prop
+;<div tw="block" />
+
+// tw + css prop
+;<div tw="block" css={{ color: 'black' }} />
+;<div tw="block" css={tw\`text-black\`} />
+;<div css={{ color: 'black' }} tw="block" />
+;<div css={{ color: 'black' }} tw="block" thisShouldBePreserved="yup" />
+
+// Extracted styles
+const styles = {
+  container: ({ isInline }) => ({ ...tw\`block\`, ...(isInline && tw\`inline\`) }),
+}
+;<div css={styles.container({ isInline: true })} />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { styled as _styled } from '__fixtures__/stitches/stitches.config.js'
+
+const _TwComponent = _styled('div', {
+  display: 'block',
+})
+
+;<_TwComponent /> // tw + css prop
+
+const _TwComponent2 = _styled('div', {
+  display: 'block',
+})
+
+const _TwComponent3 = _styled(_TwComponent2, {})
+
+;<_TwComponent3
+  css={{
+    color: 'black',
+  }}
+/>
+
+const _TwComponent4 = _styled('div', {
+  display: 'block',
+})
+
+const _TwComponent5 = _styled(_TwComponent4, {})
+
+;<_TwComponent5
+  css={{
+    '--tw-text-opacity': '1',
+    color: 'rgba(0, 0, 0, var(--tw-text-opacity))',
+  }}
+/>
+
+const _TwComponent6 = _styled('div', {
+  display: 'block',
+})
+
+const _TwComponent7 = _styled(_TwComponent6, {})
+
+;<_TwComponent7
+  css={{
+    color: 'black',
+  }}
+/>
+
+const _TwComponent8 = _styled('div', {
+  display: 'block',
+})
+
+const _TwComponent9 = _styled(_TwComponent8, {})
+
+;<_TwComponent9
+  css={{
+    color: 'black',
+  }}
+  thisShouldBePreserved="yup"
+/> // Extracted styles
+
+const styles = {
+  container: ({ isInline }) => ({
+    ...{
+      display: 'block',
+    },
+    ...(isInline && {
+      display: 'inline',
+    }),
+  }),
+}
+
+const _TwComponent10 = _styled('div', {})
+
+;<_TwComponent10
+  css={styles.container({
+    isInline: true,
+  })}
+/>
 
 
 `;

--- a/docs/options.md
+++ b/docs/options.md
@@ -7,7 +7,7 @@ These options are available in your [twin config](#configlocation):
 | Name                  | Default                | Description                                                                                                                                   |
 | --------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | config                | `"tailwind.config.js"` | The path to your Tailwind config.                                                                                                             |
-| preset                | `"emotion"`            | The css-in-js library behind the scenes.<br>Also supported: `"styled-components"` `"goober"`                                                  |
+| preset                | `"emotion"`            | The css-in-js library behind the scenes.<br>Also supported: `"styled-components"` `"goober"` `"stitches"`                                     |
 | autoCssProp           | `true`                 | This automates the import of 'styled-components/macro' so you can use their css prop. Enabled by default with the `styled-components` preset. |
 | hasSuggestions        | `true`                 | Display suggestions when a class isn’t found.                                                                                                 |
 | dataTwProp            | `true`                 | Add a prop to jsx components in development showing the original tailwind classes.<br/> Use `"all"` to keep the prop in production.           |
@@ -63,11 +63,9 @@ module.exports = {
 preset: 'emotion', // Set the css-in-js library to use with twin
 ```
 
-Supports: `'emotion'` / `'styled-components'` / `'goober'`.
+Supports: `'emotion'` / `'styled-components'` / `'goober'` / `'stitches'`.
 
 The preset option primarily assigns the library imports for `css`, `styled` and `GlobalStyles`.
-
-- [stitches](https://stitches.dev/) is supported but doesn’t have a preset yet - [see example](https://github.com/ben-rogerson/twin.examples/tree/master/next-stitches-typescript)
 
 </details>
 
@@ -336,4 +334,4 @@ b) Or in `package.json`:
 
 ---
 
-[&lsaquo; Documentation](https://github.com/ben-rogerson/twin.macro/blob/master/docs/index.md)
+[&lsaquo; Documentation index](https://github.com/ben-rogerson/twin.macro/blob/master/docs/index.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -454,14 +454,62 @@
       }
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-      "dev": true,
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
+          "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ=="
+        },
+        "@babel/types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
@@ -15263,8 +15311,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/ben-rogerson/twin.macro#readme",
   "dependencies": {
     "@babel/parser": "^7.12.5",
+    "@babel/template": "^7.14.5",
     "autoprefixer": "^10.2.5",
     "babel-plugin-macros": "^2.8.0",
     "chalk": "^4.1.0",

--- a/src/config/globalStyles.js
+++ b/src/config/globalStyles.js
@@ -1,9 +1,10 @@
-import { globalPreflightStyles } from './preflightStyles'
+import { modernNormalizeStyles, globalPreflightStyles } from './preflightStyles'
 import { globalKeyframeStyles } from './../plugins/animation'
 import { globalRingStyles } from './../plugins/ring'
 import { globalBoxShadowStyles } from './../plugins/boxShadow'
 
 const globalStyles = [
+  modernNormalizeStyles,
   globalPreflightStyles,
   globalKeyframeStyles,
   globalRingStyles,

--- a/src/config/preflightStyles.js
+++ b/src/config/preflightStyles.js
@@ -2,146 +2,65 @@
  * Embedding modern-normalize here is the best option right now as converting
  * the css file to a string causes syntax errors.
  * So these styles must be kept in sync with the remote package for now.
+ * https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css
  */
-const modernNormalizeStyles = `
-  *,
-  *::before,
-  *::after {
-    box-sizing: border-box;
-  }
-  
-  :root {
-    -moz-tab-size: 4;
-    tab-size: 4;
-  }
-
-  html {
-    line-height: 1.15;
-    -webkit-text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-
-  body {
-    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  }
-
-  hr {
-    height: 0;
-    color: inherit;
-  }
-
-  abbr[title] {
-    text-decoration: underline dotted;
-  }
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  code,
-  kbd,
-  samp,
-  pre {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: 1em;
-  }
-
-  small {
-    font-size: 80%;
-  }
-
-  sub,
-  sup {
-    font-size: 75%;
-    line-height: 0;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  sub {
-    bottom: -0.25em;
-  }
-
-  sup {
-    top: -0.5em;
-  }
-
-  table {
-    text-indent: 0;
-    border-color: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    font-family: inherit;
-    font-size: 100%;
-    line-height: 1.15;
-    margin: 0;
-  }
-
-  button,
-  select {
-    text-transform: none;
-  }
-
-  button,
-  [type='button'],
-  [type='reset'],
-  [type='submit'] {
-    -webkit-appearance: button;
-  }
-
-  ::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  :-moz-focusring {
-    outline: 1px dotted ButtonText;
-  }
-
-  :-moz-ui-invalid {
-    box-shadow: none;
-  }
-
-  legend {
-    padding: 0;
-  }
-
-  progress {
-    vertical-align: baseline;
-  }
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    height: auto;
-  }
-
-  [type='search'] {
-    -webkit-appearance: textfield;
-    outline-offset: -2px;
-  }
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-file-upload-button {
-    -webkit-appearance: button;
-    font: inherit;
-  }
-
-  summary {
-    display: list-item;
-  }
-`
+const modernNormalizeStyles = {
+  '*, *::before, *::after': { boxSizing: 'border-box' },
+  html: {
+    lineHeight: '1.15',
+    WebkitTextSizeAdjust: '100%',
+    MozTabSize: '4',
+    tabSize: '4',
+  },
+  body: {
+    margin: '0',
+    fontFamily:
+      "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+  },
+  hr: { height: '0', color: 'inherit' },
+  'abbr[title]': { textDecoration: 'underline dotted' },
+  'b, strong': { fontWeight: 'bolder' },
+  'code, kbd, samp, pre': {
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+    fontSize: '1em',
+  },
+  small: { fontSize: '80%' },
+  'sub, sup': {
+    fontSize: '75%',
+    lineHeight: '0',
+    position: 'relative',
+    verticalAlign: 'baseline',
+  },
+  sub: { bottom: '-0.25em' },
+  sup: { top: '-0.5em' },
+  table: { textIndent: '0', borderColor: 'inherit' },
+  'button, input, optgroup, select, textarea': {
+    fontFamily: 'inherit',
+    fontSize: '100%',
+    lineHeight: '1.15',
+    margin: '0',
+  },
+  'button, select': { textTransform: 'none' },
+  "button, [type='button'], [type='reset'], [type='submit']": {
+    WebkitAppearance: 'button',
+  },
+  '::-moz-focus-inner': { borderStyle: 'none', padding: '0' },
+  ':-moz-focusring': { outline: '1px dotted ButtonText' },
+  ':-moz-ui-invalid': { boxShadow: 'none' },
+  legend: { padding: '0' },
+  progress: { verticalAlign: 'baseline' },
+  '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
+    height: 'auto',
+  },
+  "[type='search']": { WebkitAppearance: 'textfield', outlineOffset: '-2px' },
+  '::-webkit-search-decoration': { WebkitAppearance: 'none' },
+  '::-webkit-file-upload-button': {
+    WebkitAppearance: 'button',
+    font: 'inherit',
+  },
+  summary: { display: 'list-item' },
+}
 
 /**
  * These are the same base styles tailwindcss uses.
@@ -149,148 +68,63 @@ const modernNormalizeStyles = `
  * converting it from css to a string.
  * https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/src/plugins/css/preflight.css
  */
-const tailwindBaseStyles = ({ theme }) => `
-  blockquote,
-  dl,
-  dd,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  hr,
-  figure,
-  p,
-  pre {
-    margin: 0;
-  }
-
-  button {
-    background-color: transparent;
-    background-image: none;
-  }
-
-  button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-  }
-
-  fieldset {
-    margin: 0;
-    padding: 0;
-  }
-
-  ol,
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    font-family: ${
+const globalPreflightStyles = ({ theme }) => ({
+  'blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre': {
+    margin: '0',
+  },
+  button: { backgroundColor: 'transparent', backgroundImage: 'none' },
+  // Css object styles can't have duplicate keys.
+  // This means fallbacks can't be specified like they can in css.
+  // Here we use a bogus `:not` for a different key without adding extra specificity.
+  'button:focus:not(/**/)': {
+    outline: '1px dotted',
+  },
+  'button:focus': {
+    outline: '5px auto -webkit-focus-ring-color',
+  },
+  fieldset: { margin: '0', padding: '0' },
+  'ol, ul': { listStyle: 'none', margin: '0', padding: '0' },
+  html: {
+    fontFamily:
       theme`fontFamily.sans` ||
-      `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`
-    };
-    line-height: 1.5;
-  }
-
-  body {
-    font-family: inherit;
-    line-height: inherit;
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: ${theme`borderColor.DEFAULT` || `currentColor`};
-  }
-
-  hr {
-    border-top-width: 1px;
-  }
-
-  img {
-    border-style: solid;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: ${theme`colors.gray.400` || `#a1a1aa`};
-  }
-
-  button,
-  [role="button"] {
-    cursor: pointer;
-  }
-
-  table {
-    border-collapse: collapse;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: inherit;
-    font-weight: inherit;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: inherit;
-  }
-
-  button,
-  input,
-  optgroup,
-  select,
-  textarea {
-    padding: 0;
-    line-height: inherit;
-    color: inherit;
-  }
-
-  pre,
-  code,
-  kbd,
-  samp {
-    font-family: ${
+      `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+    lineHeight: '1.5',
+  },
+  body: { fontFamily: 'inherit', lineHeight: 'inherit' },
+  '*, ::before, ::after': {
+    boxSizing: 'border-box',
+    borderWidth: '0',
+    borderStyle: 'solid',
+    borderColor: theme`borderColor.DEFAULT` || 'currentColor',
+  },
+  hr: { borderTopWidth: '1px' },
+  img: { borderStyle: 'solid' },
+  textarea: { resize: 'vertical' },
+  'input::placeholder, textarea::placeholder': {
+    color: theme`colors.gray.400` || '#a1a1aa',
+  },
+  'button, [role="button"]': { cursor: 'pointer' },
+  table: { borderCollapse: 'collapse' },
+  'h1, h2, h3, h4, h5, h6': {
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
+  },
+  a: { color: 'inherit', textDecoration: 'inherit' },
+  'button, input, optgroup, select, textarea': {
+    padding: '0',
+    lineHeight: 'inherit',
+    color: 'inherit',
+  },
+  'pre, code, kbd, samp': {
+    fontFamily:
       theme`fontFamily.mono` ||
-      `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`
-    };
-  }
+      `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+  },
+  'img, svg, video, canvas, audio, iframe, embed, object': {
+    display: 'block',
+    verticalAlign: 'middle',
+  },
+  'img, video': { maxWidth: '100%', height: 'auto' },
+})
 
-  img,
-  svg,
-  video,
-  canvas,
-  audio,
-  iframe,
-  embed,
-  object {
-    display: block;
-    vertical-align: middle;
-  }
-
-  img,
-  video {
-    max-width: 100%;
-    height: auto;
-  }
-`
-
-const globalPreflightStyles = ({ theme }) =>
-  [modernNormalizeStyles, tailwindBaseStyles({ theme })].join(`\n`)
-
-export { globalPreflightStyles }
+export { modernNormalizeStyles, globalPreflightStyles }

--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -1,8 +1,19 @@
 // Defaults for different css-in-js libraries
 const configDefaultsStyledComponents = { autoCssProp: true } // Automates the import of styled-components when you use their css prop
 const configDefaultsGoober = { sassyPseudo: true } // Sets selectors like hover to &:hover
+const configDefaultsStitches = {
+  sassyPseudo: true, // Sets selectors like hover to &:hover
+  convertStyledDot: true, // Convert styled.[element] to a default syntax
+  moveTwPropToStyled: true, // Move the tw prop to a styled definition
+  convertHtmlElementToStyled: true, // For packages like stitches, add a styled definition on css prop elements
+}
 
-const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
+const configDefaultsTwin = ({
+  isStyledComponents,
+  isGoober,
+  isStitches,
+  isDev,
+}) => ({
   allowStyleProp: false, // Allows styles within style="blah" without throwing an error
   autoCssProp: false, // Automates the import of styled-components when you use their css prop
   dataTwProp: isDev, // During development, add a data-tw="" prop containing your tailwind classes for backtracing
@@ -14,18 +25,26 @@ const configDefaultsTwin = ({ isStyledComponents, isGoober, isDev }) => ({
   dataCsProp: isDev, // During development, add a data-cs="" prop containing your short css classes for backtracing
   disableCsProp: false, // Disable converting css styles in the cs prop
   disableShortCss: false, // Disable converting css written using short css
+  stitchesConfig: undefined, // Set the path to the stitches config (stitches only)
+  config: undefined, // Set the path to the tailwind config
+  convertStyledDot: false, // Convert styled.[element] to a default syntax (only used for stitches so far)
+  moveTwPropToStyled: false, // Move the tw prop to a styled definition (only used for stitches so far)
+  convertHtmlElementToStyled: false, // For packages like stitches, add a styled definition on css prop elements
   ...(isStyledComponents && configDefaultsStyledComponents),
   ...(isGoober && configDefaultsGoober),
+  ...(isStitches && configDefaultsStitches),
 })
 
 const isBoolean = value => typeof value === 'boolean'
 
+const allowedPresets = ['styled-components', 'emotion', 'goober', 'stitches']
+
 const configTwinValidators = {
   preset: [
-    value =>
-      value === undefined ||
-      ['styled-components', 'emotion', 'goober'].includes(value),
-    `The config “preset” can only be set to ‘emotion’ (default), ‘styled-components’ or ‘goober’`,
+    value => value === undefined || allowedPresets.includes(value),
+    `The config “preset” can only be:\n${allowedPresets
+      .map(p => `'${p}'`)
+      .join(', ')}`,
   ],
   allowStyleProp: [
     isBoolean,
@@ -66,6 +85,18 @@ const configTwinValidators = {
   disableCsProp: [
     isBoolean,
     'The config “disableCsProp” can only be true or false',
+  ],
+  convertStyledDot: [
+    isBoolean,
+    'The config “convertStyledDot” can only be true or false',
+  ],
+  moveTwPropToStyled: [
+    isBoolean,
+    'The config “moveTwPropToStyled” can only be true or false',
+  ],
+  convertHtmlElementToStyled: [
+    isBoolean,
+    'The config “convertHtmlElementToStyled” can only be true or false',
   ],
 }
 

--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -59,4 +59,18 @@ export default {
       from: 'goober/global',
     },
   },
+  stitches: {
+    styled: {
+      import: 'styled',
+      from: 'stitches.config',
+    },
+    css: {
+      import: 'css',
+      from: 'stitches.config',
+    },
+    global: {
+      import: 'global',
+      from: 'stitches.config',
+    },
+  },
 }

--- a/src/handlers/userPlugins.js
+++ b/src/handlers/userPlugins.js
@@ -18,7 +18,7 @@ const mergeChecks = [
   ({ key, className, prefix }) => key.includes(`{{${prefix}${className}}}`),
   // Match possible symbols after the selector (ex dot)
   ({ key, className, prefix }) =>
-    [(' ', ':', '>', '~', '+', '*')].some(suffix =>
+    [' ', ':', '>', '~', '+', '*'].some(suffix =>
       key.startsWith(`${prefix}${className}${suffix}`)
     ),
 ]

--- a/src/macro/tw.js
+++ b/src/macro/tw.js
@@ -4,46 +4,29 @@ import {
   replaceWithLocation,
   getAttributeNames,
   getCssAttributeData,
+  makeStyledComponent,
 } from './../macroHelpers'
 import { throwIf } from './../utils'
 import { logGeneralError, logStylePropertyError } from './../logging'
 import { addDataTwPropToPath, addDataPropToExistingPath } from './debug'
 import getStyleData from './../getStyleData'
 
-const handleTwProperty = ({ path, t, state }) => {
-  if (!path.node || path.node.name.name !== 'tw') return
-  state.hasTwAttribute = true
+const moveTwPropToStyled = props => {
+  const { jsxPath, styles } = props
 
-  const nodeValue = path.node.value
+  makeStyledComponent({ ...props, secondArg: styles })
 
-  // Allow tw={"class"}
-  const expressionValue =
-    nodeValue.expression &&
-    nodeValue.expression.type === 'StringLiteral' &&
-    nodeValue.expression.value
-
-  // Feedback for unsupported usage
-  throwIf(nodeValue.expression && !expressionValue, () =>
-    logGeneralError(
-      `Only plain strings can be used with the "tw" prop.\nEg: <div tw="text-black" /> or <div tw={"text-black"} />\nRead more at https://twinredirect.page.link/template-literals`
-    )
+  // Remove the tw attribute
+  const tagAttributes = jsxPath.node.attributes
+  const twAttributeIndex = tagAttributes.findIndex(
+    n => n.name && n.name.name === 'tw'
   )
+  if (twAttributeIndex < 0) return
+  jsxPath.node.attributes.splice(twAttributeIndex, 1)
+}
 
-  const rawClasses = expressionValue || nodeValue.value || ''
-  const { styles } = getStyleData(rawClasses, { t, state })
-
-  const jsxPath = getParentJSX(path)
-  const attributes = jsxPath.get('attributes')
-  const { attribute: cssAttribute } = getCssAttributeData(attributes)
-
-  if (!cssAttribute) {
-    // Replace the tw prop with the css prop
-    path.replaceWith(
-      t.jsxAttribute(t.jsxIdentifier('css'), t.jsxExpressionContainer(styles))
-    )
-    addDataTwPropToPath({ t, attributes, rawClasses, path, state })
-    return
-  }
+const mergeIntoCssAttribute = ({ path, styles, cssAttribute, t }) => {
+  if (!cssAttribute) return
 
   // The expression is the value as a NodePath
   const attributeValuePath = cssAttribute.get('value')
@@ -59,7 +42,7 @@ const handleTwProperty = ({ path, t, state }) => {
     ? attributeValuePath
     : attributeValuePath.get('expression')
 
-  const attributeNames = getAttributeNames(jsxPath)
+  const attributeNames = getAttributeNames(path)
 
   const isBeforeCssAttribute =
     attributeNames.indexOf('tw') - attributeNames.indexOf('css') < 0
@@ -95,28 +78,71 @@ const handleTwProperty = ({ path, t, state }) => {
 
     existingCssAttribute.replaceWith(replacement)
   }
+}
+
+const handleTwProperty = ({ path, t, program, state }) => {
+  if (!path.node || path.node.name.name !== 'tw') return
+  state.hasTwAttribute = true
+
+  const nodeValue = path.node.value
+
+  // Allow tw={"class"}
+  const expressionValue =
+    nodeValue.expression &&
+    nodeValue.expression.type === 'StringLiteral' &&
+    nodeValue.expression.value
+
+  // Feedback for unsupported usage
+  throwIf(nodeValue.expression && !expressionValue, () =>
+    logGeneralError(
+      `Only plain strings can be used with the "tw" prop.\nEg: <div tw="text-black" /> or <div tw={"text-black"} />\nRead more at https://twinredirect.page.link/template-literals`
+    )
+  )
+
+  const rawClasses = expressionValue || nodeValue.value || ''
+  const { styles } = getStyleData(rawClasses, { t, state })
+
+  const jsxPath = getParentJSX(path)
+  const attributes = jsxPath.get('attributes')
+  const { attribute: cssAttribute } = getCssAttributeData(attributes)
+
+  if (state.configTwin.moveTwPropToStyled) {
+    moveTwPropToStyled({ styles, jsxPath, t, program, state })
+    addDataTwPropToPath({ t, attributes, rawClasses, path, state })
+    return
+  }
+
+  if (!cssAttribute) {
+    // Replace the tw prop with the css prop
+    path.replaceWith(
+      t.jsxAttribute(t.jsxIdentifier('css'), t.jsxExpressionContainer(styles))
+    )
+    addDataTwPropToPath({ t, attributes, rawClasses, path, state })
+    return
+  }
+
+  // Merge tw styles into an existing css prop
+  mergeIntoCssAttribute({ cssAttribute, path: jsxPath, styles, t })
 
   path.remove() // remove the tw prop
 
-  addDataPropToExistingPath({
-    t,
-    attributes,
-    rawClasses,
-    path: jsxPath,
-    state,
-  })
+  addDataPropToExistingPath({ t, attributes, rawClasses, path: jsxPath, state })
 }
 
 const handleTwFunction = ({ references, state, t }) => {
   const defaultImportReferences = references.default || references.tw || []
+
   defaultImportReferences.forEach(path => {
     /**
      * Gotcha: After twin changes a className/tw/cs prop path then the reference
      * becomes stale and needs to be refreshed with crawl()
      */
-    if (!path.parentPath.isTaggedTemplateExpression()) {
+    const { parentPath } = path
+    if (
+      !parentPath.isTaggedTemplateExpression() ||
+      !parentPath.isJSXExpressionContainer()
+    )
       path.scope.crawl()
-    }
 
     const parent = path.findParent(x => x.isTaggedTemplateExpression())
     if (!parent) return
@@ -138,18 +164,13 @@ const handleTwFunction = ({ references, state, t }) => {
     if (!parsed) return
 
     const rawClasses = parsed.string
-
     // Add tw-prop for css attributes
     const jsxPath = path.findParent(p => p.isJSXOpeningElement())
+
     if (jsxPath) {
       const attributes = jsxPath.get('attributes')
-      addDataPropToExistingPath({
-        t,
-        attributes,
-        rawClasses,
-        path: jsxPath,
-        state,
-      })
+      const pathData = { t, attributes, rawClasses, path: jsxPath, state }
+      addDataPropToExistingPath(pathData)
     }
 
     const { styles } = getStyleData(rawClasses, { t, state })

--- a/src/plugins/animation.js
+++ b/src/plugins/animation.js
@@ -25,20 +25,9 @@ export const globalKeyframeStyles = ({ theme }) => {
   const keyframes = theme`keyframes`
   if (!keyframes) return
 
-  return Object.entries(keyframes)
-    .map(
-      ([name, frames]) => `
-      @keyframes ${name} {${Object.entries(frames)
-        .map(
-          ([offset, styles]) => `
-          ${offset} { 
-            ${Object.entries(styles)
-              .map(([key, value]) => `${key}: ${value};`)
-              .join(' ')}
-          }
-        `
-        )
-        .join('')}}`
-    )
-    .join('')
+  const output = Object.entries(keyframes).reduce(
+    (result, [name, frames]) => ({ ...result, [`@keyframes ${name}`]: frames }),
+    {}
+  )
+  return output
 }

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -1,6 +1,6 @@
-export const globalBoxShadowStyles = () => `* {
-  --tw-shadow: 0 0 #0000; }
-`
+export const globalBoxShadowStyles = {
+  '*': { '--tw-shadow': '0 0 #0000' },
+}
 
 export default properties => {
   const {

--- a/src/plugins/ring.js
+++ b/src/plugins/ring.js
@@ -14,14 +14,16 @@ export const globalRingStyles = ({ theme }) => {
     safeCall(() => toRgba(theme`ringColor.DEFAULT`), ['147', '197', '253'])
   )
 
-  return `* {
-    --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
-    --tw-ring-offset-width: ${theme('ringOffsetWidth.DEFAULT') || '0px'};
-    --tw-ring-offset-color: ${theme('ringOffsetColor.DEFAULT') || '#fff'};
-    --tw-ring-color: ${ringColorDefault};
-    --tw-ring-offset-shadow: 0 0 #0000;
-    --tw-ring-shadow: 0 0 #0000;
-  }`
+  return {
+    '*': {
+      '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+      '--tw-ring-offset-width': theme('ringOffsetWidth.DEFAULT') || '0px',
+      '--tw-ring-offset-color': theme('ringOffsetColor.DEFAULT') || '#fff',
+      '--tw-ring-color': ringColorDefault,
+      '--tw-ring-offset-shadow': '0 0 #0000',
+      '--tw-ring-shadow': '0 0 #0000',
+    },
+  }
 }
 
 const handleWidth = ({ configValue, important }) => {

--- a/src/plugins/ringOffset.js
+++ b/src/plugins/ringOffset.js
@@ -1,4 +1,5 @@
-import { toColorValue } from './../utils'
+const toColorValue = maybeFunction =>
+  typeof maybeFunction === 'function' ? maybeFunction({}) : maybeFunction
 
 const handleColor = ({ configValue }) => {
   const value = configValue('ringOffsetColor')

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -15,4 +15,3 @@ export {
 } from './misc'
 export { default as withAlpha, transparentTo } from './withAlpha'
 export { toRgba } from './withAlpha'
-export { toColorValue } from './toColorValue'

--- a/src/utils/toColorValue.js
+++ b/src/utils/toColorValue.js
@@ -1,2 +1,0 @@
-export const toColorValue = maybeFunction =>
-  typeof maybeFunction === 'function' ? maybeFunction({}) : maybeFunction

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,4 +61,6 @@ declare global {
 declare const theme: ThemeFn
 declare const screen: ScreenFn
 
-export { theme, screen }
+declare const globalStyles: Record<string, unknown>
+
+export { theme, screen, globalStyles }


### PR DESCRIPTION
I've added some nice features that improve the experience with twin + stitches.

Add the new stitches preset to activate the features:

```js
{ preset: "stitches" }
````

## Styled components

### Basic styling

Create components with a short tw.[element] syntax:

```js
import tw from 'twin.macro'
const Component = tw.div`bg-black text-white`
```

### Conditional styling

Add conditional styling with the styled import:

```js
import tw, { styled } from 'twin.macro'

const Component = styled.input({
  ...tw`bg-black text-white`,
  variants: {
    hasBorder: { true: tw`border-purple-500` },
  },
})

const Input = () => <Component hasBorder />
```

## Prop styling

### Basic styling

Use the tw prop to add styles directly onto elements:

```js
import 'twin.macro'

const Input = () => <input tw="border hover:border-black" />
```

### Conditional styling

Use the css prop on html elements without a styled definition:

```js
import tw from 'twin.macro'

const Input = ({ hasHover }) => (
  <input css={{ ...tw`border`, ...(hasHover && tw`hover:border-black`) }} />
)
```