### PR TITLE
Fix css function usage

### DIFF
--- a/docs/styled-component-guide.md
+++ b/docs/styled-component-guide.md
@@ -340,8 +340,8 @@ The styled import accepts a sass-like syntax, allowing both custom css and tailw
 ```js
 import tw, { styled, css, theme } from 'twin.macro'
 
-const Input = styled.div(
-  css`
+const Input = styled.div`
+  ${css`
     -webkit-tap-highlight-color: transparent; /* add css styles */
     background-color: ${theme`colors.red.500`}; /* add values from your tailwind config */
     ${tw`text-blue-500 border-2`}; /* tailwind classes */
@@ -349,8 +349,8 @@ const Input = styled.div(
     &::selection {
       ${tw`text-purple-500`}; /* style custom css selectors with tailwind classes */
     }
-  `
-)
+  `}
+`
 
 const Component = () => <Input />
 ```


### PR DESCRIPTION
With the previous code example I was facing the following error using TypeScript:

![twin-css](https://user-images.githubusercontent.com/1562097/125148106-45adbf00-e106-11eb-9139-90f4e283717a.PNG)

Looking for a solution I found this comment which fixes the issue:
https://github.com/styled-components/styled-components/issues/1502#issuecomment-363954636