### PR TITLE
Add background-origin utilities

### DIFF
--- a/__fixtures__/backgrounds.js
+++ b/__fixtures__/backgrounds.js
@@ -11,6 +11,11 @@ tw`bg-clip-padding`
 tw`bg-clip-content`
 tw`bg-clip-text`
 
+// https://tailwindcss.com/docs/background-origin
+tw`bg-origin-border`
+tw`bg-origin-padding`
+tw`bg-origin-content`
+
 // https://tailwindcss.com/docs/background-color
 tw`bg-transparent`
 tw`bg-current`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2821,6 +2821,11 @@ tw\`bg-clip-padding\`
 tw\`bg-clip-content\`
 tw\`bg-clip-text\`
 
+// https://tailwindcss.com/docs/background-origin
+tw\`bg-origin-border\`
+tw\`bg-origin-padding\`
+tw\`bg-origin-content\`
+
 // https://tailwindcss.com/docs/background-color
 tw\`bg-transparent\`
 tw\`bg-current\`
@@ -3256,6 +3261,16 @@ tw\`bg-gradient-to-t from-electric to-electric text-purple-500 text-opacity-50\`
 ;({
   WebkitBackgroundClip: 'text',
   backgroundClip: 'text',
+}) // https://tailwindcss.com/docs/background-origin
+
+;({
+  backgroundOrigin: 'border-box',
+})
+;({
+  backgroundOrigin: 'padding-box',
+})
+;({
+  backgroundOrigin: 'content-box',
 }) // https://tailwindcss.com/docs/background-color
 
 ;({

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -489,6 +489,17 @@ export default {
     },
   },
 
+  // https://tailwindcss.com/docs/background-origin
+  'bg-origin-border': {
+    output: { backgroundOrigin: 'border-box' },
+  },
+  'bg-origin-padding': {
+    output: { backgroundOrigin: 'padding-box' },
+  },
+  'bg-origin-content': {
+    output: { backgroundOrigin: 'content-box' },
+  },
+
   // https://tailwindcss.com/docs/background-color
   // https://tailwindcss.com/docs/background-size
   // https://tailwindcss.com/docs/background-position


### PR DESCRIPTION
Checks off an item on the #465 to-do list.

Based on https://github.com/tailwindlabs/tailwindcss/pull/4117, https://tailwindcss.com/docs/background-origin

Thank you, @ben-rogerson, for your help! I wasn't sure if I should regenerate the test snapshot — I'd be glad to revert that commit if you'd like. Let me know if there's anything else to do on this. 😄 