### PR TITLE
Enable variants on the container class

### DIFF
--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -2,6 +2,7 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/container
 tw`container`
+tw`md:container md:mx-auto`
 
 // https://tailwindcss.com/docs/box-sizing
 tw`box-border`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12066,6 +12066,7 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/container
 tw\`container\`
+tw\`md:container md:mx-auto\`
 
 // https://tailwindcss.com/docs/box-sizing
 tw\`box-border\`
@@ -12810,6 +12811,55 @@ tw\`z-auto\`
     maxWidth: '1200px',
     paddingLeft: '12rem',
     paddingRight: '12rem',
+  },
+})
+;({
+  '@media (min-width: 768px)': {
+    width: '100%',
+    paddingLeft: '1rem',
+    paddingRight: '2rem',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    '@media (min-width: 640px)': {
+      maxWidth: '640px',
+      paddingLeft: '2rem',
+      marginLeft: 'auto',
+    },
+    '@media (min-width: 768px)': {
+      maxWidth: '768px',
+    },
+    '@media (min-width: 1024px)': {
+      maxWidth: '1024px',
+      paddingLeft: '4rem',
+      paddingRight: '4rem',
+      marginLeft: '5rem',
+      marginRight: '5rem',
+    },
+    '@media (min-width: 1280px)': {
+      maxWidth: '1280px',
+      paddingLeft: '6rem',
+      paddingRight: '6rem',
+      marginLeft: '7rem',
+      marginRight: '7rem',
+    },
+    '@media (min-width: 1536px)': {
+      maxWidth: '1536px',
+    },
+    '@media (min-width: 968px)': {
+      maxWidth: '968px',
+      paddingLeft: '8rem',
+      paddingRight: '8rem',
+    },
+    '@media (min-width: 992px)': {
+      maxWidth: '992px',
+      paddingLeft: '10rem',
+      paddingRight: '10rem',
+    },
+    '@media (min-width: 1200px)': {
+      maxWidth: '1200px',
+      paddingLeft: '12rem',
+      paddingRight: '12rem',
+    },
   },
 }) // https://tailwindcss.com/docs/box-sizing
 

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -30,11 +30,10 @@ const getSpacingStyle = (type, values, key) => {
 }
 
 export default ({
-  pieces: { hasVariants, hasImportant, hasNegative },
-  errors: { errorNoVariants, errorNoImportant, errorNoNegatives },
+  pieces: { hasImportant, hasNegative },
+  errors: { errorNoImportant, errorNoNegatives },
   theme,
 }) => {
-  hasVariants && errorNoVariants()
   hasImportant && errorNoImportant()
   hasNegative && errorNoNegatives()
 


### PR DESCRIPTION
This PR allows variants to function with the `container` class as per the [tailwindcss container docs](https://tailwindcss.com/docs/container#responsive-variants).

[From discussion 512](https://github.com/ben-rogerson/twin.macro/discussions/512)