### PR TITLE
Convert numeric theme values to string

### DIFF
--- a/__fixtures__/themeValuesToString/addBase.js
+++ b/__fixtures__/themeValuesToString/addBase.js
@@ -1,0 +1,5 @@
+import { globalStyles, theme } from './macro'
+
+globalStyles
+
+theme`keyframes`

--- a/__fixtures__/themeValuesToString/tailwind.config.js
+++ b/__fixtures__/themeValuesToString/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  theme: {
+    keyframes: {
+      'fade-up': {
+        from: {
+          transform: 'translateY(0.5rem)',
+          opacity: 0,
+        },
+        to: {
+          transform: 'translateY(0)',
+          opacity: 1,
+        },
+      },
+    },
+  },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2587,6 +2587,236 @@ animation-timing-function: cubic-bezier(0,0,0.2,1);
 
 `;
 
+exports[`twin.macro addBase.js: addBase.js 2`] = `
+
+import { globalStyles, theme } from './macro'
+
+globalStyles
+
+theme\`keyframes\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  '*, ::before, ::after': {
+    boxSizing: 'border-box',
+    borderWidth: '0',
+    borderStyle: 'solid',
+    '--tw-border-opacity': '1',
+    borderColor: 'rgba(229, 231, 235, var(--tw-border-opacity))',
+    '--tw-translate-x': '0',
+    '--tw-translate-y': '0',
+    '--tw-rotate': '0',
+    '--tw-skew-x': '0',
+    '--tw-skew-y': '0',
+    '--tw-scale-x': '1',
+    '--tw-scale-y': '1',
+    '--tw-transform':
+      'translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))',
+    '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-ring-offset-width': '0px',
+    '--tw-ring-offset-color': '#fff',
+    '--tw-ring-color': 'rgba(59, 130, 246, 0.5)',
+    '--tw-ring-offset-shadow': '0 0 #0000',
+    '--tw-ring-shadow': '0 0 #0000',
+    '--tw-shadow': '0 0 #0000',
+    '--tw-blur': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-brightness': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-contrast': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-grayscale': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-hue-rotate': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-invert': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-saturate': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-drop-shadow': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-filter':
+      'var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)',
+    '--tw-backdrop-blur': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-brightness': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-contrast': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-grayscale': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-hue-rotate': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-invert': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-opacity': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-saturate': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
+    '--tw-backdrop-filter':
+      'var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)',
+  },
+  html: {
+    lineHeight: '1.5',
+    WebkitTextSizeAdjust: '100%',
+    MozTabSize: '4',
+    tabSize: '4',
+    fontFamily:
+      'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+  },
+  body: {
+    margin: '0',
+    fontFamily: 'inherit',
+    lineHeight: 'inherit',
+  },
+  hr: {
+    height: '0',
+    color: 'inherit',
+    borderTopWidth: '1px',
+  },
+  'abbr[title]': {
+    textDecoration: 'underline dotted',
+  },
+  'b, strong': {
+    fontWeight: 'bolder',
+  },
+  'code, kbd, samp, pre': {
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace",
+    fontSize: '1em',
+  },
+  small: {
+    fontSize: '80%',
+  },
+  'sub, sup': {
+    fontSize: '75%',
+    lineHeight: '0',
+    position: 'relative',
+    verticalAlign: 'baseline',
+  },
+  sub: {
+    bottom: '-0.25em',
+  },
+  sup: {
+    top: '-0.5em',
+  },
+  table: {
+    textIndent: '0',
+    borderColor: 'inherit',
+    borderCollapse: 'collapse',
+  },
+  'button, input, optgroup, select, textarea': {
+    fontFamily: 'inherit',
+    fontSize: '100%',
+    lineHeight: 'inherit',
+    margin: '0',
+    padding: '0',
+    color: 'inherit',
+  },
+  'button, select': {
+    textTransform: 'none',
+  },
+  "button, [type='button'], [type='reset'], [type='submit']": {
+    WebkitAppearance: 'button',
+  },
+  '::-moz-focus-inner': {
+    borderStyle: 'none',
+    padding: '0',
+  },
+  ':-moz-focusring': {
+    outline: '1px dotted ButtonText',
+  },
+  ':-moz-ui-invalid': {
+    boxShadow: 'none',
+  },
+  legend: {
+    padding: '0',
+  },
+  progress: {
+    verticalAlign: 'baseline',
+  },
+  '::-webkit-inner-spin-button, ::-webkit-outer-spin-button': {
+    height: 'auto',
+  },
+  "[type='search']": {
+    WebkitAppearance: 'textfield',
+    outlineOffset: '-2px',
+  },
+  '::-webkit-search-decoration': {
+    WebkitAppearance: 'none',
+  },
+  '::-webkit-file-upload-button': {
+    WebkitAppearance: 'button',
+    font: 'inherit',
+  },
+  summary: {
+    display: 'list-item',
+  },
+  'blockquote, dl, dd, h1, h2, h3, h4, h5, h6, hr, figure, p, pre': {
+    margin: '0',
+  },
+  button: {
+    backgroundColor: 'transparent',
+    backgroundImage: 'none',
+  },
+  fieldset: {
+    margin: '0',
+    padding: '0',
+  },
+  'ol, ul': {
+    listStyle: 'none',
+    margin: '0',
+    padding: '0',
+  },
+  img: {
+    borderStyle: 'solid',
+  },
+  textarea: {
+    resize: 'vertical',
+  },
+  'input::placeholder, textarea::placeholder': {
+    color: '#9ca3af',
+  },
+  'button, [role="button"]': {
+    cursor: 'pointer',
+  },
+  'h1, h2, h3, h4, h5, h6': {
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
+  },
+  a: {
+    color: 'inherit',
+    textDecoration: 'inherit',
+  },
+  'pre, code, kbd, samp': {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  },
+  'img, svg, video, canvas, audio, iframe, embed, object': {
+    display: 'block',
+    verticalAlign: 'middle',
+  },
+  'img, video': {
+    maxWidth: '100%',
+    height: 'auto',
+  },
+  '[hidden]': {
+    display: 'none',
+  },
+  '@keyframes fade-up': {
+    from: {
+      transform: 'translateY(0.5rem)',
+      opacity: '0',
+    },
+    to: {
+      transform: 'translateY(0)',
+      opacity: '1',
+    },
+  },
+})
+;({
+  'fade-up': {
+    from: {
+      transform: 'translateY(0.5rem)',
+      opacity: '0',
+    },
+    to: {
+      transform: 'translateY(0)',
+      opacity: '1',
+    },
+  },
+})
+
+
+`;
+
 exports[`twin.macro arbitraryValues.js: arbitraryValues.js 1`] = `
 
 import tw from './macro'

--- a/src/macro/globalStyles.js
+++ b/src/macro/globalStyles.js
@@ -177,7 +177,7 @@ const handleGlobalStylesJsx = props => {
   const path = references.GlobalStyles[0]
   const parentPath = path.findParent(x => x.isJSXElement())
 
-  throwIf(state.isStyledComponents && !parentPath, () =>
+  throwIf(!parentPath, () =>
     logGeneralError(
       'GlobalStyles must be added as a JSX element, eg: <GlobalStyles />'
     )

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,3 +1,4 @@
+import deepMerge from 'lodash.merge'
 import { MacroError } from 'babel-plugin-macros'
 import get from 'lodash.get'
 
@@ -44,15 +45,20 @@ function transformThemeValue(themeSection) {
   return value => value
 }
 
-const normalizeThemeValue = themeValue => {
-  if (typeof themeValue === 'object' && !Array.isArray(themeValue))
-    return Object.entries(themeValue).reduce((result, [key, value]) => {
-      if (typeof value === 'object' && !Array.isArray(value))
-        return { ...result, [key]: normalizeThemeValue(value) }
-      return { ...result, [key]: String(value) }
-    }, {})
+const objectToStringValues = obj => {
+  if (typeof obj === 'object' && !Array.isArray(obj))
+    return Object.entries(obj).reduce(
+      (result, [key, value]) =>
+        deepMerge(result, { [key]: objectToStringValues(value) }),
+      {}
+    )
 
-  return themeValue
+  if (Array.isArray(obj)) return obj.map(i => objectToStringValues(i))
+
+  if (typeof obj === 'number') return String(obj)
+
+  // typeof obj = string / function
+  return obj
 }
 
 const getTheme = configTheme => grab => {
@@ -63,7 +69,7 @@ const getTheme = configTheme => grab => {
   const themeKey = value.split('.')[0]
   // Get the resulting value from the config
   const themeValue = get(configTheme, value)
-  return normalizeThemeValue(transformThemeValue(themeKey)(themeValue))
+  return objectToStringValues(transformThemeValue(themeKey)(themeValue))
 }
 
 const stripNegative = string =>

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -44,6 +44,17 @@ function transformThemeValue(themeSection) {
   return value => value
 }
 
+const normalizeThemeValue = themeValue => {
+  if (typeof themeValue === 'object' && !Array.isArray(themeValue))
+    return Object.entries(themeValue).reduce((result, [key, value]) => {
+      if (typeof value === 'object' && !Array.isArray(value))
+        return { ...result, [key]: normalizeThemeValue(value) }
+      return { ...result, [key]: String(value) }
+    }, {})
+
+  return themeValue
+}
+
 const getTheme = configTheme => grab => {
   if (!grab) return configTheme
   // Allow theme`` which gets supplied as an array
@@ -52,8 +63,7 @@ const getTheme = configTheme => grab => {
   const themeKey = value.split('.')[0]
   // Get the resulting value from the config
   const themeValue = get(configTheme, value)
-  // Treat values differently depending on the key name
-  return transformThemeValue(themeKey)(themeValue)
+  return normalizeThemeValue(transformThemeValue(themeKey)(themeValue))
 }
 
 const stripNegative = string =>


### PR DESCRIPTION
This PR converts numeric values into strings to avoid styles getting stripped.
It affects the output of twin exports `globalStyles`, `tw`, `theme`.

## Previously

```js
import { theme } from "twin.macro";

theme`keyframes`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "fade-up": {
    "from": {
      "transform": "translateY(0.5rem)",
      "opacity": 0
    },
    "to": {
      "transform": "translateY(0)",
      "opacity": 1
    }
  }
});
```

## Now

```js
import { theme } from "twin.macro";

theme`keyframes`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "fade-up": {
    "from": {
      "transform": "translateY(0.5rem)",
      "opacity": "0"
    },
    "to": {
      "transform": "translateY(0)",
      "opacity": "1"
    }
  }
});
```

Closes #528