### PR TITLE
Fix issue with transform (cpu & gpu)

### DIFF
--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -786,6 +786,13 @@ export default {
 
   'transform-gpu': {
     output: {
+      '--tw-translate-x': 0,
+      '--tw-translate-y': 0,
+      '--tw-rotate': 0,
+      '--tw-skew-x': 0,
+      '--tw-skew-y': 0,
+      '--tw-scale-x': 1,
+      '--tw-scale-y': 1,
       '--tw-transform':
         'translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))',
     },
@@ -793,6 +800,13 @@ export default {
 
   'transform-cpu': {
     output: {
+      '--tw-translate-x': 0,
+      '--tw-translate-y': 0,
+      '--tw-rotate': 0,
+      '--tw-skew-x': 0,
+      '--tw-skew-y': 0,
+      '--tw-scale-x': 1,
+      '--tw-scale-y': 1,
       '--tw-transform':
         'translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))',
     },


### PR DESCRIPTION
With all the default values of the variables left out, transform is currently broken. If someone, for example, wants to only apply a `scale-100 hover:scale-110` (like me), it won't work, since the scale is fed into the overall transform function with empty/broken variables.

I have confirmed on my local machine (with my component library) that adding in the default variables according to the tailwind spec fixes the issue. My buttons now scale again. :)