### PR TITLE
Add arbitrary variants

### DIFF
--- a/__fixtures__/arbitraryVariants/arbitraryVariants.js
+++ b/__fixtures__/arbitraryVariants/arbitraryVariants.js
@@ -1,0 +1,18 @@
+import tw from './macro'
+
+tw`[section]:hover:block`
+
+tw`[p]:hover:block`
+tw`hover:[p]:block`
+
+tw`[* + *]:block` // Spaces
+tw`[.class1 .class2]:block` // Classes
+
+tw`[.class1]:[.class2]:block` // Multiple dynamic variants
+tw`[.class1 .class2]:[.class3]:block` // Multiple dynamic variants
+
+tw`[p]:placeholder-red-500/[var(--myvar)]`
+tw`[p]:mt-[var(--myvar)]`
+tw`[p]:marginTop[var(--myvar)]`
+
+tw`[p]:(mt-4 mb-4)`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -3113,6 +3113,105 @@ tw\`md:text-[red]\`
 
 `;
 
+exports[`twin.macro arbitraryVariants.js: arbitraryVariants.js 1`] = `
+
+import tw from './macro'
+
+tw\`[section]:hover:block\`
+
+tw\`[p]:hover:block\`
+tw\`hover:[p]:block\`
+
+tw\`[* + *]:block\` // Spaces
+tw\`[.class1 .class2]:block\` // Classes
+
+tw\`[.class1]:[.class2]:block\` // Multiple dynamic variants
+tw\`[.class1 .class2]:[.class3]:block\` // Multiple dynamic variants
+
+tw\`[p]:placeholder-red-500/[var(--myvar)]\`
+tw\`[p]:mt-[var(--myvar)]\`
+tw\`[p]:marginTop[var(--myvar)]\`
+
+tw\`[p]:(mt-4 mb-4)\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  section: {
+    ':hover': {
+      display: 'block',
+    },
+  },
+})
+;({
+  p: {
+    ':hover': {
+      display: 'block',
+    },
+  },
+})
+;({
+  ':hover': {
+    p: {
+      display: 'block',
+    },
+  },
+})
+;({
+  '* + *': {
+    display: 'block',
+  },
+}) // Spaces
+
+;({
+  '.class1 .class2': {
+    display: 'block',
+  },
+}) // Classes
+
+;({
+  '.class1': {
+    '.class2': {
+      display: 'block',
+    },
+  },
+}) // Multiple dynamic variants
+
+;({
+  '.class1 .class2': {
+    '.class3': {
+      display: 'block',
+    },
+  },
+}) // Multiple dynamic variants
+
+;({
+  p: {
+    '::placeholder': {
+      color: 'rgba(239, 68, 68, var(--myvar))',
+    },
+  },
+})
+;({
+  p: {
+    marginTop: 'var(--myvar)',
+  },
+})
+;({
+  p: {
+    marginTop: 'var(--myvar)',
+  },
+})
+;({
+  p: {
+    marginTop: '1rem',
+    marginBottom: '1rem',
+  },
+})
+
+
+`;
+
 exports[`twin.macro autoCssProp.js: autoCssProp.js 1`] = `
 
 import './macro' // twinImport


### PR DESCRIPTION
This PR adds custom selectors to twin.
These selectors can be added within square brackets using the same syntax as variants:

```js
// Style all child paragraph elements
tw`[div]:block`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "div": {
    "display": "block"
  }
});
```

## Add scoped styles from a parent

```js
// Prop styling
;<div tw="[p]:(text-white bg-black) [div]:my-4">
    <p>...</p>
	<div>...</div>
</div>

// Styled component
const Component = tw.div`[p]:(text-white bg-black) [div]:my-4`
;<Component>
    <p>...</p>
	<div>...</div>
</Component>
```

## Style all child elements when the parent is hovered

```js
// Prop styling
;<div tw="hover:[*]:bg-black">...</div>

// Styled component
const Component = tw.div`hover:[*]:bg-black`
;<Component>....</Component>
```

## Style an element by its custom className

```js
// Prop styling
const Component = (props) => (
	<div {...props} tw="[&.is-padded]:p-10">...</div>
)
;<Component className="is-padded" />

// Styled component
const StyledComponent = tw.div`[&.is-padded]:p-10`
const Component = (props) => (
	<StyledComponent {...props}>....</StyledComponent>
)
;<Component className="is-padded" />
```