### PR TITLE
Push `bg-opacity-x` to the end of class lists

### DIFF
--- a/__fixtures__/!ordering.js
+++ b/__fixtures__/!ordering.js
@@ -2,3 +2,6 @@ import tw from './macro'
 
 // Test the screen ordering - they are ordered by screens in tailwind.config.js
 tw.div`xl:bg-red-500 lg:bg-blue-500 bg-green-500 fill-current md:bg-pink-500 sm:bg-green-500 sm:text-yellow-500 hidden`
+
+// Bg opacity should trump the default bg opacity
+tw`bg-opacity-50 bg-red-500`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -821,6 +821,9 @@ import tw from './macro'
 // Test the screen ordering - they are ordered by screens in tailwind.config.js
 tw.div\`xl:bg-red-500 lg:bg-blue-500 bg-green-500 fill-current md:bg-pink-500 sm:bg-green-500 sm:text-yellow-500 hidden\`
 
+// Bg opacity should trump the default bg opacity
+tw\`bg-opacity-50 bg-red-500\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import _styled from '@emotion/styled'
@@ -849,6 +852,11 @@ _styled.div({
     '--tw-bg-opacity': '1',
     backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
   },
+}) // Bg opacity should trump the default bg opacity
+
+;({
+  '--tw-bg-opacity': '0.5',
+  backgroundColor: 'rgba(239, 68, 68, var(--tw-bg-opacity))',
 })
 
 

--- a/src/bgOpacity.js
+++ b/src/bgOpacity.js
@@ -1,0 +1,19 @@
+import timSort from 'timsort'
+
+const bgOpacityCompare = (a, b) => {
+  // The order of bg-opacity matters when combined into a single object
+  // So we move bg-opacity-xxx to the end to avoid being trumped by the bg color
+  const A = /(^|:)bg-opacity-/.test(a) ? 0 : -1
+  const B = /(^|:)bg-opacity-/.test(b) ? 0 : -1
+  return A - B
+}
+
+const orderBgOpacityProperty = className => {
+  const classNames = className.match(/\S+/g) || []
+  // Tim Sort provides accurate sorting in node < 11
+  // https://github.com/ben-rogerson/twin.macro/issues/20
+  timSort.sort(classNames, bgOpacityCompare)
+  return classNames.join(' ')
+}
+
+export { orderBgOpacityProperty }

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -17,6 +17,7 @@ import { orderGridProperty } from './grid'
 import { orderTransitionProperty } from './transition'
 import { orderTransformProperty } from './transform'
 import { orderRingProperty } from './ring'
+import { orderBgOpacityProperty } from './bgOpacity'
 import { orderBackdropProperty } from './backdrop'
 import { orderFilterProperty } from './filter'
 import { addContentClass } from './content'
@@ -63,6 +64,7 @@ const formatTasks = [
   ({ classes }) => orderRingProperty(classes),
   ({ classes }) => orderBackdropProperty(classes),
   ({ classes }) => orderFilterProperty(classes),
+  ({ classes }) => orderBgOpacityProperty(classes),
   // Move and sort the responsive items to the end of the list
   ({ classes, state }) => orderByScreens(classes, state),
   // Add a missing content class for after:/before: variants


### PR DESCRIPTION
This PR orders `bg-opacity-x` classes to the end of class lists to make sure bg colors don't overwrite it when merged into a css object.

## Before

```js
tw`bg-opacity-50 bg-red-500`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "--tw-bg-opacity": "1", // < this should be "0.5"
  "backgroundColor": "rgba(239, 68, 68, var(--tw-bg-opacity))"
});
```

## After

```js
tw`bg-opacity-50 bg-red-500`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "--tw-bg-opacity": "0.5", // < Bingo
  "backgroundColor": "rgba(239, 68, 68, var(--tw-bg-opacity))"
});
```

Related #541 