### PR TITLE
Add array value types for the screen import

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,7 +22,7 @@ export type ThemeFn = <T = string>(arg?: string | TemplateStringsArray) => T
 
 export type ScreenFn = <T = string>(
   screenValue: string | TemplateStringsArray
-) => (styles?: string | TemplateStringsArray | TwStyle) => T
+) => (styles?: string | TemplateStringsArray | TwStyle | TwStyle[]) => T
 
 export type TwComponent<K extends keyof JSX.IntrinsicElements> = (
   props: JSX.IntrinsicElements[K]


### PR DESCRIPTION
This PR adds typescript types for arrays used with the screen import in this usage pattern:

```js
screen`lg`([tw`text-xs`, condition && tw`text-base`]);
```