### PR TITLE
Allow font face values added via addBase

### DIFF
--- a/__fixtures__/addBase/tailwind.config.js
+++ b/__fixtures__/addBase/tailwind.config.js
@@ -3,6 +3,12 @@ function addBasePlugin({ addBase }) {
     ':root': {
       '--color-pink-900': '#831843',
     },
+    '@font-face': {
+      fontFamily: 'NotoSans',
+      fontWeight: 400,
+      fontStyle: 'normal',
+      src: `url('./fonts/myfont.ttf')`,
+    },
     body: {
       marginTop: '20rem',
       backgroundColor: 'black',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -2592,6 +2592,12 @@ animation-timing-function: cubic-bezier(0,0,0.2,1);
         }
 :root {
 --color-pink-900: #831843;
+        }
+@font-face  {
+src: url('./fonts/myfont.ttf');
+font-style: normal;
+font-weight: 400;
+font-family: NotoSans;
         }\`}
   />
 )
@@ -2837,6 +2843,12 @@ animation-timing-function: cubic-bezier(0,0,0.2,1);
   },
   ':root': {
     '--color-pink-900': '#831843',
+  },
+  '@font-face ': {
+    src: "url('./fonts/myfont.ttf')",
+    'font-style': 'normal',
+    'font-weight': '400',
+    'font-family': 'NotoSans',
   },
 })
 

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -136,6 +136,11 @@ const ruleSorter = arr => {
 
 const getUserPluginRules = (rules, screens, isBase) =>
   ruleSorter(rules).reduce((result, rule) => {
+    if (rule.type === 'decl') {
+      const builtRules = { [rule.prop]: rule.value }
+      return deepMerge(result, builtRules)
+    }
+
     // Build the media queries
     if (rule.type !== 'atrule') {
       const builtRules = getBuiltRules(rule, { isBase })


### PR DESCRIPTION
This PR fixes an issue with `@font-face` being added in a tailwind plugin using `addBase`.

### Example

```js
// tailwind.config.js

const plugin = require("tailwindcss/plugin");

const basePlugin = plugin(({ addBase }) => {
  addBase({
    "@font-face": {
      fontFamily: "myFont",
      fontWeight: 400,
      fontStyle: "normal",
      src: `url('./fonts/myFont.ttf')`,
    },
  });
});

module.exports = {
  plugins: [basePlugin],
};
```

### Output before

Using GlobalStyles to render the base styles:

```css
// ...
'@font-face' { } 
```

### Output after

```css
// ...
@font-face {
  src: url('./fonts/myFont.ttf');
  font-style: normal;
  font-weight: 400;
  font-family: myFont;
}
```