### PR TITLE
Add not-placeholder-shown variants

### DIFF
--- a/__fixtures__/!variants.js
+++ b/__fixtures__/!variants.js
@@ -34,6 +34,7 @@ tw`out-of-range:flex`
 tw`required:flex`
 tw`placeholder:flex`
 tw`placeholder-shown:flex`
+tw`not-placeholder-shown:flex`
 tw`read-only:flex`
 tw`read-write:flex`
 

--- a/__fixtures__/peers/peers.js
+++ b/__fixtures__/peers/peers.js
@@ -13,6 +13,7 @@ tw`peer-default:block`
 tw`peer-checked:block`
 tw`peer-indeterminate:block`
 tw`peer-placeholder-shown:block`
+tw`peer-not-placeholder-shown:block`
 tw`peer-autofill:block`
 tw`peer-required:block`
 tw`peer-valid:block`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1317,6 +1317,7 @@ tw\`out-of-range:flex\`
 tw\`required:flex\`
 tw\`placeholder:flex\`
 tw\`placeholder-shown:flex\`
+tw\`not-placeholder-shown:flex\`
 tw\`read-only:flex\`
 tw\`read-write:flex\`
 
@@ -1579,6 +1580,11 @@ tw\`xl:placeholder-red-500! first:md:block sm:disabled:flex\`
 })
 ;({
   ':placeholder-shown': {
+    display: 'flex',
+  },
+})
+;({
+  ':not(:placeholder-shown)': {
     display: 'flex',
   },
 })

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -36495,6 +36495,7 @@ tw\`peer-default:block\`
 tw\`peer-checked:block\`
 tw\`peer-indeterminate:block\`
 tw\`peer-placeholder-shown:block\`
+tw\`peer-not-placeholder-shown:block\`
 tw\`peer-autofill:block\`
 tw\`peer-required:block\`
 tw\`peer-valid:block\`
@@ -36579,6 +36580,11 @@ tw\`peer-focus:first:peer-hover:peer-active:block\`
 })
 ;({
   '.peer:placeholder-shown ~ &': {
+    display: 'block',
+  },
+})
+;({
+  '.peer:not(:placeholder-shown) ~ &': {
     display: 'block',
   },
 })

--- a/src/config/variantConfig.js
+++ b/src/config/variantConfig.js
@@ -198,6 +198,7 @@ const variantConfig = ({
   'peer-checked': createPeer('checked'),
   'peer-indeterminate': createPeer('indeterminate'),
   'peer-placeholder-shown': createPeer('placeholder-shown'),
+  'peer-not-placeholder-shown': createPeer('not(:placeholder-shown)'),
   'peer-autofill': createPeer('autofill'),
   'peer-focus-within': createPeer('focus-within'),
   'peer-focus-visible': createPeer('focus-visible'),

--- a/src/config/variantConfig.js
+++ b/src/config/variantConfig.js
@@ -46,6 +46,7 @@ const variantConfig = ({
   'out-of-range': ':out-of-range',
   required: ':required',
   'placeholder-shown': ':placeholder-shown',
+  'not-placeholder-shown': ':not(:placeholder-shown)',
   placeholder: '::placeholder',
   'read-only': ':read-only',
   'read-write': ':read-write',


### PR DESCRIPTION
This PR adds `not-placeholder-shown` and `peer-not-placeholder-shown` variants.

This is great for styling inputs when they have a value present.

```js
tw`not-placeholder-shown:block`
tw`peer-not-placeholder-shown:block`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  ":not(:placeholder-shown)": {
    display: 'block',
  }
}); 

;({
  '.peer:not(:placeholder-shown) ~ &': {
    display: 'block',
  },
})
```

Requested in discussion #569