### PR TITLE
Tweak the styled-components styled import preset

### DIFF
--- a/__fixtures__/autoCssProp/config.json
+++ b/__fixtures__/autoCssProp/config.json
@@ -1,3 +1,0 @@
-{
-  "preset": "styled-components"
-}

--- a/__fixtures__/cssPropEmotion/autoCssProp.js
+++ b/__fixtures__/cssPropEmotion/autoCssProp.js
@@ -1,0 +1,4 @@
+import './macro' // twinImport
+
+;<div css="" />
+;<div className="" />

--- a/__fixtures__/cssPropEmotion/autoCssPropWithStyled.js
+++ b/__fixtures__/cssPropEmotion/autoCssPropWithStyled.js
@@ -1,0 +1,8 @@
+import tw from './macro' // twinImport
+
+// Css prop isn't handled by twin
+tw.div`block`
+;<div tw="block" />
+
+const Test = tw.div``
+;<Test tw="block" />

--- a/__fixtures__/cssPropStyledComponents/autoCssProp.js
+++ b/__fixtures__/cssPropStyledComponents/autoCssProp.js
@@ -1,0 +1,4 @@
+import './macro' // twinImport
+
+;<div css="" />
+;<div className="" />

--- a/__fixtures__/cssPropStyledComponents/autoCssPropWithStyled.js
+++ b/__fixtures__/cssPropStyledComponents/autoCssPropWithStyled.js
@@ -2,3 +2,6 @@ import tw from './macro' // twinImport
 
 tw.div`block`
 ;<div tw="block" />
+
+const Test = tw.div``
+;<Test tw="block" />

--- a/__fixtures__/cssPropStyledComponents/config.json
+++ b/__fixtures__/cssPropStyledComponents/config.json
@@ -1,0 +1,4 @@
+{
+  "preset": "styled-components",
+  "autoCssProp": false
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -3714,9 +3714,39 @@ exports[`twin.macro autoCssProp.js: autoCssProp.js 1`] = `
 
 import './macro' // twinImport
 
-    // Css prop isn't handled by twin
-    ; <div css="" />
-    ; <div className="" />
+// Css prop isn't handled by twin
+;<div css="" />
+;<div className="" />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;<div css="" />
+;<div className="" />
+
+
+`;
+
+exports[`twin.macro autoCssProp.js: autoCssProp.js 2`] = `
+
+import './macro' // twinImport
+
+;<div css="" />
+;<div className="" />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;<div css="" />
+;<div className="" />
+
+
+`;
+
+exports[`twin.macro autoCssProp.js: autoCssProp.js 3`] = `
+
+import './macro' // twinImport
+
+;<div css="" />
+;<div className="" />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -3730,30 +3760,72 @@ exports[`twin.macro autoCssPropWithStyled.js: autoCssPropWithStyled.js 1`] = `
 
 import tw from './macro' // twinImport
 
+// Css prop isn't handled by twin
 tw.div\`block\`
 ;<div tw="block" />
 
+const Test = tw.div\`\`
+;<Test tw="block" />
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _styled3 from 'styled-components'
-import _styled2 from 'styled-components'
+import _styled from '@emotion/styled'
 
 // twinImport
-_styled2.div.withConfig({
-  displayName: 'plugintest',
-  componentId: 'sc-16ats9e-0',
-})({
+// Css prop isn't handled by twin
+_styled.div({
   display: 'block',
 })
 
-var _StyledDiv = _styled2('div').withConfig({
-  displayName: 'plugintest___StyledDiv',
-  componentId: 'sc-16ats9e-1',
-})({
+;<div
+  css={{
+    display: 'block',
+  }}
+/>
+
+const Test = _styled.div({})
+
+;<Test
+  css={{
+    display: 'block',
+  }}
+/>
+
+
+`;
+
+exports[`twin.macro autoCssPropWithStyled.js: autoCssPropWithStyled.js 2`] = `
+
+import tw from './macro' // twinImport
+
+tw.div\`block\`
+;<div tw="block" />
+
+const Test = tw.div\`\`
+;<Test tw="block" />
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from 'styled-components'
+
+// twinImport
+_styled.div({
   display: 'block',
 })
 
-;<_StyledDiv />
+;<div
+  css={{
+    display: 'block',
+  }}
+/>
+
+const Test = _styled.div({})
+
+;<Test
+  css={{
+    display: 'block',
+  }}
+/>
 
 
 `;

--- a/src/config/userPresets.js
+++ b/src/config/userPresets.js
@@ -20,7 +20,7 @@ export default {
   'styled-components': {
     styled: {
       import: 'default',
-      from: 'styled-components/macro',
+      from: 'styled-components',
     },
     css: {
       import: 'css',


### PR DESCRIPTION
This PR fixes the `_styled is not defined` error when using the `styled-components` styling library with twin.

The  styled-components preset defines a default styled import of `import styled from "styled-components/macro`.
The problem is that their macro doesn't preserve the `_styled` import which twin.macro adds when the tw prop is added to a styled component. 
The solution is to adjust the imports to the non-macro import: `import styled from "styled-components`.
[More info](https://github.com/ben-rogerson/twin.macro/issues/192#issuecomment-986106680)

Closes #192 