### PR TITLE
First-class negative value support

### DIFF
--- a/__fixtures__/arbitraryValues/arbitraryValues.js
+++ b/__fixtures__/arbitraryValues/arbitraryValues.js
@@ -92,6 +92,8 @@ tw`object-[var(--position)]`
 tw`stroke-[#da5b66]`
 tw`leading-[var(--leading)]`
 tw`tracking-[var(--tracking)]`
+tw`-tracking-[var(--tracking)]`
+tw`-tracking-[2em]`
 tw`placeholder-[var(--placeholder)]`
 tw`placeholder-opacity-[var(--placeholder-opacity)]`
 tw`opacity-[var(--opacity)]`

--- a/__fixtures__/layout.js
+++ b/__fixtures__/layout.js
@@ -692,9 +692,15 @@ tw`invisible`
 
 // https://tailwindcss.com/docs/z-index
 tw`z-0`
+tw`-z-0`
 tw`z-10`
+tw`-z-10`
 tw`z-20`
+tw`-z-20`
 tw`z-30`
+tw`-z-30`
 tw`z-40`
+tw`-z-40`
 tw`z-50`
+tw`-z-50`
 tw`z-auto`

--- a/__fixtures__/typography.js
+++ b/__fixtures__/typography.js
@@ -58,11 +58,16 @@ tw`normal-nums`
 // https://tailwindcss.com/docs/letter-spacing
 tw`tracking-tighter`
 tw`tracking-tight`
-tw`tracking-tight`
 tw`tracking-normal`
 tw`tracking-wide`
 tw`tracking-wider`
 tw`tracking-widest`
+tw`-tracking-tighter`
+tw`-tracking-tight`
+tw`-tracking-normal`
+tw`-tracking-wide`
+tw`-tracking-wider`
+tw`-tracking-widest`
 
 // https://tailwindcss.com/docs/line-height
 tw`leading-3`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -3183,6 +3183,8 @@ tw\`object-[var(--position)]\`
 tw\`stroke-[#da5b66]\`
 tw\`leading-[var(--leading)]\`
 tw\`tracking-[var(--tracking)]\`
+tw\`-tracking-[var(--tracking)]\`
+tw\`-tracking-[2em]\`
 tw\`placeholder-[var(--placeholder)]\`
 tw\`placeholder-opacity-[var(--placeholder-opacity)]\`
 tw\`opacity-[var(--opacity)]\`
@@ -3532,6 +3534,12 @@ tw\`md:text-[red]\`
 })
 ;({
   letterSpacing: 'var(--tracking)',
+})
+;({
+  letterSpacing: 'calc(var(--tracking) * -1)',
+})
+;({
+  letterSpacing: '-2em',
 })
 ;({
   '::placeholder': {
@@ -13412,11 +13420,17 @@ tw\`invisible\`
 
 // https://tailwindcss.com/docs/z-index
 tw\`z-0\`
+tw\`-z-0\`
 tw\`z-10\`
+tw\`-z-10\`
 tw\`z-20\`
+tw\`-z-20\`
 tw\`z-30\`
+tw\`-z-30\`
 tw\`z-40\`
+tw\`-z-40\`
 tw\`z-50\`
+tw\`-z-50\`
 tw\`z-auto\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -15945,19 +15959,37 @@ tw\`z-auto\`
   zIndex: '0',
 })
 ;({
+  zIndex: '-0',
+})
+;({
   zIndex: '10',
+})
+;({
+  zIndex: '-10',
 })
 ;({
   zIndex: '20',
 })
 ;({
+  zIndex: '-20',
+})
+;({
   zIndex: '30',
+})
+;({
+  zIndex: '-30',
 })
 ;({
   zIndex: '40',
 })
 ;({
+  zIndex: '-40',
+})
+;({
   zIndex: '50',
+})
+;({
+  zIndex: '-50',
 })
 ;({
   zIndex: 'auto',
@@ -26333,11 +26365,16 @@ tw\`normal-nums\`
 // https://tailwindcss.com/docs/letter-spacing
 tw\`tracking-tighter\`
 tw\`tracking-tight\`
-tw\`tracking-tight\`
 tw\`tracking-normal\`
 tw\`tracking-wide\`
 tw\`tracking-wider\`
 tw\`tracking-widest\`
+tw\`-tracking-tighter\`
+tw\`-tracking-tight\`
+tw\`-tracking-normal\`
+tw\`-tracking-wide\`
+tw\`-tracking-wider\`
+tw\`-tracking-widest\`
 
 // https://tailwindcss.com/docs/line-height
 tw\`leading-3\`
@@ -26820,9 +26857,6 @@ tw\`break-all\`
   letterSpacing: '-0.025em',
 })
 ;({
-  letterSpacing: '-0.025em',
-})
-;({
   letterSpacing: '0em',
 })
 ;({
@@ -26833,6 +26867,24 @@ tw\`break-all\`
 })
 ;({
   letterSpacing: '0.1em',
+})
+;({
+  letterSpacing: '0.05em',
+})
+;({
+  letterSpacing: '0.025em',
+})
+;({
+  letterSpacing: '-0em',
+})
+;({
+  letterSpacing: '-0.025em',
+})
+;({
+  letterSpacing: '-0.05em',
+})
+;({
+  letterSpacing: '-0.1em',
 }) // https://tailwindcss.com/docs/line-height
 
 ;({

--- a/src/handlers/arbitraryCss.js
+++ b/src/handlers/arbitraryCss.js
@@ -1,6 +1,7 @@
 import stringSimilarity from 'string-similarity'
 import { SPACE_ID } from './../contants'
 import { dynamicStyles } from './../config'
+import { maybeAddNegative } from './../negative'
 import {
   throwIf,
   withAlpha,
@@ -185,12 +186,11 @@ export default ({ className, state, pieces }) => {
   const arbitraryProperty = config.prop
 
   const color = props => withAlpha({ color: value, pieces, ...props })
-  const { negative } = pieces
 
   const arbitraryValue =
     typeof config.value === 'function'
-      ? config.value({ value, transparentTo, color, negative })
-      : value
+      ? config.value({ value, transparentTo, color, negative: pieces.negative })
+      : maybeAddNegative(value, pieces.negative)
 
   // Raw values - no prop value found in config
   if (!arbitraryProperty)

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -1,16 +1,7 @@
 import getConfigValue from './../utils/getConfigValue'
-import { throwIf, isNumeric, transparentTo } from './../utils'
+import { throwIf, transparentTo } from './../utils'
 import { errorSuggestions } from './../logging'
-
-const maybeAddNegative = (value, negative) => {
-  if (!negative) return value
-
-  if (typeof value === 'string' && value.startsWith('var('))
-    return `calc(${value} * -1)`
-  if (isNumeric(value.slice(0, 1))) return `${negative}${value}`
-
-  return value
-}
+import { maybeAddNegative } from './../negative'
 
 const styleify = ({ property, value, negative }) => {
   value = Array.isArray(value)

--- a/src/negative.js
+++ b/src/negative.js
@@ -1,13 +1,10 @@
-import { isShortCss, isArbitraryCss } from './utils'
+import { isShortCss, isNumeric } from './utils'
 
 /**
  * Split the negative from the className
  */
 const splitNegative = ({ className }) => {
-  const hasNegative =
-    !isShortCss(className) &&
-    !isArbitraryCss(className) &&
-    className.slice(0, 1) === '-'
+  const hasNegative = !isShortCss(className) && className.slice(0, 1) === '-'
 
   if (hasNegative) {
     className = className.slice(1, className.length)
@@ -18,4 +15,17 @@ const splitNegative = ({ className }) => {
   return { className, hasNegative, negative }
 }
 
-export { splitNegative }
+const maybeAddNegative = (value, negative) => {
+  if (!negative) return value
+
+  if (typeof value === 'string') {
+    if (value.startsWith('-')) return value.slice(1)
+    if (value.startsWith('var(')) return `calc(${value} * -1)`
+  }
+
+  if (isNumeric(value.slice(0, 1))) return `${negative}${value}`
+
+  return value
+}
+
+export { splitNegative, maybeAddNegative }


### PR DESCRIPTION
This PR adds the finishing touches to achieve first-class negative value support - mostly around allowing negative arbitrary values.
The first half of this feature was achieved in #610 in order to satisfy existing tests. 

Refs [#5709](https://github.com/tailwindlabs/tailwindcss/pull/5709), [c48e629](https://github.com/tailwindlabs/tailwindcss/commit/c48e629955585ad18dadba9f470fda59cc448ab7)