### PR TITLE
Add will-change utilities

### DIFF
--- a/__fixtures__/interactivity.js
+++ b/__fixtures__/interactivity.js
@@ -1,4 +1,4 @@
-import tw from './macro'
+import tw, { theme } from './macro'
 
 // https://tailwindcss.com/docs/appearance
 tw`appearance-none`
@@ -34,3 +34,11 @@ tw`select-none`
 tw`select-text`
 tw`select-all`
 tw`select-auto`
+
+// https://tailwindcss.com/docs/will-change
+theme`willChange`
+tw`will-change-auto`
+tw`will-change-scroll`
+tw`will-change-contents`
+tw`will-change-transform`
+tw`will-change-[top,left]`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -12614,7 +12614,7 @@ const CssThenTwThenClassNameThenCs = (
 
 exports[`twin.macro interactivity.js: interactivity.js 1`] = `
 
-import tw from './macro'
+import tw, { theme } from './macro'
 
 // https://tailwindcss.com/docs/appearance
 tw\`appearance-none\`
@@ -12650,6 +12650,14 @@ tw\`select-none\`
 tw\`select-text\`
 tw\`select-all\`
 tw\`select-auto\`
+
+// https://tailwindcss.com/docs/will-change
+theme\`willChange\`
+tw\`will-change-auto\`
+tw\`will-change-scroll\`
+tw\`will-change-contents\`
+tw\`will-change-transform\`
+tw\`will-change-[top,left]\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -12719,6 +12727,28 @@ tw\`select-auto\`
 })
 ;({
   userSelect: 'auto',
+}) // https://tailwindcss.com/docs/will-change
+
+;({
+  auto: 'auto',
+  scroll: 'scroll-position',
+  contents: 'contents',
+  transform: 'transform',
+})
+;({
+  willChange: 'auto',
+})
+;({
+  willChange: 'scroll-position',
+})
+;({
+  willChange: 'contents',
+})
+;({
+  willChange: 'transform',
+})
+;({
+  willChange: 'top,left',
 })
 
 

--- a/src/config/dynamicStyles.js
+++ b/src/config/dynamicStyles.js
@@ -781,6 +781,9 @@ export default {
   // https://tailwindcss.com/docs/user-select
   // See staticStyles.js
 
+  // https://tailwindcss.com/docs/will-change
+  'will-change': { prop: 'willChange', config: 'willChange' },
+
   /**
    * ===========================================
    * Svg


### PR DESCRIPTION
This PR adds new utilities for [will-change](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change):

```js
import tw, { theme } from './macro'

theme`willChange`
tw`will-change-auto`
tw`will-change-scroll`
tw`will-change-contents`
tw`will-change-transform`
tw`will-change-[top,left]`


// ↓ ↓ ↓ ↓ ↓ ↓

({
  "auto": "auto",
  "scroll": "scroll-position",
  "contents": "contents",
  "transform": "transform"
});
({
  "willChange": "auto"
});
({
  "willChange": "scroll-position"
});
({
  "willChange": "contents"
});
({
  "willChange": "transform"
});
({
  "willChange": "top,left"
});
```

Ref [#5448](https://github.com/tailwindlabs/tailwindcss/pull/5448)