### PR TITLE
Sync before after with tailwind

### DIFF
--- a/__fixtures__/!custom.js
+++ b/__fixtures__/!custom.js
@@ -4,8 +4,6 @@ import tw from './macro'
  * Test custom Twin classes
  */
 
-tw`content`
-
 tw`font-customFontWeightAsString`
 tw`font-customFontWeightAsNumber`
 

--- a/__fixtures__/!variantGrouping.js
+++ b/__fixtures__/!variantGrouping.js
@@ -3,7 +3,7 @@ import tw from './macro'
 const basic = tw`group-hover:(flex m-10)`
 const subMediaQuery = tw`focus-within:(md:flex mt-5)`
 const multipleClasses = tw`hover:(bg-black text-white underline)`
-const pseudoElement = tw`before:(content w-10 h-10 block bg-black)`
+const pseudoElement = tw`before:(w-10 h-10 block bg-black)`
 const pseudoElementNoContent = tw`before:(w-10 h-10 block bg-black)`
 const pseudoElementsNoContent = tw`before:(w-10 h-10) after:(w-10 h-10)`
 const mediaHover = tw`sm:hover:(bg-black text-white)`

--- a/__fixtures__/!variants.js
+++ b/__fixtures__/!variants.js
@@ -1,8 +1,6 @@
 import tw from './macro'
 
 // Before/after pseudo elements
-tw`before:content`
-tw`after:content`
 tw`before:flex`
 tw`after:flex`
 

--- a/__fixtures__/content/emotion/contentEmotion.js
+++ b/__fixtures__/content/emotion/contentEmotion.js
@@ -3,8 +3,11 @@ import tw, { theme } from './macro'
 // https://tailwindcss.com/docs/content
 theme`content`
 
-tw`content-none`
-
+tw`content`
+tw`content-test`
 tw`content-['hello']`
 tw`content-[attr(content-before)]`
-tw`before:content-[attr(content-before)]`
+tw`content-['>']`
+tw`content-none`
+tw`before:block`
+tw`peer-focus:before:block`

--- a/__fixtures__/content/emotion/tailwind.config.js
+++ b/__fixtures__/content/emotion/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  theme: {
+    extend: {
+      content: {
+        test: '"hi"',
+        DEFAULT: '"default"',
+      },
+    },
+  },
+}

--- a/__fixtures__/content/styledComponents/config.json
+++ b/__fixtures__/content/styledComponents/config.json
@@ -1,0 +1,3 @@
+{
+  "preset": "styled-components"
+}

--- a/__fixtures__/content/styledComponents/contentStyledComponents.js
+++ b/__fixtures__/content/styledComponents/contentStyledComponents.js
@@ -1,0 +1,13 @@
+import tw, { theme } from './macro'
+
+// https://tailwindcss.com/docs/content
+theme`content`
+
+tw`content`
+tw`content-test`
+tw`content-['hello']`
+tw`content-[attr(content-before)]`
+tw`content-['>']`
+tw`content-none`
+tw`before:block`
+tw`peer-focus:before:block`

--- a/__fixtures__/content/styledComponents/tailwind.config.js
+++ b/__fixtures__/content/styledComponents/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  theme: {
+    extend: {
+      content: {
+        test: '"hi"',
+        DEFAULT: '"default"',
+      },
+    },
+  },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -8,8 +8,6 @@ import tw from './macro'
  * Test custom Twin classes
  */
 
-tw\`content\`
-
 tw\`font-customFontWeightAsString\`
 tw\`font-customFontWeightAsNumber\`
 
@@ -25,9 +23,6 @@ tw\`stroke-non-scaling\`
 /**
  * Test custom Twin classes
  */
-;({
-  content: '""',
-})
 ;({
   fontWeight: '700',
 })
@@ -516,7 +511,7 @@ border-color: rgb(229 231 235 / var(--tw-border-opacity));
 --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
         }
 ::before, ::after {
---tw-content: ;
+--tw-content: '';
         }
 html {
 line-height: 1.5;
@@ -1244,7 +1239,7 @@ import tw from './macro'
 const basic = tw\`group-hover:(flex m-10)\`
 const subMediaQuery = tw\`focus-within:(md:flex mt-5)\`
 const multipleClasses = tw\`hover:(bg-black text-white underline)\`
-const pseudoElement = tw\`before:(content w-10 h-10 block bg-black)\`
+const pseudoElement = tw\`before:(w-10 h-10 block bg-black)\`
 const pseudoElementNoContent = tw\`before:(w-10 h-10 block bg-black)\`
 const pseudoElementsNoContent = tw\`before:(w-10 h-10) after:(w-10 h-10)\`
 const mediaHover = tw\`sm:hover:(bg-black text-white)\`
@@ -1460,8 +1455,6 @@ exports[`twin.macro !variants.js: !variants.js 1`] = `
 import tw from './macro'
 
 // Before/after pseudo elements
-tw\`before:content\`
-tw\`after:content\`
 tw\`before:flex\`
 tw\`after:flex\`
 
@@ -1616,16 +1609,6 @@ tw\`xl:placeholder-red-500! first:md:block sm:disabled:flex\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 // Before/after pseudo elements
-;({
-  ':before': {
-    content: '""',
-  },
-})
-;({
-  ':after': {
-    content: '""',
-  },
-})
 ;({
   ':before': {
     content: '""',
@@ -3611,7 +3594,7 @@ border-color: rgb(229 231 235 / var(--tw-border-opacity));
 --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
         }
 ::before, ::after {
---tw-content: ;
+--tw-content: '';
         }
 html {
 line-height: 1.5;
@@ -3867,7 +3850,7 @@ font-family: NotoSans;
     '--tw-backdrop-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
   },
   '::before, ::after': {
-    '--tw-content': '',
+    '--tw-content': "''",
   },
   html: {
     lineHeight: '1.5',
@@ -4119,7 +4102,7 @@ theme\`keyframes\`
     '--tw-backdrop-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
   },
   '::before, ::after': {
-    '--tw-content': '',
+    '--tw-content': "''",
   },
   html: {
     lineHeight: '1.5',
@@ -17037,7 +17020,7 @@ border-color: rgb(var(--twc-gray-200));
 --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
         }
 ::before, ::after {
---tw-content: ;
+--tw-content: '';
         }
 html {
 line-height: 1.5;
@@ -17738,27 +17721,31 @@ tw\`md:container md:mx-auto\`
 
 `;
 
-exports[`twin.macro content.js: content.js 1`] = `
+exports[`twin.macro contentEmotion.js: contentEmotion.js 1`] = `
 
 import tw, { theme } from './macro'
 
 // https://tailwindcss.com/docs/content
 theme\`content\`
 
-tw\`content-none\`
-
+tw\`content\`
+tw\`content-test\`
 tw\`content-['hello']\`
 tw\`content-[attr(content-before)]\`
-tw\`before:content-[attr(content-before)]\`
+tw\`content-['>']\`
+tw\`content-none\`
+tw\`before:block\`
+tw\`peer-focus:before:block\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 // https://tailwindcss.com/docs/content
+"\\"default\\""
 ;({
-  none: 'none',
+  content: '"default"',
 })
 ;({
-  content: 'none',
+  content: '"hi"',
 })
 ;({
   content: "'hello'",
@@ -17767,8 +17754,85 @@ tw\`before:content-[attr(content-before)]\`
   content: 'attr(content-before)',
 })
 ;({
+  content: "'>'",
+})
+;({
+  content: 'none',
+})
+;({
   ':before': {
-    content: 'attr(content-before)',
+    content: '""',
+    display: 'block',
+  },
+})
+;({
+  '.peer:focus ~ &': {
+    ':before': {
+      content: '""',
+      display: 'block',
+    },
+  },
+})
+
+
+`;
+
+exports[`twin.macro contentStyledComponents.js: contentStyledComponents.js 1`] = `
+
+import tw, { theme } from './macro'
+
+// https://tailwindcss.com/docs/content
+theme\`content\`
+
+tw\`content\`
+tw\`content-test\`
+tw\`content-['hello']\`
+tw\`content-[attr(content-before)]\`
+tw\`content-['>']\`
+tw\`content-none\`
+tw\`before:block\`
+tw\`peer-focus:before:block\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// https://tailwindcss.com/docs/content
+"\\"default\\""
+;({
+  '--tw-content': '"default"',
+  content: 'var(--tw-content)',
+})
+;({
+  '--tw-content': '"hi"',
+  content: 'var(--tw-content)',
+})
+;({
+  '--tw-content': "'hello'",
+  content: 'var(--tw-content)',
+})
+;({
+  '--tw-content': 'attr(content-before)',
+  content: 'var(--tw-content)',
+})
+;({
+  '--tw-content': "'>'",
+  content: 'var(--tw-content)',
+})
+;({
+  '--tw-content': 'none',
+  content: 'var(--tw-content)',
+})
+;({
+  ':before': {
+    content: 'var(--tw-content)',
+    display: 'block',
+  },
+})
+;({
+  '.peer:focus ~ &': {
+    ':before': {
+      content: 'var(--tw-content)',
+      display: 'block',
+    },
   },
 })
 
@@ -22861,7 +22925,7 @@ const _GlobalStyles = () => (
       }
       ::before,
       ::after {
-        --tw-content: ;
+        --tw-content: '';
       }
       html {
         line-height: 1.5;
@@ -36565,7 +36629,7 @@ border-color: rgb(229 231 235 / var(--tw-border-opacity));
 --tw-backdrop-sepia: var(--tw-empty,/*!*/ /*!*/);
         }
 ::before, ::after {
---tw-content: ;
+--tw-content: '';
         }
 html {
 line-height: 1.5;
@@ -45055,7 +45119,7 @@ const globals = global({
     '--tw-backdrop-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
   },
   '::before, ::after': {
-    '--tw-content': '',
+    '--tw-content': "''",
   },
   html: {
     lineHeight: '1.5',

--- a/src/config/dynamicStyles.js
+++ b/src/config/dynamicStyles.js
@@ -11,7 +11,14 @@ export default {
   container: { hasArbitrary: false, plugin: 'container' },
 
   // https://tailwindcss.com/docs/just-in-time-mode#content-utilities
-  content: { prop: 'content', config: 'content' },
+  content: {
+    config: 'content',
+    value: ({ value, isEmotion }) => {
+      // Temp fix until emotion supports css variables with the content property
+      if (isEmotion) return { content: value }
+      return { '--tw-content': value, content: 'var(--tw-content)' }
+    },
+  },
 
   // https://tailwindcss.com/docs/just-in-time-mode#caret-color-utilities
   caret: {

--- a/src/config/preflightStyles.js
+++ b/src/config/preflightStyles.js
@@ -10,7 +10,9 @@ const globalPreflightStyles = ({ theme, withAlpha }) => ({
       variable: '--tw-border-opacity',
     }),
   },
-  '::before, ::after': { '--tw-content': '' },
+  '::before, ::after': {
+    '--tw-content': "''",
+  },
   html: {
     lineHeight: '1.5',
     WebkitTextSizeAdjust: '100%',

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -803,12 +803,4 @@ export default {
   },
 
   'transform-none': { output: { transform: 'none' } },
-
-  /**
-   * ===========================================
-   * Extras
-   * Extra styles that aren't part of Tailwind
-   */
-
-  content: { output: { content: '""' } },
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,4 @@
-const addContentClass = classes => {
+const addContentClass = (classes, state) => {
   const newClasses = []
   classes.forEach(classSet => {
     const shouldAddContent = /(?!.*:content($|\[))(before:|after:)/.test(
@@ -10,7 +10,10 @@ const addContentClass = classes => {
 
     // Avoid adding content if it's already in the new class list
     if (!newClasses.some(c => c.startsWith(`${variants}:content`)))
-      newClasses.push(`${variants}:content`)
+      // Temp fix until emotion supports css variables with the content property
+      newClasses.push(
+        `${variants}:content[${state.isEmotion ? '""' : 'var(--tw-content)'}]`
+      )
 
     newClasses.push(classSet)
   })

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -68,7 +68,7 @@ const formatTasks = [
   // Move and sort the responsive items to the end of the list
   ({ classes, state }) => orderByScreens(classes, state),
   // Add a missing content class for after:/before: variants
-  ({ classes }) => addContentClass(classes),
+  ({ classes, state }) => addContentClass(classes, state),
 ]
 
 export default (

--- a/src/handlers/arbitraryCss.js
+++ b/src/handlers/arbitraryCss.js
@@ -221,7 +221,13 @@ export default ({ state, pieces }) => {
 
   const arbitraryValue =
     typeof config.value === 'function'
-      ? config.value({ value, transparentTo, color, negative: pieces.negative })
+      ? config.value({
+          value,
+          transparentTo,
+          color,
+          negative: pieces.negative,
+          isEmotion: state.isEmotion,
+        })
       : maybeAddNegative(value, pieces.negative)
 
   // Raw values - no prop value found in config

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -30,7 +30,12 @@ export default ({ theme, pieces, state, dynamicKey, dynamicConfig }) => {
     if (value) {
       results =
         typeof item.value === 'function'
-          ? item.value({ value, transparentTo, negative })
+          ? item.value({
+              value,
+              transparentTo,
+              negative,
+              isEmotion: state.isEmotion,
+            })
           : styleify({
               property: item.prop,
               value,


### PR DESCRIPTION
This PR syncs the before and after variants with tailwind.

I stumbled on a bug within Emotion which doesn't support css variables with the content property. I'll raise an issue but in the meantime emotion will use a sightly different technique as a workaround.

**Breaking change**

The `content` class is no longer available by default.
Twin now uses the dynamic content item in your tailwind.config to set content classes so adding a custom `content` class no longer makes sense.

If you need it, this config will bring back that class and restore the functionality:

```js
// tailwind.config.js
module.exports = {
  theme: {
    extend: {
      content: {
        DEFAULT: '""'
      }
    }
  },
}
```

[Ref](https://github.com/tailwindlabs/tailwindcss/pull/5820) 