### PR TITLE
Add `border-x` and `border-y` width and color classes

### DIFF
--- a/__fixtures__/utilitiesBackgrounds/backgroundColor.js
+++ b/__fixtures__/utilitiesBackgrounds/backgroundColor.js
@@ -237,6 +237,9 @@ tw`bg-[url('/img/hero-pattern.svg')]`
 
 tw`bg-red-500/25`
 tw`bg-red-500/fromConfig`
+tw`bg-red-500/fromConfig/25`
+tw`bg-red-500/fromConfig/[.555]`
+tw`bg-red-500/fromConfig/[var(--myvar)]`
 tw`bg-red-500/[.555]`
 tw`bg-red-500/[var(--myvar)]`
 tw`bg-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesBackgrounds/gradientColorStops.js
+++ b/__fixtures__/utilitiesBackgrounds/gradientColorStops.js
@@ -694,6 +694,9 @@ tw`from-[var(--color)] via-[var(--color)] to-[var(--color)]`
 tw`from-red-500`
 tw`from-red-500/25`
 tw`from-red-500/fromConfig`
+tw`from-red-500/fromConfig/25`
+tw`from-red-500/fromConfig/[.555]`
+tw`from-red-500/fromConfig/[var(--myvar)]`
 tw`from-red-500/[.555]`
 tw`from-red-500/[var(--myvar)]`
 tw`from-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesBorders/borderColor.js
+++ b/__fixtures__/utilitiesBorders/borderColor.js
@@ -1590,6 +1590,9 @@ tw`border-t-[#f00]`
 
 tw`border-red-500/25`
 tw`border-red-500/fromConfig`
+tw`border-red-500/fromConfig/25`
+tw`border-red-500/fromConfig/[.555]`
+tw`border-red-500/fromConfig/[var(--myvar)]`
 tw`border-red-500/[.555]`
 tw`border-red-500/[var(--myvar)]`
 tw`border-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesBorders/borderColor.js
+++ b/__fixtures__/utilitiesBorders/borderColor.js
@@ -228,456 +228,456 @@ tw`border-rose-600`
 tw`border-rose-700`
 tw`border-rose-800`
 tw`border-rose-900`
-// tw`border-x-inherit`
-// tw`border-x-current`
-// tw`border-x-transparent`
-// tw`border-x-black`
-// tw`border-x-white`
-// tw`border-x-slate-50`
-// tw`border-x-slate-100`
-// tw`border-x-slate-200`
-// tw`border-x-slate-300`
-// tw`border-x-slate-400`
-// tw`border-x-slate-500`
-// tw`border-x-slate-600`
-// tw`border-x-slate-700`
-// tw`border-x-slate-800`
-// tw`border-x-slate-900`
-// tw`border-x-gray-50`
-// tw`border-x-gray-100`
-// tw`border-x-gray-200`
-// tw`border-x-gray-300`
-// tw`border-x-gray-400`
-// tw`border-x-gray-500`
-// tw`border-x-gray-600`
-// tw`border-x-gray-700`
-// tw`border-x-gray-800`
-// tw`border-x-gray-900`
-// tw`border-x-zinc-50`
-// tw`border-x-zinc-100`
-// tw`border-x-zinc-200`
-// tw`border-x-zinc-300`
-// tw`border-x-zinc-400`
-// tw`border-x-zinc-500`
-// tw`border-x-zinc-600`
-// tw`border-x-zinc-700`
-// tw`border-x-zinc-800`
-// tw`border-x-zinc-900`
-// tw`border-x-neutral-50`
-// tw`border-x-neutral-100`
-// tw`border-x-neutral-200`
-// tw`border-x-neutral-300`
-// tw`border-x-neutral-400`
-// tw`border-x-neutral-500`
-// tw`border-x-neutral-600`
-// tw`border-x-neutral-700`
-// tw`border-x-neutral-800`
-// tw`border-x-neutral-900`
-// tw`border-x-stone-50`
-// tw`border-x-stone-100`
-// tw`border-x-stone-200`
-// tw`border-x-stone-300`
-// tw`border-x-stone-400`
-// tw`border-x-stone-500`
-// tw`border-x-stone-600`
-// tw`border-x-stone-700`
-// tw`border-x-stone-800`
-// tw`border-x-stone-900`
-// tw`border-x-red-50`
-// tw`border-x-red-100`
-// tw`border-x-red-200`
-// tw`border-x-red-300`
-// tw`border-x-red-400`
-// tw`border-x-red-500`
-// tw`border-x-red-600`
-// tw`border-x-red-700`
-// tw`border-x-red-800`
-// tw`border-x-red-900`
-// tw`border-x-orange-50`
-// tw`border-x-orange-100`
-// tw`border-x-orange-200`
-// tw`border-x-orange-300`
-// tw`border-x-orange-400`
-// tw`border-x-orange-500`
-// tw`border-x-orange-600`
-// tw`border-x-orange-700`
-// tw`border-x-orange-800`
-// tw`border-x-orange-900`
-// tw`border-x-amber-50`
-// tw`border-x-amber-100`
-// tw`border-x-amber-200`
-// tw`border-x-amber-300`
-// tw`border-x-amber-400`
-// tw`border-x-amber-500`
-// tw`border-x-amber-600`
-// tw`border-x-amber-700`
-// tw`border-x-amber-800`
-// tw`border-x-amber-900`
-// tw`border-x-yellow-50`
-// tw`border-x-yellow-100`
-// tw`border-x-yellow-200`
-// tw`border-x-yellow-300`
-// tw`border-x-yellow-400`
-// tw`border-x-yellow-500`
-// tw`border-x-yellow-600`
-// tw`border-x-yellow-700`
-// tw`border-x-yellow-800`
-// tw`border-x-yellow-900`
-// tw`border-x-lime-50`
-// tw`border-x-lime-100`
-// tw`border-x-lime-200`
-// tw`border-x-lime-300`
-// tw`border-x-lime-400`
-// tw`border-x-lime-500`
-// tw`border-x-lime-600`
-// tw`border-x-lime-700`
-// tw`border-x-lime-800`
-// tw`border-x-lime-900`
-// tw`border-x-green-50`
-// tw`border-x-green-100`
-// tw`border-x-green-200`
-// tw`border-x-green-300`
-// tw`border-x-green-400`
-// tw`border-x-green-500`
-// tw`border-x-green-600`
-// tw`border-x-green-700`
-// tw`border-x-green-800`
-// tw`border-x-green-900`
-// tw`border-x-emerald-50`
-// tw`border-x-emerald-100`
-// tw`border-x-emerald-200`
-// tw`border-x-emerald-300`
-// tw`border-x-emerald-400`
-// tw`border-x-emerald-500`
-// tw`border-x-emerald-600`
-// tw`border-x-emerald-700`
-// tw`border-x-emerald-800`
-// tw`border-x-emerald-900`
-// tw`border-x-teal-50`
-// tw`border-x-teal-100`
-// tw`border-x-teal-200`
-// tw`border-x-teal-300`
-// tw`border-x-teal-400`
-// tw`border-x-teal-500`
-// tw`border-x-teal-600`
-// tw`border-x-teal-700`
-// tw`border-x-teal-800`
-// tw`border-x-teal-900`
-// tw`border-x-cyan-50`
-// tw`border-x-cyan-100`
-// tw`border-x-cyan-200`
-// tw`border-x-cyan-300`
-// tw`border-x-cyan-400`
-// tw`border-x-cyan-500`
-// tw`border-x-cyan-600`
-// tw`border-x-cyan-700`
-// tw`border-x-cyan-800`
-// tw`border-x-cyan-900`
-// tw`border-x-sky-50`
-// tw`border-x-sky-100`
-// tw`border-x-sky-200`
-// tw`border-x-sky-300`
-// tw`border-x-sky-400`
-// tw`border-x-sky-500`
-// tw`border-x-sky-600`
-// tw`border-x-sky-700`
-// tw`border-x-sky-800`
-// tw`border-x-sky-900`
-// tw`border-x-blue-50`
-// tw`border-x-blue-100`
-// tw`border-x-blue-200`
-// tw`border-x-blue-300`
-// tw`border-x-blue-400`
-// tw`border-x-blue-500`
-// tw`border-x-blue-600`
-// tw`border-x-blue-700`
-// tw`border-x-blue-800`
-// tw`border-x-blue-900`
-// tw`border-x-indigo-50`
-// tw`border-x-indigo-100`
-// tw`border-x-indigo-200`
-// tw`border-x-indigo-300`
-// tw`border-x-indigo-400`
-// tw`border-x-indigo-500`
-// tw`border-x-indigo-600`
-// tw`border-x-indigo-700`
-// tw`border-x-indigo-800`
-// tw`border-x-indigo-900`
-// tw`border-x-violet-50`
-// tw`border-x-violet-100`
-// tw`border-x-violet-200`
-// tw`border-x-violet-300`
-// tw`border-x-violet-400`
-// tw`border-x-violet-500`
-// tw`border-x-violet-600`
-// tw`border-x-violet-700`
-// tw`border-x-violet-800`
-// tw`border-x-violet-900`
-// tw`border-x-purple-50`
-// tw`border-x-purple-100`
-// tw`border-x-purple-200`
-// tw`border-x-purple-300`
-// tw`border-x-purple-400`
-// tw`border-x-purple-500`
-// tw`border-x-purple-600`
-// tw`border-x-purple-700`
-// tw`border-x-purple-800`
-// tw`border-x-purple-900`
-// tw`border-x-fuchsia-50`
-// tw`border-x-fuchsia-100`
-// tw`border-x-fuchsia-200`
-// tw`border-x-fuchsia-300`
-// tw`border-x-fuchsia-400`
-// tw`border-x-fuchsia-500`
-// tw`border-x-fuchsia-600`
-// tw`border-x-fuchsia-700`
-// tw`border-x-fuchsia-800`
-// tw`border-x-fuchsia-900`
-// tw`border-x-pink-50`
-// tw`border-x-pink-100`
-// tw`border-x-pink-200`
-// tw`border-x-pink-300`
-// tw`border-x-pink-400`
-// tw`border-x-pink-500`
-// tw`border-x-pink-600`
-// tw`border-x-pink-700`
-// tw`border-x-pink-800`
-// tw`border-x-pink-900`
-// tw`border-x-rose-50`
-// tw`border-x-rose-100`
-// tw`border-x-rose-200`
-// tw`border-x-rose-300`
-// tw`border-x-rose-400`
-// tw`border-x-rose-500`
-// tw`border-x-rose-600`
-// tw`border-x-rose-700`
-// tw`border-x-rose-800`
-// tw`border-x-rose-900`
-// tw`border-y-inherit`
-// tw`border-y-current`
-// tw`border-y-transparent`
-// tw`border-y-black`
-// tw`border-y-white`
-// tw`border-y-slate-50`
-// tw`border-y-slate-100`
-// tw`border-y-slate-200`
-// tw`border-y-slate-300`
-// tw`border-y-slate-400`
-// tw`border-y-slate-500`
-// tw`border-y-slate-600`
-// tw`border-y-slate-700`
-// tw`border-y-slate-800`
-// tw`border-y-slate-900`
-// tw`border-y-gray-50`
-// tw`border-y-gray-100`
-// tw`border-y-gray-200`
-// tw`border-y-gray-300`
-// tw`border-y-gray-400`
-// tw`border-y-gray-500`
-// tw`border-y-gray-600`
-// tw`border-y-gray-700`
-// tw`border-y-gray-800`
-// tw`border-y-gray-900`
-// tw`border-y-zinc-50`
-// tw`border-y-zinc-100`
-// tw`border-y-zinc-200`
-// tw`border-y-zinc-300`
-// tw`border-y-zinc-400`
-// tw`border-y-zinc-500`
-// tw`border-y-zinc-600`
-// tw`border-y-zinc-700`
-// tw`border-y-zinc-800`
-// tw`border-y-zinc-900`
-// tw`border-y-neutral-50`
-// tw`border-y-neutral-100`
-// tw`border-y-neutral-200`
-// tw`border-y-neutral-300`
-// tw`border-y-neutral-400`
-// tw`border-y-neutral-500`
-// tw`border-y-neutral-600`
-// tw`border-y-neutral-700`
-// tw`border-y-neutral-800`
-// tw`border-y-neutral-900`
-// tw`border-y-stone-50`
-// tw`border-y-stone-100`
-// tw`border-y-stone-200`
-// tw`border-y-stone-300`
-// tw`border-y-stone-400`
-// tw`border-y-stone-500`
-// tw`border-y-stone-600`
-// tw`border-y-stone-700`
-// tw`border-y-stone-800`
-// tw`border-y-stone-900`
-// tw`border-y-red-50`
-// tw`border-y-red-100`
-// tw`border-y-red-200`
-// tw`border-y-red-300`
-// tw`border-y-red-400`
-// tw`border-y-red-500`
-// tw`border-y-red-600`
-// tw`border-y-red-700`
-// tw`border-y-red-800`
-// tw`border-y-red-900`
-// tw`border-y-orange-50`
-// tw`border-y-orange-100`
-// tw`border-y-orange-200`
-// tw`border-y-orange-300`
-// tw`border-y-orange-400`
-// tw`border-y-orange-500`
-// tw`border-y-orange-600`
-// tw`border-y-orange-700`
-// tw`border-y-orange-800`
-// tw`border-y-orange-900`
-// tw`border-y-amber-50`
-// tw`border-y-amber-100`
-// tw`border-y-amber-200`
-// tw`border-y-amber-300`
-// tw`border-y-amber-400`
-// tw`border-y-amber-500`
-// tw`border-y-amber-600`
-// tw`border-y-amber-700`
-// tw`border-y-amber-800`
-// tw`border-y-amber-900`
-// tw`border-y-yellow-50`
-// tw`border-y-yellow-100`
-// tw`border-y-yellow-200`
-// tw`border-y-yellow-300`
-// tw`border-y-yellow-400`
-// tw`border-y-yellow-500`
-// tw`border-y-yellow-600`
-// tw`border-y-yellow-700`
-// tw`border-y-yellow-800`
-// tw`border-y-yellow-900`
-// tw`border-y-lime-50`
-// tw`border-y-lime-100`
-// tw`border-y-lime-200`
-// tw`border-y-lime-300`
-// tw`border-y-lime-400`
-// tw`border-y-lime-500`
-// tw`border-y-lime-600`
-// tw`border-y-lime-700`
-// tw`border-y-lime-800`
-// tw`border-y-lime-900`
-// tw`border-y-green-50`
-// tw`border-y-green-100`
-// tw`border-y-green-200`
-// tw`border-y-green-300`
-// tw`border-y-green-400`
-// tw`border-y-green-500`
-// tw`border-y-green-600`
-// tw`border-y-green-700`
-// tw`border-y-green-800`
-// tw`border-y-green-900`
-// tw`border-y-emerald-50`
-// tw`border-y-emerald-100`
-// tw`border-y-emerald-200`
-// tw`border-y-emerald-300`
-// tw`border-y-emerald-400`
-// tw`border-y-emerald-500`
-// tw`border-y-emerald-600`
-// tw`border-y-emerald-700`
-// tw`border-y-emerald-800`
-// tw`border-y-emerald-900`
-// tw`border-y-teal-50`
-// tw`border-y-teal-100`
-// tw`border-y-teal-200`
-// tw`border-y-teal-300`
-// tw`border-y-teal-400`
-// tw`border-y-teal-500`
-// tw`border-y-teal-600`
-// tw`border-y-teal-700`
-// tw`border-y-teal-800`
-// tw`border-y-teal-900`
-// tw`border-y-cyan-50`
-// tw`border-y-cyan-100`
-// tw`border-y-cyan-200`
-// tw`border-y-cyan-300`
-// tw`border-y-cyan-400`
-// tw`border-y-cyan-500`
-// tw`border-y-cyan-600`
-// tw`border-y-cyan-700`
-// tw`border-y-cyan-800`
-// tw`border-y-cyan-900`
-// tw`border-y-sky-50`
-// tw`border-y-sky-100`
-// tw`border-y-sky-200`
-// tw`border-y-sky-300`
-// tw`border-y-sky-400`
-// tw`border-y-sky-500`
-// tw`border-y-sky-600`
-// tw`border-y-sky-700`
-// tw`border-y-sky-800`
-// tw`border-y-sky-900`
-// tw`border-y-blue-50`
-// tw`border-y-blue-100`
-// tw`border-y-blue-200`
-// tw`border-y-blue-300`
-// tw`border-y-blue-400`
-// tw`border-y-blue-500`
-// tw`border-y-blue-600`
-// tw`border-y-blue-700`
-// tw`border-y-blue-800`
-// tw`border-y-blue-900`
-// tw`border-y-indigo-50`
-// tw`border-y-indigo-100`
-// tw`border-y-indigo-200`
-// tw`border-y-indigo-300`
-// tw`border-y-indigo-400`
-// tw`border-y-indigo-500`
-// tw`border-y-indigo-600`
-// tw`border-y-indigo-700`
-// tw`border-y-indigo-800`
-// tw`border-y-indigo-900`
-// tw`border-y-violet-50`
-// tw`border-y-violet-100`
-// tw`border-y-violet-200`
-// tw`border-y-violet-300`
-// tw`border-y-violet-400`
-// tw`border-y-violet-500`
-// tw`border-y-violet-600`
-// tw`border-y-violet-700`
-// tw`border-y-violet-800`
-// tw`border-y-violet-900`
-// tw`border-y-purple-50`
-// tw`border-y-purple-100`
-// tw`border-y-purple-200`
-// tw`border-y-purple-300`
-// tw`border-y-purple-400`
-// tw`border-y-purple-500`
-// tw`border-y-purple-600`
-// tw`border-y-purple-700`
-// tw`border-y-purple-800`
-// tw`border-y-purple-900`
-// tw`border-y-fuchsia-50`
-// tw`border-y-fuchsia-100`
-// tw`border-y-fuchsia-200`
-// tw`border-y-fuchsia-300`
-// tw`border-y-fuchsia-400`
-// tw`border-y-fuchsia-500`
-// tw`border-y-fuchsia-600`
-// tw`border-y-fuchsia-700`
-// tw`border-y-fuchsia-800`
-// tw`border-y-fuchsia-900`
-// tw`border-y-pink-50`
-// tw`border-y-pink-100`
-// tw`border-y-pink-200`
-// tw`border-y-pink-300`
-// tw`border-y-pink-400`
-// tw`border-y-pink-500`
-// tw`border-y-pink-600`
-// tw`border-y-pink-700`
-// tw`border-y-pink-800`
-// tw`border-y-pink-900`
-// tw`border-y-rose-50`
-// tw`border-y-rose-100`
-// tw`border-y-rose-200`
-// tw`border-y-rose-300`
-// tw`border-y-rose-400`
-// tw`border-y-rose-500`
-// tw`border-y-rose-600`
-// tw`border-y-rose-700`
-// tw`border-y-rose-800`
-// tw`border-y-rose-900`
+tw`border-x-inherit`
+tw`border-x-current`
+tw`border-x-transparent`
+tw`border-x-black`
+tw`border-x-white`
+tw`border-x-slate-50`
+tw`border-x-slate-100`
+tw`border-x-slate-200`
+tw`border-x-slate-300`
+tw`border-x-slate-400`
+tw`border-x-slate-500`
+tw`border-x-slate-600`
+tw`border-x-slate-700`
+tw`border-x-slate-800`
+tw`border-x-slate-900`
+tw`border-x-gray-50`
+tw`border-x-gray-100`
+tw`border-x-gray-200`
+tw`border-x-gray-300`
+tw`border-x-gray-400`
+tw`border-x-gray-500`
+tw`border-x-gray-600`
+tw`border-x-gray-700`
+tw`border-x-gray-800`
+tw`border-x-gray-900`
+tw`border-x-zinc-50`
+tw`border-x-zinc-100`
+tw`border-x-zinc-200`
+tw`border-x-zinc-300`
+tw`border-x-zinc-400`
+tw`border-x-zinc-500`
+tw`border-x-zinc-600`
+tw`border-x-zinc-700`
+tw`border-x-zinc-800`
+tw`border-x-zinc-900`
+tw`border-x-neutral-50`
+tw`border-x-neutral-100`
+tw`border-x-neutral-200`
+tw`border-x-neutral-300`
+tw`border-x-neutral-400`
+tw`border-x-neutral-500`
+tw`border-x-neutral-600`
+tw`border-x-neutral-700`
+tw`border-x-neutral-800`
+tw`border-x-neutral-900`
+tw`border-x-stone-50`
+tw`border-x-stone-100`
+tw`border-x-stone-200`
+tw`border-x-stone-300`
+tw`border-x-stone-400`
+tw`border-x-stone-500`
+tw`border-x-stone-600`
+tw`border-x-stone-700`
+tw`border-x-stone-800`
+tw`border-x-stone-900`
+tw`border-x-red-50`
+tw`border-x-red-100`
+tw`border-x-red-200`
+tw`border-x-red-300`
+tw`border-x-red-400`
+tw`border-x-red-500`
+tw`border-x-red-600`
+tw`border-x-red-700`
+tw`border-x-red-800`
+tw`border-x-red-900`
+tw`border-x-orange-50`
+tw`border-x-orange-100`
+tw`border-x-orange-200`
+tw`border-x-orange-300`
+tw`border-x-orange-400`
+tw`border-x-orange-500`
+tw`border-x-orange-600`
+tw`border-x-orange-700`
+tw`border-x-orange-800`
+tw`border-x-orange-900`
+tw`border-x-amber-50`
+tw`border-x-amber-100`
+tw`border-x-amber-200`
+tw`border-x-amber-300`
+tw`border-x-amber-400`
+tw`border-x-amber-500`
+tw`border-x-amber-600`
+tw`border-x-amber-700`
+tw`border-x-amber-800`
+tw`border-x-amber-900`
+tw`border-x-yellow-50`
+tw`border-x-yellow-100`
+tw`border-x-yellow-200`
+tw`border-x-yellow-300`
+tw`border-x-yellow-400`
+tw`border-x-yellow-500`
+tw`border-x-yellow-600`
+tw`border-x-yellow-700`
+tw`border-x-yellow-800`
+tw`border-x-yellow-900`
+tw`border-x-lime-50`
+tw`border-x-lime-100`
+tw`border-x-lime-200`
+tw`border-x-lime-300`
+tw`border-x-lime-400`
+tw`border-x-lime-500`
+tw`border-x-lime-600`
+tw`border-x-lime-700`
+tw`border-x-lime-800`
+tw`border-x-lime-900`
+tw`border-x-green-50`
+tw`border-x-green-100`
+tw`border-x-green-200`
+tw`border-x-green-300`
+tw`border-x-green-400`
+tw`border-x-green-500`
+tw`border-x-green-600`
+tw`border-x-green-700`
+tw`border-x-green-800`
+tw`border-x-green-900`
+tw`border-x-emerald-50`
+tw`border-x-emerald-100`
+tw`border-x-emerald-200`
+tw`border-x-emerald-300`
+tw`border-x-emerald-400`
+tw`border-x-emerald-500`
+tw`border-x-emerald-600`
+tw`border-x-emerald-700`
+tw`border-x-emerald-800`
+tw`border-x-emerald-900`
+tw`border-x-teal-50`
+tw`border-x-teal-100`
+tw`border-x-teal-200`
+tw`border-x-teal-300`
+tw`border-x-teal-400`
+tw`border-x-teal-500`
+tw`border-x-teal-600`
+tw`border-x-teal-700`
+tw`border-x-teal-800`
+tw`border-x-teal-900`
+tw`border-x-cyan-50`
+tw`border-x-cyan-100`
+tw`border-x-cyan-200`
+tw`border-x-cyan-300`
+tw`border-x-cyan-400`
+tw`border-x-cyan-500`
+tw`border-x-cyan-600`
+tw`border-x-cyan-700`
+tw`border-x-cyan-800`
+tw`border-x-cyan-900`
+tw`border-x-sky-50`
+tw`border-x-sky-100`
+tw`border-x-sky-200`
+tw`border-x-sky-300`
+tw`border-x-sky-400`
+tw`border-x-sky-500`
+tw`border-x-sky-600`
+tw`border-x-sky-700`
+tw`border-x-sky-800`
+tw`border-x-sky-900`
+tw`border-x-blue-50`
+tw`border-x-blue-100`
+tw`border-x-blue-200`
+tw`border-x-blue-300`
+tw`border-x-blue-400`
+tw`border-x-blue-500`
+tw`border-x-blue-600`
+tw`border-x-blue-700`
+tw`border-x-blue-800`
+tw`border-x-blue-900`
+tw`border-x-indigo-50`
+tw`border-x-indigo-100`
+tw`border-x-indigo-200`
+tw`border-x-indigo-300`
+tw`border-x-indigo-400`
+tw`border-x-indigo-500`
+tw`border-x-indigo-600`
+tw`border-x-indigo-700`
+tw`border-x-indigo-800`
+tw`border-x-indigo-900`
+tw`border-x-violet-50`
+tw`border-x-violet-100`
+tw`border-x-violet-200`
+tw`border-x-violet-300`
+tw`border-x-violet-400`
+tw`border-x-violet-500`
+tw`border-x-violet-600`
+tw`border-x-violet-700`
+tw`border-x-violet-800`
+tw`border-x-violet-900`
+tw`border-x-purple-50`
+tw`border-x-purple-100`
+tw`border-x-purple-200`
+tw`border-x-purple-300`
+tw`border-x-purple-400`
+tw`border-x-purple-500`
+tw`border-x-purple-600`
+tw`border-x-purple-700`
+tw`border-x-purple-800`
+tw`border-x-purple-900`
+tw`border-x-fuchsia-50`
+tw`border-x-fuchsia-100`
+tw`border-x-fuchsia-200`
+tw`border-x-fuchsia-300`
+tw`border-x-fuchsia-400`
+tw`border-x-fuchsia-500`
+tw`border-x-fuchsia-600`
+tw`border-x-fuchsia-700`
+tw`border-x-fuchsia-800`
+tw`border-x-fuchsia-900`
+tw`border-x-pink-50`
+tw`border-x-pink-100`
+tw`border-x-pink-200`
+tw`border-x-pink-300`
+tw`border-x-pink-400`
+tw`border-x-pink-500`
+tw`border-x-pink-600`
+tw`border-x-pink-700`
+tw`border-x-pink-800`
+tw`border-x-pink-900`
+tw`border-x-rose-50`
+tw`border-x-rose-100`
+tw`border-x-rose-200`
+tw`border-x-rose-300`
+tw`border-x-rose-400`
+tw`border-x-rose-500`
+tw`border-x-rose-600`
+tw`border-x-rose-700`
+tw`border-x-rose-800`
+tw`border-x-rose-900`
+tw`border-y-inherit`
+tw`border-y-current`
+tw`border-y-transparent`
+tw`border-y-black`
+tw`border-y-white`
+tw`border-y-slate-50`
+tw`border-y-slate-100`
+tw`border-y-slate-200`
+tw`border-y-slate-300`
+tw`border-y-slate-400`
+tw`border-y-slate-500`
+tw`border-y-slate-600`
+tw`border-y-slate-700`
+tw`border-y-slate-800`
+tw`border-y-slate-900`
+tw`border-y-gray-50`
+tw`border-y-gray-100`
+tw`border-y-gray-200`
+tw`border-y-gray-300`
+tw`border-y-gray-400`
+tw`border-y-gray-500`
+tw`border-y-gray-600`
+tw`border-y-gray-700`
+tw`border-y-gray-800`
+tw`border-y-gray-900`
+tw`border-y-zinc-50`
+tw`border-y-zinc-100`
+tw`border-y-zinc-200`
+tw`border-y-zinc-300`
+tw`border-y-zinc-400`
+tw`border-y-zinc-500`
+tw`border-y-zinc-600`
+tw`border-y-zinc-700`
+tw`border-y-zinc-800`
+tw`border-y-zinc-900`
+tw`border-y-neutral-50`
+tw`border-y-neutral-100`
+tw`border-y-neutral-200`
+tw`border-y-neutral-300`
+tw`border-y-neutral-400`
+tw`border-y-neutral-500`
+tw`border-y-neutral-600`
+tw`border-y-neutral-700`
+tw`border-y-neutral-800`
+tw`border-y-neutral-900`
+tw`border-y-stone-50`
+tw`border-y-stone-100`
+tw`border-y-stone-200`
+tw`border-y-stone-300`
+tw`border-y-stone-400`
+tw`border-y-stone-500`
+tw`border-y-stone-600`
+tw`border-y-stone-700`
+tw`border-y-stone-800`
+tw`border-y-stone-900`
+tw`border-y-red-50`
+tw`border-y-red-100`
+tw`border-y-red-200`
+tw`border-y-red-300`
+tw`border-y-red-400`
+tw`border-y-red-500`
+tw`border-y-red-600`
+tw`border-y-red-700`
+tw`border-y-red-800`
+tw`border-y-red-900`
+tw`border-y-orange-50`
+tw`border-y-orange-100`
+tw`border-y-orange-200`
+tw`border-y-orange-300`
+tw`border-y-orange-400`
+tw`border-y-orange-500`
+tw`border-y-orange-600`
+tw`border-y-orange-700`
+tw`border-y-orange-800`
+tw`border-y-orange-900`
+tw`border-y-amber-50`
+tw`border-y-amber-100`
+tw`border-y-amber-200`
+tw`border-y-amber-300`
+tw`border-y-amber-400`
+tw`border-y-amber-500`
+tw`border-y-amber-600`
+tw`border-y-amber-700`
+tw`border-y-amber-800`
+tw`border-y-amber-900`
+tw`border-y-yellow-50`
+tw`border-y-yellow-100`
+tw`border-y-yellow-200`
+tw`border-y-yellow-300`
+tw`border-y-yellow-400`
+tw`border-y-yellow-500`
+tw`border-y-yellow-600`
+tw`border-y-yellow-700`
+tw`border-y-yellow-800`
+tw`border-y-yellow-900`
+tw`border-y-lime-50`
+tw`border-y-lime-100`
+tw`border-y-lime-200`
+tw`border-y-lime-300`
+tw`border-y-lime-400`
+tw`border-y-lime-500`
+tw`border-y-lime-600`
+tw`border-y-lime-700`
+tw`border-y-lime-800`
+tw`border-y-lime-900`
+tw`border-y-green-50`
+tw`border-y-green-100`
+tw`border-y-green-200`
+tw`border-y-green-300`
+tw`border-y-green-400`
+tw`border-y-green-500`
+tw`border-y-green-600`
+tw`border-y-green-700`
+tw`border-y-green-800`
+tw`border-y-green-900`
+tw`border-y-emerald-50`
+tw`border-y-emerald-100`
+tw`border-y-emerald-200`
+tw`border-y-emerald-300`
+tw`border-y-emerald-400`
+tw`border-y-emerald-500`
+tw`border-y-emerald-600`
+tw`border-y-emerald-700`
+tw`border-y-emerald-800`
+tw`border-y-emerald-900`
+tw`border-y-teal-50`
+tw`border-y-teal-100`
+tw`border-y-teal-200`
+tw`border-y-teal-300`
+tw`border-y-teal-400`
+tw`border-y-teal-500`
+tw`border-y-teal-600`
+tw`border-y-teal-700`
+tw`border-y-teal-800`
+tw`border-y-teal-900`
+tw`border-y-cyan-50`
+tw`border-y-cyan-100`
+tw`border-y-cyan-200`
+tw`border-y-cyan-300`
+tw`border-y-cyan-400`
+tw`border-y-cyan-500`
+tw`border-y-cyan-600`
+tw`border-y-cyan-700`
+tw`border-y-cyan-800`
+tw`border-y-cyan-900`
+tw`border-y-sky-50`
+tw`border-y-sky-100`
+tw`border-y-sky-200`
+tw`border-y-sky-300`
+tw`border-y-sky-400`
+tw`border-y-sky-500`
+tw`border-y-sky-600`
+tw`border-y-sky-700`
+tw`border-y-sky-800`
+tw`border-y-sky-900`
+tw`border-y-blue-50`
+tw`border-y-blue-100`
+tw`border-y-blue-200`
+tw`border-y-blue-300`
+tw`border-y-blue-400`
+tw`border-y-blue-500`
+tw`border-y-blue-600`
+tw`border-y-blue-700`
+tw`border-y-blue-800`
+tw`border-y-blue-900`
+tw`border-y-indigo-50`
+tw`border-y-indigo-100`
+tw`border-y-indigo-200`
+tw`border-y-indigo-300`
+tw`border-y-indigo-400`
+tw`border-y-indigo-500`
+tw`border-y-indigo-600`
+tw`border-y-indigo-700`
+tw`border-y-indigo-800`
+tw`border-y-indigo-900`
+tw`border-y-violet-50`
+tw`border-y-violet-100`
+tw`border-y-violet-200`
+tw`border-y-violet-300`
+tw`border-y-violet-400`
+tw`border-y-violet-500`
+tw`border-y-violet-600`
+tw`border-y-violet-700`
+tw`border-y-violet-800`
+tw`border-y-violet-900`
+tw`border-y-purple-50`
+tw`border-y-purple-100`
+tw`border-y-purple-200`
+tw`border-y-purple-300`
+tw`border-y-purple-400`
+tw`border-y-purple-500`
+tw`border-y-purple-600`
+tw`border-y-purple-700`
+tw`border-y-purple-800`
+tw`border-y-purple-900`
+tw`border-y-fuchsia-50`
+tw`border-y-fuchsia-100`
+tw`border-y-fuchsia-200`
+tw`border-y-fuchsia-300`
+tw`border-y-fuchsia-400`
+tw`border-y-fuchsia-500`
+tw`border-y-fuchsia-600`
+tw`border-y-fuchsia-700`
+tw`border-y-fuchsia-800`
+tw`border-y-fuchsia-900`
+tw`border-y-pink-50`
+tw`border-y-pink-100`
+tw`border-y-pink-200`
+tw`border-y-pink-300`
+tw`border-y-pink-400`
+tw`border-y-pink-500`
+tw`border-y-pink-600`
+tw`border-y-pink-700`
+tw`border-y-pink-800`
+tw`border-y-pink-900`
+tw`border-y-rose-50`
+tw`border-y-rose-100`
+tw`border-y-rose-200`
+tw`border-y-rose-300`
+tw`border-y-rose-400`
+tw`border-y-rose-500`
+tw`border-y-rose-600`
+tw`border-y-rose-700`
+tw`border-y-rose-800`
+tw`border-y-rose-900`
 tw`border-t-inherit`
 tw`border-t-current`
 tw`border-t-transparent`

--- a/__fixtures__/utilitiesBorders/borderWidth.js
+++ b/__fixtures__/utilitiesBorders/borderWidth.js
@@ -8,16 +8,16 @@ tw`border-2`
 tw`border-4`
 tw`border-8`
 tw`border`
-// tw`border-x-0`
-// tw`border-x-2`
-// tw`border-x-4`
-// tw`border-x-8`
-// tw`border-x`
-// tw`border-y-0`
-// tw`border-y-2`
-// tw`border-y-4`
-// tw`border-y-8`
-// tw`border-y`
+tw`border-x-0`
+tw`border-x-2`
+tw`border-x-4`
+tw`border-x-8`
+tw`border-x`
+tw`border-y-0`
+tw`border-y-2`
+tw`border-y-4`
+tw`border-y-8`
+tw`border-y`
 tw`border-t-0`
 tw`border-t-2`
 tw`border-t-4`

--- a/__fixtures__/utilitiesBorders/ringColor.js
+++ b/__fixtures__/utilitiesBorders/ringColor.js
@@ -236,6 +236,9 @@ tw`ring-[#50d71e]`
 tw`ring-red-500`
 tw`ring-red-500/25`
 tw`ring-red-500/fromConfig`
+tw`ring-red-500/fromConfig/25`
+tw`ring-red-500/fromConfig/[.555]`
+tw`ring-red-500/fromConfig/[var(--myvar)]`
 tw`ring-red-500/[.555]`
 tw`ring-red-500/[var(--myvar)]`
 tw`ring-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesBorders/ringOffsetColor.js
+++ b/__fixtures__/utilitiesBorders/ringOffsetColor.js
@@ -241,6 +241,9 @@ tw`ring-offset-[#50d71e]`
 tw`ring-offset-red-500`
 tw`ring-offset-red-500/25`
 tw`ring-offset-red-500/fromConfig`
+tw`ring-offset-red-500/fromConfig/25`
+tw`ring-offset-red-500/fromConfig/[.555]`
+tw`ring-offset-red-500/fromConfig/[var(--myvar)]`
 tw`ring-offset-red-500/[.555]`
 tw`ring-offset-red-500/[var(--myvar)]`
 tw`ring-offset-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesSvg/fill.js
+++ b/__fixtures__/utilitiesSvg/fill.js
@@ -240,6 +240,9 @@ tw`fill-[var(--color)]`
 tw`fill-red-500`
 tw`fill-red-500/25`
 tw`fill-red-500/fromConfig`
+tw`fill-red-500/fromConfig/25`
+tw`fill-red-500/fromConfig/[.555]`
+tw`fill-red-500/fromConfig/[var(--myvar)]`
 tw`fill-red-500/[.555]`
 tw`fill-red-500/[var(--myvar)]`
 tw`fill-[theme('colors.red.500')]`

--- a/__fixtures__/utilitiesSvg/stroke.js
+++ b/__fixtures__/utilitiesSvg/stroke.js
@@ -239,6 +239,9 @@ tw`stroke-[#243c5a]`
 tw`stroke-red-500`
 tw`stroke-red-500/25`
 tw`stroke-red-500/fromConfig`
+tw`stroke-red-500/fromConfig/25`
+tw`stroke-red-500/fromConfig/[.555]`
+tw`stroke-red-500/fromConfig/[var(--myvar)]`
 tw`stroke-red-500/[.555]`
 tw`stroke-red-500/[var(--myvar)]`
 tw`stroke-[theme('colors.red.500')]`

--- a/__fixtures__/utiltiesInteractivity/caretColor.js
+++ b/__fixtures__/utiltiesInteractivity/caretColor.js
@@ -233,6 +233,9 @@ tw`caret-[#50d71e]`
 
 tw`caret-red-500/25`
 tw`caret-red-500/fromConfig`
+tw`caret-red-500/fromConfig/25`
+tw`caret-red-500/fromConfig/[.555]`
+tw`caret-red-500/fromConfig/[var(--myvar)]`
 tw`caret-red-500/[.555]`
 tw`caret-red-500/[var(--myvar)]`
 tw`caret-[theme('colors.red.500')]`

--- a/__fixtures__/utiltiesTypography/placeholderColor.js
+++ b/__fixtures__/utiltiesTypography/placeholderColor.js
@@ -232,6 +232,9 @@ tw`placeholder-[var(--placeholder)]`
 
 tw`placeholder-red-500/25`
 tw`placeholder-red-500/fromConfig`
+tw`placeholder-red-500/fromConfig/25`
+tw`placeholder-red-500/fromConfig/[.555]`
+tw`placeholder-red-500/fromConfig/[var(--myvar)]`
 tw`placeholder-red-500/[.555]`
 tw`placeholder-red-500/[var(--myvar)]`
 tw`placeholder-[theme('colors.red.500')]`

--- a/__fixtures__/utiltiesTypography/textColor.js
+++ b/__fixtures__/utiltiesTypography/textColor.js
@@ -237,6 +237,9 @@ tw`text-[color:var(--color)]`
 tw`text-red-500`
 tw`text-red-500/25`
 tw`text-red-500/fromConfig`
+tw`text-red-500/fromConfig/25`
+tw`text-red-500/fromConfig/[.555]`
+tw`text-red-500/fromConfig/[var(--myvar)]`
 tw`text-red-500/[.555]`
 tw`text-red-500/[var(--myvar)]`
 tw`text-[theme('colors.red.500')]`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -5679,6 +5679,9 @@ tw\`bg-[url('/img/hero-pattern.svg')]\`
 
 tw\`bg-red-500/25\`
 tw\`bg-red-500/fromConfig\`
+tw\`bg-red-500/fromConfig/25\`
+tw\`bg-red-500/fromConfig/[.555]\`
+tw\`bg-red-500/fromConfig/[var(--myvar)]\`
 tw\`bg-red-500/[.555]\`
 tw\`bg-red-500/[var(--myvar)]\`
 tw\`bg-[theme('colors.red.500')]\`
@@ -6890,6 +6893,15 @@ tw\`bg-[theme('colors.electric')]/20\`
   backgroundColor: 'rgb(0 0 0 / var(--tw-bg-opacity))',
 })
 ;({
+  backgroundColor: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  backgroundColor: 'rgb(0 0 0 / .555)',
+})
+;({
+  backgroundColor: 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   backgroundColor: 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -6907,13 +6919,13 @@ tw\`bg-[theme('colors.electric')]/20\`
   backgroundColor: 'rgba(219, 0, 255, var(--tw-bg-opacity))',
 })
 ;({
-  backgroundColor: 'rgb(219 0 255 / 0.25)',
+  backgroundColor: 'rgba(219, 0, 255, 0.25)',
 })
 ;({
-  backgroundColor: 'rgb(219 0 255 / .555)',
+  backgroundColor: 'rgba(219, 0, 255, .555)',
 })
 ;({
-  backgroundColor: 'rgb(219 0 255 / var(--myvar))',
+  backgroundColor: 'rgba(219, 0, 255, var(--myvar))',
 })
 ;({
   '--tw-bg-opacity': '1',
@@ -8927,6 +8939,9 @@ tw\`border-t-[#f00]\`
 
 tw\`border-red-500/25\`
 tw\`border-red-500/fromConfig\`
+tw\`border-red-500/fromConfig/25\`
+tw\`border-red-500/fromConfig/[.555]\`
+tw\`border-red-500/fromConfig/[var(--myvar)]\`
 tw\`border-red-500/[.555]\`
 tw\`border-red-500/[var(--myvar)]\`
 tw\`border-[theme('colors.red.500')]\`
@@ -13896,6 +13911,15 @@ tw\`border-[theme('colors.electric')]/20\`
   borderColor: 'rgb(0 0 0 / var(--tw-border-opacity))',
 })
 ;({
+  borderColor: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  borderColor: 'rgb(0 0 0 / .555)',
+})
+;({
+  borderColor: 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   borderColor: 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -13909,13 +13933,13 @@ tw\`border-[theme('colors.electric')]/20\`
   borderColor: 'rgb(239 68 68 / 0.2)',
 })
 ;({
-  borderColor: 'rgb(219 0 255 / 0.25)',
+  borderColor: 'rgba(219, 0, 255, 0.25)',
 })
 ;({
-  borderColor: 'rgb(219 0 255 / .555)',
+  borderColor: 'rgba(219, 0, 255, .555)',
 })
 ;({
-  borderColor: 'rgb(219 0 255 / var(--myvar))',
+  borderColor: 'rgba(219, 0, 255, var(--myvar))',
 })
 ;({
   '--tw-border-opacity': '1',
@@ -15782,6 +15806,9 @@ tw\`caret-[#50d71e]\`
 
 tw\`caret-red-500/25\`
 tw\`caret-red-500/fromConfig\`
+tw\`caret-red-500/fromConfig/25\`
+tw\`caret-red-500/fromConfig/[.555]\`
+tw\`caret-red-500/fromConfig/[var(--myvar)]\`
 tw\`caret-red-500/[.555]\`
 tw\`caret-red-500/[var(--myvar)]\`
 tw\`caret-[theme('colors.red.500')]\`
@@ -16753,6 +16780,15 @@ tw\`caret-[theme('colors.electric')]/20\`
 })
 ;({
   caretColor: '#000',
+})
+;({
+  caretColor: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  caretColor: 'rgb(0 0 0 / .555)',
+})
+;({
+  caretColor: 'rgb(0 0 0 / var(--myvar))',
 })
 ;({
   caretColor: 'rgb(239 68 68 / .555)',
@@ -19940,7 +19976,7 @@ tw\`divide-[#243c5a]\`
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(4px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(4px * var(--tw-divide-y-reverse))',
     borderColor: 'rgb(148 163 184 / 0.25)',
@@ -19948,15 +19984,17 @@ tw\`divide-[#243c5a]\`
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(4px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(4px * var(--tw-divide-y-reverse))',
     borderColor: 'rgb(148 163 184 / .24)',
   },
 })
 ;({
-  '--tw-divide-opacity': '1',
-  borderColor: 'rgb(36 60 90 / var(--tw-divide-opacity))',
+  '> :not([hidden]) ~ :not([hidden])': {
+    '--tw-divide-opacity': '1',
+    borderColor: 'rgb(36 60 90 / var(--tw-divide-opacity))',
+  },
 })
 
 
@@ -20139,70 +20177,70 @@ tw\`divide-y-[3px]\`
 '1px'
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-x-reverse': 0,
+    '--tw-divide-x-reverse': '0',
     borderRightWidth: 'calc(0px * var(--tw-divide-x-reverse))',
     borderLeftWidth: 'calc(0px * calc(1 - var(--tw-divide-x-reverse)))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-x-reverse': 0,
+    '--tw-divide-x-reverse': '0',
     borderRightWidth: 'calc(2px * var(--tw-divide-x-reverse))',
     borderLeftWidth: 'calc(2px * calc(1 - var(--tw-divide-x-reverse)))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-x-reverse': 0,
+    '--tw-divide-x-reverse': '0',
     borderRightWidth: 'calc(4px * var(--tw-divide-x-reverse))',
     borderLeftWidth: 'calc(4px * calc(1 - var(--tw-divide-x-reverse)))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-x-reverse': 0,
+    '--tw-divide-x-reverse': '0',
     borderRightWidth: 'calc(8px * var(--tw-divide-x-reverse))',
     borderLeftWidth: 'calc(8px * calc(1 - var(--tw-divide-x-reverse)))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-x-reverse': 0,
+    '--tw-divide-x-reverse': '0',
     borderRightWidth: 'calc(1px * var(--tw-divide-x-reverse))',
     borderLeftWidth: 'calc(1px * calc(1 - var(--tw-divide-x-reverse)))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(0px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(0px * var(--tw-divide-y-reverse))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(2px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(2px * var(--tw-divide-y-reverse))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(4px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(4px * var(--tw-divide-y-reverse))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(8px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(8px * var(--tw-divide-y-reverse))',
   },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
-    '--tw-divide-y-reverse': 0,
+    '--tw-divide-y-reverse': '0',
     borderTopWidth: 'calc(1px * calc(1 - var(--tw-divide-y-reverse)))',
     borderBottomWidth: 'calc(1px * var(--tw-divide-y-reverse))',
   },
@@ -20218,9 +20256,11 @@ tw\`divide-y-[3px]\`
   },
 })
 ;({
-  '--tw-divide-x-reverse': '0',
-  borderRightWidth: 'calc(3px * var(--tw-divide-x-reverse))',
-  borderLeftWidth: 'calc(3px * calc(1 - var(--tw-divide-x-reverse)))',
+  '> :not([hidden]) ~ :not([hidden])': {
+    '--tw-divide-x-reverse': '0',
+    borderRightWidth: 'calc(3px * var(--tw-divide-x-reverse))',
+    borderLeftWidth: 'calc(3px * calc(1 - var(--tw-divide-x-reverse)))',
+  },
 })
 ;({
   '> :not([hidden]) ~ :not([hidden])': {
@@ -20546,6 +20586,9 @@ tw\`fill-[var(--color)]\`
 tw\`fill-red-500\`
 tw\`fill-red-500/25\`
 tw\`fill-red-500/fromConfig\`
+tw\`fill-red-500/fromConfig/25\`
+tw\`fill-red-500/fromConfig/[.555]\`
+tw\`fill-red-500/fromConfig/[var(--myvar)]\`
 tw\`fill-red-500/[.555]\`
 tw\`fill-red-500/[var(--myvar)]\`
 tw\`fill-[theme('colors.red.500')]\`
@@ -21538,6 +21581,15 @@ tw\`fill-[theme('colors.electric')]/20\`
 })
 ;({
   fill: '#000',
+})
+;({
+  fill: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  fill: 'rgb(0 0 0 / .555)',
+})
+;({
+  fill: 'rgb(0 0 0 / var(--myvar))',
 })
 ;({
   fill: 'rgb(239 68 68 / .555)',
@@ -23901,6 +23953,9 @@ tw\`from-[var(--color)] via-[var(--color)] to-[var(--color)]\`
 tw\`from-red-500\`
 tw\`from-red-500/25\`
 tw\`from-red-500/fromConfig\`
+tw\`from-red-500/fromConfig/25\`
+tw\`from-red-500/fromConfig/[.555]\`
+tw\`from-red-500/fromConfig/[var(--myvar)]\`
 tw\`from-red-500/[.555]\`
 tw\`from-red-500/[var(--myvar)]\`
 tw\`from-[theme('colors.red.500')]\`
@@ -26985,7 +27040,7 @@ tw\`to-[theme('colors.electric')]\`
 ;({
   '--tw-gradient-from': 'rgb(239 68 68 / 0.25)',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0))',
 })
 ;({
   '--tw-gradient-from': '#000',
@@ -26993,14 +27048,29 @@ tw\`to-[theme('colors.electric')]\`
     'var(--tw-gradient-from), var(--tw-gradient-to, rgb(0 0 0 / 0))',
 })
 ;({
+  '--tw-gradient-from': 'rgb(0 0 0 / 0.25)',
+  '--tw-gradient-stops':
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(0 0 0 / 0))',
+})
+;({
+  '--tw-gradient-from': 'rgb(0 0 0 / .555)',
+  '--tw-gradient-stops':
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(0 0 0 / 0))',
+})
+;({
+  '--tw-gradient-from': 'rgb(0 0 0 / var(--myvar))',
+  '--tw-gradient-stops':
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(0 0 0 / 0))',
+})
+;({
   '--tw-gradient-from': 'rgb(239 68 68 / .555)',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0))',
 })
 ;({
   '--tw-gradient-from': 'rgb(239 68 68 / var(--myvar))',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(239 68 68 / 0))',
 })
 ;({
   '--tw-gradient-from': '#ef4444',
@@ -27015,17 +27085,17 @@ tw\`to-[theme('colors.electric')]\`
 ;({
   '--tw-gradient-from': 'rgb(219 0 255 / 0.25)',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0))',
 })
 ;({
   '--tw-gradient-from': 'rgb(219 0 255 / .555)',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0))',
 })
 ;({
   '--tw-gradient-from': 'rgb(219 0 255 / var(--myvar))',
   '--tw-gradient-stops':
-    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0)',
+    'var(--tw-gradient-from), var(--tw-gradient-to, rgb(219 0 255 / 0))',
 })
 ;({
   '--tw-gradient-from': 'rgb(219, 0, 255)',
@@ -35061,6 +35131,9 @@ tw\`placeholder-[var(--placeholder)]\`
 
 tw\`placeholder-red-500/25\`
 tw\`placeholder-red-500/fromConfig\`
+tw\`placeholder-red-500/fromConfig/25\`
+tw\`placeholder-red-500/fromConfig/[.555]\`
+tw\`placeholder-red-500/fromConfig/[var(--myvar)]\`
 tw\`placeholder-red-500/[.555]\`
 tw\`placeholder-red-500/[var(--myvar)]\`
 tw\`placeholder-[theme('colors.red.500')]\`
@@ -36445,6 +36518,21 @@ tw\`placeholder-[theme('colors.electric')]\`
 })
 ;({
   '::placeholder': {
+    color: 'rgb(0 0 0 / 0.25)',
+  },
+})
+;({
+  '::placeholder': {
+    color: 'rgb(0 0 0 / .555)',
+  },
+})
+;({
+  '::placeholder': {
+    color: 'rgb(0 0 0 / var(--myvar))',
+  },
+})
+;({
+  '::placeholder': {
     color: 'rgb(239 68 68 / .555)',
   },
 })
@@ -36467,17 +36555,17 @@ tw\`placeholder-[theme('colors.electric')]\`
 })
 ;({
   '::placeholder': {
-    color: 'rgb(219 0 255 / 0.25)',
+    color: 'rgba(219, 0, 255, 0.25)',
   },
 })
 ;({
   '::placeholder': {
-    color: 'rgb(219 0 255 / .555)',
+    color: 'rgba(219, 0, 255, .555)',
   },
 })
 ;({
   '::placeholder': {
-    color: 'rgb(219 0 255 / var(--myvar))',
+    color: 'rgba(219, 0, 255, var(--myvar))',
   },
 })
 ;({
@@ -38725,6 +38813,9 @@ tw\`ring-[#50d71e]\`
 tw\`ring-red-500\`
 tw\`ring-red-500/25\`
 tw\`ring-red-500/fromConfig\`
+tw\`ring-red-500/fromConfig/25\`
+tw\`ring-red-500/fromConfig/[.555]\`
+tw\`ring-red-500/fromConfig/[var(--myvar)]\`
 tw\`ring-red-500/[.555]\`
 tw\`ring-red-500/[var(--myvar)]\`
 tw\`ring-[theme('colors.red.500')]\`
@@ -39660,6 +39751,15 @@ tw\`ring-[theme('colors.electric')]/20\`
   '--tw-ring-color': 'rgb(0 0 0 / var(--tw-ring-opacity))',
 })
 ;({
+  '--tw-ring-color': 'rgb(0 0 0 / 0.25)',
+})
+;({
+  '--tw-ring-color': 'rgb(0 0 0 / .555)',
+})
+;({
+  '--tw-ring-color': 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   '--tw-ring-color': 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -39677,13 +39777,13 @@ tw\`ring-[theme('colors.electric')]/20\`
   '--tw-ring-color': 'rgba(219, 0, 255, var(--tw-ring-opacity))',
 })
 ;({
-  '--tw-ring-color': 'rgb(219 0 255 / 0.25)',
+  '--tw-ring-color': 'rgba(219, 0, 255, 0.25)',
 })
 ;({
-  '--tw-ring-color': 'rgb(219 0 255 / .555)',
+  '--tw-ring-color': 'rgba(219, 0, 255, .555)',
 })
 ;({
-  '--tw-ring-color': 'rgb(219 0 255 / var(--myvar))',
+  '--tw-ring-color': 'rgba(219, 0, 255, var(--myvar))',
 })
 ;({
   '--tw-ring-opacity': '1',
@@ -40057,6 +40157,9 @@ tw\`ring-offset-[#50d71e]\`
 tw\`ring-offset-red-500\`
 tw\`ring-offset-red-500/25\`
 tw\`ring-offset-red-500/fromConfig\`
+tw\`ring-offset-red-500/fromConfig/25\`
+tw\`ring-offset-red-500/fromConfig/[.555]\`
+tw\`ring-offset-red-500/fromConfig/[var(--myvar)]\`
 tw\`ring-offset-red-500/[.555]\`
 tw\`ring-offset-red-500/[var(--myvar)]\`
 tw\`ring-offset-[theme('colors.red.500')]\`
@@ -41054,6 +41157,15 @@ tw\`ring-offset-[theme('colors.electric')]/20\`
   '--tw-ring-offset-color': '#000',
 })
 ;({
+  '--tw-ring-offset-color': 'rgb(0 0 0 / 0.25)',
+})
+;({
+  '--tw-ring-offset-color': 'rgb(0 0 0 / .555)',
+})
+;({
+  '--tw-ring-offset-color': 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   '--tw-ring-offset-color': 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -41063,7 +41175,7 @@ tw\`ring-offset-[theme('colors.electric')]/20\`
   '--tw-ring-offset-color': '#ef4444',
 })
 ;({
-  '--tw-ring-offset-color': '#ef4444',
+  '--tw-ring-offset-color': 'rgb(239 68 68 / 0.2)',
 })
 ;({
   '--tw-ring-offset-color': 'rgb(219, 0, 255)',
@@ -41081,7 +41193,7 @@ tw\`ring-offset-[theme('colors.electric')]/20\`
   '--tw-ring-offset-color': 'rgb(219, 0, 255)',
 })
 ;({
-  '--tw-ring-offset-color': 'rgb(219, 0, 255)',
+  '--tw-ring-offset-color': 'rgb(219 0 255 / 0.2)',
 })
 
 
@@ -45731,6 +45843,9 @@ tw\`stroke-[#243c5a]\`
 tw\`stroke-red-500\`
 tw\`stroke-red-500/25\`
 tw\`stroke-red-500/fromConfig\`
+tw\`stroke-red-500/fromConfig/25\`
+tw\`stroke-red-500/fromConfig/[.555]\`
+tw\`stroke-red-500/fromConfig/[var(--myvar)]\`
 tw\`stroke-red-500/[.555]\`
 tw\`stroke-red-500/[var(--myvar)]\`
 tw\`stroke-[theme('colors.red.500')]\`
@@ -46722,6 +46837,15 @@ tw\`stroke-[theme('colors.electric')]/20\`
   stroke: '#000',
 })
 ;({
+  stroke: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  stroke: 'rgb(0 0 0 / .555)',
+})
+;({
+  stroke: 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   stroke: 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -46731,7 +46855,7 @@ tw\`stroke-[theme('colors.electric')]/20\`
   stroke: '#ef4444',
 })
 ;({
-  stroke: '#ef4444',
+  stroke: 'rgb(239 68 68 / 0.2)',
 })
 ;({
   stroke: 'rgb(219, 0, 255)',
@@ -46749,7 +46873,7 @@ tw\`stroke-[theme('colors.electric')]/20\`
   stroke: 'rgb(219, 0, 255)',
 })
 ;({
-  stroke: 'rgb(219, 0, 255)',
+  stroke: 'rgb(219 0 255 / 0.2)',
 })
 
 
@@ -47083,6 +47207,9 @@ tw\`text-[color:var(--color)]\`
 tw\`text-red-500\`
 tw\`text-red-500/25\`
 tw\`text-red-500/fromConfig\`
+tw\`text-red-500/fromConfig/25\`
+tw\`text-red-500/fromConfig/[.555]\`
+tw\`text-red-500/fromConfig/[var(--myvar)]\`
 tw\`text-red-500/[.555]\`
 tw\`text-red-500/[var(--myvar)]\`
 tw\`text-[theme('colors.red.500')]\`
@@ -48293,6 +48420,15 @@ tw\`text-[theme('colors.electric')]/20\`
   color: 'rgb(0 0 0 / var(--tw-text-opacity))',
 })
 ;({
+  color: 'rgb(0 0 0 / 0.25)',
+})
+;({
+  color: 'rgb(0 0 0 / .555)',
+})
+;({
+  color: 'rgb(0 0 0 / var(--myvar))',
+})
+;({
   color: 'rgb(239 68 68 / .555)',
 })
 ;({
@@ -48310,13 +48446,13 @@ tw\`text-[theme('colors.electric')]/20\`
   color: 'rgba(219, 0, 255, var(--tw-text-opacity))',
 })
 ;({
-  color: 'rgb(219 0 255 / 0.25)',
+  color: 'rgba(219, 0, 255, 0.25)',
 })
 ;({
-  color: 'rgb(219 0 255 / .555)',
+  color: 'rgba(219, 0, 255, .555)',
 })
 ;({
-  color: 'rgb(219 0 255 / var(--myvar))',
+  color: 'rgba(219, 0, 255, var(--myvar))',
 })
 ;({
   '--tw-text-opacity': '1',

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -7577,456 +7577,456 @@ tw\`border-rose-600\`
 tw\`border-rose-700\`
 tw\`border-rose-800\`
 tw\`border-rose-900\`
-// tw\`border-x-inherit\`
-// tw\`border-x-current\`
-// tw\`border-x-transparent\`
-// tw\`border-x-black\`
-// tw\`border-x-white\`
-// tw\`border-x-slate-50\`
-// tw\`border-x-slate-100\`
-// tw\`border-x-slate-200\`
-// tw\`border-x-slate-300\`
-// tw\`border-x-slate-400\`
-// tw\`border-x-slate-500\`
-// tw\`border-x-slate-600\`
-// tw\`border-x-slate-700\`
-// tw\`border-x-slate-800\`
-// tw\`border-x-slate-900\`
-// tw\`border-x-gray-50\`
-// tw\`border-x-gray-100\`
-// tw\`border-x-gray-200\`
-// tw\`border-x-gray-300\`
-// tw\`border-x-gray-400\`
-// tw\`border-x-gray-500\`
-// tw\`border-x-gray-600\`
-// tw\`border-x-gray-700\`
-// tw\`border-x-gray-800\`
-// tw\`border-x-gray-900\`
-// tw\`border-x-zinc-50\`
-// tw\`border-x-zinc-100\`
-// tw\`border-x-zinc-200\`
-// tw\`border-x-zinc-300\`
-// tw\`border-x-zinc-400\`
-// tw\`border-x-zinc-500\`
-// tw\`border-x-zinc-600\`
-// tw\`border-x-zinc-700\`
-// tw\`border-x-zinc-800\`
-// tw\`border-x-zinc-900\`
-// tw\`border-x-neutral-50\`
-// tw\`border-x-neutral-100\`
-// tw\`border-x-neutral-200\`
-// tw\`border-x-neutral-300\`
-// tw\`border-x-neutral-400\`
-// tw\`border-x-neutral-500\`
-// tw\`border-x-neutral-600\`
-// tw\`border-x-neutral-700\`
-// tw\`border-x-neutral-800\`
-// tw\`border-x-neutral-900\`
-// tw\`border-x-stone-50\`
-// tw\`border-x-stone-100\`
-// tw\`border-x-stone-200\`
-// tw\`border-x-stone-300\`
-// tw\`border-x-stone-400\`
-// tw\`border-x-stone-500\`
-// tw\`border-x-stone-600\`
-// tw\`border-x-stone-700\`
-// tw\`border-x-stone-800\`
-// tw\`border-x-stone-900\`
-// tw\`border-x-red-50\`
-// tw\`border-x-red-100\`
-// tw\`border-x-red-200\`
-// tw\`border-x-red-300\`
-// tw\`border-x-red-400\`
-// tw\`border-x-red-500\`
-// tw\`border-x-red-600\`
-// tw\`border-x-red-700\`
-// tw\`border-x-red-800\`
-// tw\`border-x-red-900\`
-// tw\`border-x-orange-50\`
-// tw\`border-x-orange-100\`
-// tw\`border-x-orange-200\`
-// tw\`border-x-orange-300\`
-// tw\`border-x-orange-400\`
-// tw\`border-x-orange-500\`
-// tw\`border-x-orange-600\`
-// tw\`border-x-orange-700\`
-// tw\`border-x-orange-800\`
-// tw\`border-x-orange-900\`
-// tw\`border-x-amber-50\`
-// tw\`border-x-amber-100\`
-// tw\`border-x-amber-200\`
-// tw\`border-x-amber-300\`
-// tw\`border-x-amber-400\`
-// tw\`border-x-amber-500\`
-// tw\`border-x-amber-600\`
-// tw\`border-x-amber-700\`
-// tw\`border-x-amber-800\`
-// tw\`border-x-amber-900\`
-// tw\`border-x-yellow-50\`
-// tw\`border-x-yellow-100\`
-// tw\`border-x-yellow-200\`
-// tw\`border-x-yellow-300\`
-// tw\`border-x-yellow-400\`
-// tw\`border-x-yellow-500\`
-// tw\`border-x-yellow-600\`
-// tw\`border-x-yellow-700\`
-// tw\`border-x-yellow-800\`
-// tw\`border-x-yellow-900\`
-// tw\`border-x-lime-50\`
-// tw\`border-x-lime-100\`
-// tw\`border-x-lime-200\`
-// tw\`border-x-lime-300\`
-// tw\`border-x-lime-400\`
-// tw\`border-x-lime-500\`
-// tw\`border-x-lime-600\`
-// tw\`border-x-lime-700\`
-// tw\`border-x-lime-800\`
-// tw\`border-x-lime-900\`
-// tw\`border-x-green-50\`
-// tw\`border-x-green-100\`
-// tw\`border-x-green-200\`
-// tw\`border-x-green-300\`
-// tw\`border-x-green-400\`
-// tw\`border-x-green-500\`
-// tw\`border-x-green-600\`
-// tw\`border-x-green-700\`
-// tw\`border-x-green-800\`
-// tw\`border-x-green-900\`
-// tw\`border-x-emerald-50\`
-// tw\`border-x-emerald-100\`
-// tw\`border-x-emerald-200\`
-// tw\`border-x-emerald-300\`
-// tw\`border-x-emerald-400\`
-// tw\`border-x-emerald-500\`
-// tw\`border-x-emerald-600\`
-// tw\`border-x-emerald-700\`
-// tw\`border-x-emerald-800\`
-// tw\`border-x-emerald-900\`
-// tw\`border-x-teal-50\`
-// tw\`border-x-teal-100\`
-// tw\`border-x-teal-200\`
-// tw\`border-x-teal-300\`
-// tw\`border-x-teal-400\`
-// tw\`border-x-teal-500\`
-// tw\`border-x-teal-600\`
-// tw\`border-x-teal-700\`
-// tw\`border-x-teal-800\`
-// tw\`border-x-teal-900\`
-// tw\`border-x-cyan-50\`
-// tw\`border-x-cyan-100\`
-// tw\`border-x-cyan-200\`
-// tw\`border-x-cyan-300\`
-// tw\`border-x-cyan-400\`
-// tw\`border-x-cyan-500\`
-// tw\`border-x-cyan-600\`
-// tw\`border-x-cyan-700\`
-// tw\`border-x-cyan-800\`
-// tw\`border-x-cyan-900\`
-// tw\`border-x-sky-50\`
-// tw\`border-x-sky-100\`
-// tw\`border-x-sky-200\`
-// tw\`border-x-sky-300\`
-// tw\`border-x-sky-400\`
-// tw\`border-x-sky-500\`
-// tw\`border-x-sky-600\`
-// tw\`border-x-sky-700\`
-// tw\`border-x-sky-800\`
-// tw\`border-x-sky-900\`
-// tw\`border-x-blue-50\`
-// tw\`border-x-blue-100\`
-// tw\`border-x-blue-200\`
-// tw\`border-x-blue-300\`
-// tw\`border-x-blue-400\`
-// tw\`border-x-blue-500\`
-// tw\`border-x-blue-600\`
-// tw\`border-x-blue-700\`
-// tw\`border-x-blue-800\`
-// tw\`border-x-blue-900\`
-// tw\`border-x-indigo-50\`
-// tw\`border-x-indigo-100\`
-// tw\`border-x-indigo-200\`
-// tw\`border-x-indigo-300\`
-// tw\`border-x-indigo-400\`
-// tw\`border-x-indigo-500\`
-// tw\`border-x-indigo-600\`
-// tw\`border-x-indigo-700\`
-// tw\`border-x-indigo-800\`
-// tw\`border-x-indigo-900\`
-// tw\`border-x-violet-50\`
-// tw\`border-x-violet-100\`
-// tw\`border-x-violet-200\`
-// tw\`border-x-violet-300\`
-// tw\`border-x-violet-400\`
-// tw\`border-x-violet-500\`
-// tw\`border-x-violet-600\`
-// tw\`border-x-violet-700\`
-// tw\`border-x-violet-800\`
-// tw\`border-x-violet-900\`
-// tw\`border-x-purple-50\`
-// tw\`border-x-purple-100\`
-// tw\`border-x-purple-200\`
-// tw\`border-x-purple-300\`
-// tw\`border-x-purple-400\`
-// tw\`border-x-purple-500\`
-// tw\`border-x-purple-600\`
-// tw\`border-x-purple-700\`
-// tw\`border-x-purple-800\`
-// tw\`border-x-purple-900\`
-// tw\`border-x-fuchsia-50\`
-// tw\`border-x-fuchsia-100\`
-// tw\`border-x-fuchsia-200\`
-// tw\`border-x-fuchsia-300\`
-// tw\`border-x-fuchsia-400\`
-// tw\`border-x-fuchsia-500\`
-// tw\`border-x-fuchsia-600\`
-// tw\`border-x-fuchsia-700\`
-// tw\`border-x-fuchsia-800\`
-// tw\`border-x-fuchsia-900\`
-// tw\`border-x-pink-50\`
-// tw\`border-x-pink-100\`
-// tw\`border-x-pink-200\`
-// tw\`border-x-pink-300\`
-// tw\`border-x-pink-400\`
-// tw\`border-x-pink-500\`
-// tw\`border-x-pink-600\`
-// tw\`border-x-pink-700\`
-// tw\`border-x-pink-800\`
-// tw\`border-x-pink-900\`
-// tw\`border-x-rose-50\`
-// tw\`border-x-rose-100\`
-// tw\`border-x-rose-200\`
-// tw\`border-x-rose-300\`
-// tw\`border-x-rose-400\`
-// tw\`border-x-rose-500\`
-// tw\`border-x-rose-600\`
-// tw\`border-x-rose-700\`
-// tw\`border-x-rose-800\`
-// tw\`border-x-rose-900\`
-// tw\`border-y-inherit\`
-// tw\`border-y-current\`
-// tw\`border-y-transparent\`
-// tw\`border-y-black\`
-// tw\`border-y-white\`
-// tw\`border-y-slate-50\`
-// tw\`border-y-slate-100\`
-// tw\`border-y-slate-200\`
-// tw\`border-y-slate-300\`
-// tw\`border-y-slate-400\`
-// tw\`border-y-slate-500\`
-// tw\`border-y-slate-600\`
-// tw\`border-y-slate-700\`
-// tw\`border-y-slate-800\`
-// tw\`border-y-slate-900\`
-// tw\`border-y-gray-50\`
-// tw\`border-y-gray-100\`
-// tw\`border-y-gray-200\`
-// tw\`border-y-gray-300\`
-// tw\`border-y-gray-400\`
-// tw\`border-y-gray-500\`
-// tw\`border-y-gray-600\`
-// tw\`border-y-gray-700\`
-// tw\`border-y-gray-800\`
-// tw\`border-y-gray-900\`
-// tw\`border-y-zinc-50\`
-// tw\`border-y-zinc-100\`
-// tw\`border-y-zinc-200\`
-// tw\`border-y-zinc-300\`
-// tw\`border-y-zinc-400\`
-// tw\`border-y-zinc-500\`
-// tw\`border-y-zinc-600\`
-// tw\`border-y-zinc-700\`
-// tw\`border-y-zinc-800\`
-// tw\`border-y-zinc-900\`
-// tw\`border-y-neutral-50\`
-// tw\`border-y-neutral-100\`
-// tw\`border-y-neutral-200\`
-// tw\`border-y-neutral-300\`
-// tw\`border-y-neutral-400\`
-// tw\`border-y-neutral-500\`
-// tw\`border-y-neutral-600\`
-// tw\`border-y-neutral-700\`
-// tw\`border-y-neutral-800\`
-// tw\`border-y-neutral-900\`
-// tw\`border-y-stone-50\`
-// tw\`border-y-stone-100\`
-// tw\`border-y-stone-200\`
-// tw\`border-y-stone-300\`
-// tw\`border-y-stone-400\`
-// tw\`border-y-stone-500\`
-// tw\`border-y-stone-600\`
-// tw\`border-y-stone-700\`
-// tw\`border-y-stone-800\`
-// tw\`border-y-stone-900\`
-// tw\`border-y-red-50\`
-// tw\`border-y-red-100\`
-// tw\`border-y-red-200\`
-// tw\`border-y-red-300\`
-// tw\`border-y-red-400\`
-// tw\`border-y-red-500\`
-// tw\`border-y-red-600\`
-// tw\`border-y-red-700\`
-// tw\`border-y-red-800\`
-// tw\`border-y-red-900\`
-// tw\`border-y-orange-50\`
-// tw\`border-y-orange-100\`
-// tw\`border-y-orange-200\`
-// tw\`border-y-orange-300\`
-// tw\`border-y-orange-400\`
-// tw\`border-y-orange-500\`
-// tw\`border-y-orange-600\`
-// tw\`border-y-orange-700\`
-// tw\`border-y-orange-800\`
-// tw\`border-y-orange-900\`
-// tw\`border-y-amber-50\`
-// tw\`border-y-amber-100\`
-// tw\`border-y-amber-200\`
-// tw\`border-y-amber-300\`
-// tw\`border-y-amber-400\`
-// tw\`border-y-amber-500\`
-// tw\`border-y-amber-600\`
-// tw\`border-y-amber-700\`
-// tw\`border-y-amber-800\`
-// tw\`border-y-amber-900\`
-// tw\`border-y-yellow-50\`
-// tw\`border-y-yellow-100\`
-// tw\`border-y-yellow-200\`
-// tw\`border-y-yellow-300\`
-// tw\`border-y-yellow-400\`
-// tw\`border-y-yellow-500\`
-// tw\`border-y-yellow-600\`
-// tw\`border-y-yellow-700\`
-// tw\`border-y-yellow-800\`
-// tw\`border-y-yellow-900\`
-// tw\`border-y-lime-50\`
-// tw\`border-y-lime-100\`
-// tw\`border-y-lime-200\`
-// tw\`border-y-lime-300\`
-// tw\`border-y-lime-400\`
-// tw\`border-y-lime-500\`
-// tw\`border-y-lime-600\`
-// tw\`border-y-lime-700\`
-// tw\`border-y-lime-800\`
-// tw\`border-y-lime-900\`
-// tw\`border-y-green-50\`
-// tw\`border-y-green-100\`
-// tw\`border-y-green-200\`
-// tw\`border-y-green-300\`
-// tw\`border-y-green-400\`
-// tw\`border-y-green-500\`
-// tw\`border-y-green-600\`
-// tw\`border-y-green-700\`
-// tw\`border-y-green-800\`
-// tw\`border-y-green-900\`
-// tw\`border-y-emerald-50\`
-// tw\`border-y-emerald-100\`
-// tw\`border-y-emerald-200\`
-// tw\`border-y-emerald-300\`
-// tw\`border-y-emerald-400\`
-// tw\`border-y-emerald-500\`
-// tw\`border-y-emerald-600\`
-// tw\`border-y-emerald-700\`
-// tw\`border-y-emerald-800\`
-// tw\`border-y-emerald-900\`
-// tw\`border-y-teal-50\`
-// tw\`border-y-teal-100\`
-// tw\`border-y-teal-200\`
-// tw\`border-y-teal-300\`
-// tw\`border-y-teal-400\`
-// tw\`border-y-teal-500\`
-// tw\`border-y-teal-600\`
-// tw\`border-y-teal-700\`
-// tw\`border-y-teal-800\`
-// tw\`border-y-teal-900\`
-// tw\`border-y-cyan-50\`
-// tw\`border-y-cyan-100\`
-// tw\`border-y-cyan-200\`
-// tw\`border-y-cyan-300\`
-// tw\`border-y-cyan-400\`
-// tw\`border-y-cyan-500\`
-// tw\`border-y-cyan-600\`
-// tw\`border-y-cyan-700\`
-// tw\`border-y-cyan-800\`
-// tw\`border-y-cyan-900\`
-// tw\`border-y-sky-50\`
-// tw\`border-y-sky-100\`
-// tw\`border-y-sky-200\`
-// tw\`border-y-sky-300\`
-// tw\`border-y-sky-400\`
-// tw\`border-y-sky-500\`
-// tw\`border-y-sky-600\`
-// tw\`border-y-sky-700\`
-// tw\`border-y-sky-800\`
-// tw\`border-y-sky-900\`
-// tw\`border-y-blue-50\`
-// tw\`border-y-blue-100\`
-// tw\`border-y-blue-200\`
-// tw\`border-y-blue-300\`
-// tw\`border-y-blue-400\`
-// tw\`border-y-blue-500\`
-// tw\`border-y-blue-600\`
-// tw\`border-y-blue-700\`
-// tw\`border-y-blue-800\`
-// tw\`border-y-blue-900\`
-// tw\`border-y-indigo-50\`
-// tw\`border-y-indigo-100\`
-// tw\`border-y-indigo-200\`
-// tw\`border-y-indigo-300\`
-// tw\`border-y-indigo-400\`
-// tw\`border-y-indigo-500\`
-// tw\`border-y-indigo-600\`
-// tw\`border-y-indigo-700\`
-// tw\`border-y-indigo-800\`
-// tw\`border-y-indigo-900\`
-// tw\`border-y-violet-50\`
-// tw\`border-y-violet-100\`
-// tw\`border-y-violet-200\`
-// tw\`border-y-violet-300\`
-// tw\`border-y-violet-400\`
-// tw\`border-y-violet-500\`
-// tw\`border-y-violet-600\`
-// tw\`border-y-violet-700\`
-// tw\`border-y-violet-800\`
-// tw\`border-y-violet-900\`
-// tw\`border-y-purple-50\`
-// tw\`border-y-purple-100\`
-// tw\`border-y-purple-200\`
-// tw\`border-y-purple-300\`
-// tw\`border-y-purple-400\`
-// tw\`border-y-purple-500\`
-// tw\`border-y-purple-600\`
-// tw\`border-y-purple-700\`
-// tw\`border-y-purple-800\`
-// tw\`border-y-purple-900\`
-// tw\`border-y-fuchsia-50\`
-// tw\`border-y-fuchsia-100\`
-// tw\`border-y-fuchsia-200\`
-// tw\`border-y-fuchsia-300\`
-// tw\`border-y-fuchsia-400\`
-// tw\`border-y-fuchsia-500\`
-// tw\`border-y-fuchsia-600\`
-// tw\`border-y-fuchsia-700\`
-// tw\`border-y-fuchsia-800\`
-// tw\`border-y-fuchsia-900\`
-// tw\`border-y-pink-50\`
-// tw\`border-y-pink-100\`
-// tw\`border-y-pink-200\`
-// tw\`border-y-pink-300\`
-// tw\`border-y-pink-400\`
-// tw\`border-y-pink-500\`
-// tw\`border-y-pink-600\`
-// tw\`border-y-pink-700\`
-// tw\`border-y-pink-800\`
-// tw\`border-y-pink-900\`
-// tw\`border-y-rose-50\`
-// tw\`border-y-rose-100\`
-// tw\`border-y-rose-200\`
-// tw\`border-y-rose-300\`
-// tw\`border-y-rose-400\`
-// tw\`border-y-rose-500\`
-// tw\`border-y-rose-600\`
-// tw\`border-y-rose-700\`
-// tw\`border-y-rose-800\`
-// tw\`border-y-rose-900\`
+tw\`border-x-inherit\`
+tw\`border-x-current\`
+tw\`border-x-transparent\`
+tw\`border-x-black\`
+tw\`border-x-white\`
+tw\`border-x-slate-50\`
+tw\`border-x-slate-100\`
+tw\`border-x-slate-200\`
+tw\`border-x-slate-300\`
+tw\`border-x-slate-400\`
+tw\`border-x-slate-500\`
+tw\`border-x-slate-600\`
+tw\`border-x-slate-700\`
+tw\`border-x-slate-800\`
+tw\`border-x-slate-900\`
+tw\`border-x-gray-50\`
+tw\`border-x-gray-100\`
+tw\`border-x-gray-200\`
+tw\`border-x-gray-300\`
+tw\`border-x-gray-400\`
+tw\`border-x-gray-500\`
+tw\`border-x-gray-600\`
+tw\`border-x-gray-700\`
+tw\`border-x-gray-800\`
+tw\`border-x-gray-900\`
+tw\`border-x-zinc-50\`
+tw\`border-x-zinc-100\`
+tw\`border-x-zinc-200\`
+tw\`border-x-zinc-300\`
+tw\`border-x-zinc-400\`
+tw\`border-x-zinc-500\`
+tw\`border-x-zinc-600\`
+tw\`border-x-zinc-700\`
+tw\`border-x-zinc-800\`
+tw\`border-x-zinc-900\`
+tw\`border-x-neutral-50\`
+tw\`border-x-neutral-100\`
+tw\`border-x-neutral-200\`
+tw\`border-x-neutral-300\`
+tw\`border-x-neutral-400\`
+tw\`border-x-neutral-500\`
+tw\`border-x-neutral-600\`
+tw\`border-x-neutral-700\`
+tw\`border-x-neutral-800\`
+tw\`border-x-neutral-900\`
+tw\`border-x-stone-50\`
+tw\`border-x-stone-100\`
+tw\`border-x-stone-200\`
+tw\`border-x-stone-300\`
+tw\`border-x-stone-400\`
+tw\`border-x-stone-500\`
+tw\`border-x-stone-600\`
+tw\`border-x-stone-700\`
+tw\`border-x-stone-800\`
+tw\`border-x-stone-900\`
+tw\`border-x-red-50\`
+tw\`border-x-red-100\`
+tw\`border-x-red-200\`
+tw\`border-x-red-300\`
+tw\`border-x-red-400\`
+tw\`border-x-red-500\`
+tw\`border-x-red-600\`
+tw\`border-x-red-700\`
+tw\`border-x-red-800\`
+tw\`border-x-red-900\`
+tw\`border-x-orange-50\`
+tw\`border-x-orange-100\`
+tw\`border-x-orange-200\`
+tw\`border-x-orange-300\`
+tw\`border-x-orange-400\`
+tw\`border-x-orange-500\`
+tw\`border-x-orange-600\`
+tw\`border-x-orange-700\`
+tw\`border-x-orange-800\`
+tw\`border-x-orange-900\`
+tw\`border-x-amber-50\`
+tw\`border-x-amber-100\`
+tw\`border-x-amber-200\`
+tw\`border-x-amber-300\`
+tw\`border-x-amber-400\`
+tw\`border-x-amber-500\`
+tw\`border-x-amber-600\`
+tw\`border-x-amber-700\`
+tw\`border-x-amber-800\`
+tw\`border-x-amber-900\`
+tw\`border-x-yellow-50\`
+tw\`border-x-yellow-100\`
+tw\`border-x-yellow-200\`
+tw\`border-x-yellow-300\`
+tw\`border-x-yellow-400\`
+tw\`border-x-yellow-500\`
+tw\`border-x-yellow-600\`
+tw\`border-x-yellow-700\`
+tw\`border-x-yellow-800\`
+tw\`border-x-yellow-900\`
+tw\`border-x-lime-50\`
+tw\`border-x-lime-100\`
+tw\`border-x-lime-200\`
+tw\`border-x-lime-300\`
+tw\`border-x-lime-400\`
+tw\`border-x-lime-500\`
+tw\`border-x-lime-600\`
+tw\`border-x-lime-700\`
+tw\`border-x-lime-800\`
+tw\`border-x-lime-900\`
+tw\`border-x-green-50\`
+tw\`border-x-green-100\`
+tw\`border-x-green-200\`
+tw\`border-x-green-300\`
+tw\`border-x-green-400\`
+tw\`border-x-green-500\`
+tw\`border-x-green-600\`
+tw\`border-x-green-700\`
+tw\`border-x-green-800\`
+tw\`border-x-green-900\`
+tw\`border-x-emerald-50\`
+tw\`border-x-emerald-100\`
+tw\`border-x-emerald-200\`
+tw\`border-x-emerald-300\`
+tw\`border-x-emerald-400\`
+tw\`border-x-emerald-500\`
+tw\`border-x-emerald-600\`
+tw\`border-x-emerald-700\`
+tw\`border-x-emerald-800\`
+tw\`border-x-emerald-900\`
+tw\`border-x-teal-50\`
+tw\`border-x-teal-100\`
+tw\`border-x-teal-200\`
+tw\`border-x-teal-300\`
+tw\`border-x-teal-400\`
+tw\`border-x-teal-500\`
+tw\`border-x-teal-600\`
+tw\`border-x-teal-700\`
+tw\`border-x-teal-800\`
+tw\`border-x-teal-900\`
+tw\`border-x-cyan-50\`
+tw\`border-x-cyan-100\`
+tw\`border-x-cyan-200\`
+tw\`border-x-cyan-300\`
+tw\`border-x-cyan-400\`
+tw\`border-x-cyan-500\`
+tw\`border-x-cyan-600\`
+tw\`border-x-cyan-700\`
+tw\`border-x-cyan-800\`
+tw\`border-x-cyan-900\`
+tw\`border-x-sky-50\`
+tw\`border-x-sky-100\`
+tw\`border-x-sky-200\`
+tw\`border-x-sky-300\`
+tw\`border-x-sky-400\`
+tw\`border-x-sky-500\`
+tw\`border-x-sky-600\`
+tw\`border-x-sky-700\`
+tw\`border-x-sky-800\`
+tw\`border-x-sky-900\`
+tw\`border-x-blue-50\`
+tw\`border-x-blue-100\`
+tw\`border-x-blue-200\`
+tw\`border-x-blue-300\`
+tw\`border-x-blue-400\`
+tw\`border-x-blue-500\`
+tw\`border-x-blue-600\`
+tw\`border-x-blue-700\`
+tw\`border-x-blue-800\`
+tw\`border-x-blue-900\`
+tw\`border-x-indigo-50\`
+tw\`border-x-indigo-100\`
+tw\`border-x-indigo-200\`
+tw\`border-x-indigo-300\`
+tw\`border-x-indigo-400\`
+tw\`border-x-indigo-500\`
+tw\`border-x-indigo-600\`
+tw\`border-x-indigo-700\`
+tw\`border-x-indigo-800\`
+tw\`border-x-indigo-900\`
+tw\`border-x-violet-50\`
+tw\`border-x-violet-100\`
+tw\`border-x-violet-200\`
+tw\`border-x-violet-300\`
+tw\`border-x-violet-400\`
+tw\`border-x-violet-500\`
+tw\`border-x-violet-600\`
+tw\`border-x-violet-700\`
+tw\`border-x-violet-800\`
+tw\`border-x-violet-900\`
+tw\`border-x-purple-50\`
+tw\`border-x-purple-100\`
+tw\`border-x-purple-200\`
+tw\`border-x-purple-300\`
+tw\`border-x-purple-400\`
+tw\`border-x-purple-500\`
+tw\`border-x-purple-600\`
+tw\`border-x-purple-700\`
+tw\`border-x-purple-800\`
+tw\`border-x-purple-900\`
+tw\`border-x-fuchsia-50\`
+tw\`border-x-fuchsia-100\`
+tw\`border-x-fuchsia-200\`
+tw\`border-x-fuchsia-300\`
+tw\`border-x-fuchsia-400\`
+tw\`border-x-fuchsia-500\`
+tw\`border-x-fuchsia-600\`
+tw\`border-x-fuchsia-700\`
+tw\`border-x-fuchsia-800\`
+tw\`border-x-fuchsia-900\`
+tw\`border-x-pink-50\`
+tw\`border-x-pink-100\`
+tw\`border-x-pink-200\`
+tw\`border-x-pink-300\`
+tw\`border-x-pink-400\`
+tw\`border-x-pink-500\`
+tw\`border-x-pink-600\`
+tw\`border-x-pink-700\`
+tw\`border-x-pink-800\`
+tw\`border-x-pink-900\`
+tw\`border-x-rose-50\`
+tw\`border-x-rose-100\`
+tw\`border-x-rose-200\`
+tw\`border-x-rose-300\`
+tw\`border-x-rose-400\`
+tw\`border-x-rose-500\`
+tw\`border-x-rose-600\`
+tw\`border-x-rose-700\`
+tw\`border-x-rose-800\`
+tw\`border-x-rose-900\`
+tw\`border-y-inherit\`
+tw\`border-y-current\`
+tw\`border-y-transparent\`
+tw\`border-y-black\`
+tw\`border-y-white\`
+tw\`border-y-slate-50\`
+tw\`border-y-slate-100\`
+tw\`border-y-slate-200\`
+tw\`border-y-slate-300\`
+tw\`border-y-slate-400\`
+tw\`border-y-slate-500\`
+tw\`border-y-slate-600\`
+tw\`border-y-slate-700\`
+tw\`border-y-slate-800\`
+tw\`border-y-slate-900\`
+tw\`border-y-gray-50\`
+tw\`border-y-gray-100\`
+tw\`border-y-gray-200\`
+tw\`border-y-gray-300\`
+tw\`border-y-gray-400\`
+tw\`border-y-gray-500\`
+tw\`border-y-gray-600\`
+tw\`border-y-gray-700\`
+tw\`border-y-gray-800\`
+tw\`border-y-gray-900\`
+tw\`border-y-zinc-50\`
+tw\`border-y-zinc-100\`
+tw\`border-y-zinc-200\`
+tw\`border-y-zinc-300\`
+tw\`border-y-zinc-400\`
+tw\`border-y-zinc-500\`
+tw\`border-y-zinc-600\`
+tw\`border-y-zinc-700\`
+tw\`border-y-zinc-800\`
+tw\`border-y-zinc-900\`
+tw\`border-y-neutral-50\`
+tw\`border-y-neutral-100\`
+tw\`border-y-neutral-200\`
+tw\`border-y-neutral-300\`
+tw\`border-y-neutral-400\`
+tw\`border-y-neutral-500\`
+tw\`border-y-neutral-600\`
+tw\`border-y-neutral-700\`
+tw\`border-y-neutral-800\`
+tw\`border-y-neutral-900\`
+tw\`border-y-stone-50\`
+tw\`border-y-stone-100\`
+tw\`border-y-stone-200\`
+tw\`border-y-stone-300\`
+tw\`border-y-stone-400\`
+tw\`border-y-stone-500\`
+tw\`border-y-stone-600\`
+tw\`border-y-stone-700\`
+tw\`border-y-stone-800\`
+tw\`border-y-stone-900\`
+tw\`border-y-red-50\`
+tw\`border-y-red-100\`
+tw\`border-y-red-200\`
+tw\`border-y-red-300\`
+tw\`border-y-red-400\`
+tw\`border-y-red-500\`
+tw\`border-y-red-600\`
+tw\`border-y-red-700\`
+tw\`border-y-red-800\`
+tw\`border-y-red-900\`
+tw\`border-y-orange-50\`
+tw\`border-y-orange-100\`
+tw\`border-y-orange-200\`
+tw\`border-y-orange-300\`
+tw\`border-y-orange-400\`
+tw\`border-y-orange-500\`
+tw\`border-y-orange-600\`
+tw\`border-y-orange-700\`
+tw\`border-y-orange-800\`
+tw\`border-y-orange-900\`
+tw\`border-y-amber-50\`
+tw\`border-y-amber-100\`
+tw\`border-y-amber-200\`
+tw\`border-y-amber-300\`
+tw\`border-y-amber-400\`
+tw\`border-y-amber-500\`
+tw\`border-y-amber-600\`
+tw\`border-y-amber-700\`
+tw\`border-y-amber-800\`
+tw\`border-y-amber-900\`
+tw\`border-y-yellow-50\`
+tw\`border-y-yellow-100\`
+tw\`border-y-yellow-200\`
+tw\`border-y-yellow-300\`
+tw\`border-y-yellow-400\`
+tw\`border-y-yellow-500\`
+tw\`border-y-yellow-600\`
+tw\`border-y-yellow-700\`
+tw\`border-y-yellow-800\`
+tw\`border-y-yellow-900\`
+tw\`border-y-lime-50\`
+tw\`border-y-lime-100\`
+tw\`border-y-lime-200\`
+tw\`border-y-lime-300\`
+tw\`border-y-lime-400\`
+tw\`border-y-lime-500\`
+tw\`border-y-lime-600\`
+tw\`border-y-lime-700\`
+tw\`border-y-lime-800\`
+tw\`border-y-lime-900\`
+tw\`border-y-green-50\`
+tw\`border-y-green-100\`
+tw\`border-y-green-200\`
+tw\`border-y-green-300\`
+tw\`border-y-green-400\`
+tw\`border-y-green-500\`
+tw\`border-y-green-600\`
+tw\`border-y-green-700\`
+tw\`border-y-green-800\`
+tw\`border-y-green-900\`
+tw\`border-y-emerald-50\`
+tw\`border-y-emerald-100\`
+tw\`border-y-emerald-200\`
+tw\`border-y-emerald-300\`
+tw\`border-y-emerald-400\`
+tw\`border-y-emerald-500\`
+tw\`border-y-emerald-600\`
+tw\`border-y-emerald-700\`
+tw\`border-y-emerald-800\`
+tw\`border-y-emerald-900\`
+tw\`border-y-teal-50\`
+tw\`border-y-teal-100\`
+tw\`border-y-teal-200\`
+tw\`border-y-teal-300\`
+tw\`border-y-teal-400\`
+tw\`border-y-teal-500\`
+tw\`border-y-teal-600\`
+tw\`border-y-teal-700\`
+tw\`border-y-teal-800\`
+tw\`border-y-teal-900\`
+tw\`border-y-cyan-50\`
+tw\`border-y-cyan-100\`
+tw\`border-y-cyan-200\`
+tw\`border-y-cyan-300\`
+tw\`border-y-cyan-400\`
+tw\`border-y-cyan-500\`
+tw\`border-y-cyan-600\`
+tw\`border-y-cyan-700\`
+tw\`border-y-cyan-800\`
+tw\`border-y-cyan-900\`
+tw\`border-y-sky-50\`
+tw\`border-y-sky-100\`
+tw\`border-y-sky-200\`
+tw\`border-y-sky-300\`
+tw\`border-y-sky-400\`
+tw\`border-y-sky-500\`
+tw\`border-y-sky-600\`
+tw\`border-y-sky-700\`
+tw\`border-y-sky-800\`
+tw\`border-y-sky-900\`
+tw\`border-y-blue-50\`
+tw\`border-y-blue-100\`
+tw\`border-y-blue-200\`
+tw\`border-y-blue-300\`
+tw\`border-y-blue-400\`
+tw\`border-y-blue-500\`
+tw\`border-y-blue-600\`
+tw\`border-y-blue-700\`
+tw\`border-y-blue-800\`
+tw\`border-y-blue-900\`
+tw\`border-y-indigo-50\`
+tw\`border-y-indigo-100\`
+tw\`border-y-indigo-200\`
+tw\`border-y-indigo-300\`
+tw\`border-y-indigo-400\`
+tw\`border-y-indigo-500\`
+tw\`border-y-indigo-600\`
+tw\`border-y-indigo-700\`
+tw\`border-y-indigo-800\`
+tw\`border-y-indigo-900\`
+tw\`border-y-violet-50\`
+tw\`border-y-violet-100\`
+tw\`border-y-violet-200\`
+tw\`border-y-violet-300\`
+tw\`border-y-violet-400\`
+tw\`border-y-violet-500\`
+tw\`border-y-violet-600\`
+tw\`border-y-violet-700\`
+tw\`border-y-violet-800\`
+tw\`border-y-violet-900\`
+tw\`border-y-purple-50\`
+tw\`border-y-purple-100\`
+tw\`border-y-purple-200\`
+tw\`border-y-purple-300\`
+tw\`border-y-purple-400\`
+tw\`border-y-purple-500\`
+tw\`border-y-purple-600\`
+tw\`border-y-purple-700\`
+tw\`border-y-purple-800\`
+tw\`border-y-purple-900\`
+tw\`border-y-fuchsia-50\`
+tw\`border-y-fuchsia-100\`
+tw\`border-y-fuchsia-200\`
+tw\`border-y-fuchsia-300\`
+tw\`border-y-fuchsia-400\`
+tw\`border-y-fuchsia-500\`
+tw\`border-y-fuchsia-600\`
+tw\`border-y-fuchsia-700\`
+tw\`border-y-fuchsia-800\`
+tw\`border-y-fuchsia-900\`
+tw\`border-y-pink-50\`
+tw\`border-y-pink-100\`
+tw\`border-y-pink-200\`
+tw\`border-y-pink-300\`
+tw\`border-y-pink-400\`
+tw\`border-y-pink-500\`
+tw\`border-y-pink-600\`
+tw\`border-y-pink-700\`
+tw\`border-y-pink-800\`
+tw\`border-y-pink-900\`
+tw\`border-y-rose-50\`
+tw\`border-y-rose-100\`
+tw\`border-y-rose-200\`
+tw\`border-y-rose-300\`
+tw\`border-y-rose-400\`
+tw\`border-y-rose-500\`
+tw\`border-y-rose-600\`
+tw\`border-y-rose-700\`
+tw\`border-y-rose-800\`
+tw\`border-y-rose-900\`
 tw\`border-t-inherit\`
 tw\`border-t-current\`
 tw\`border-t-transparent\`
@@ -9853,457 +9853,2251 @@ tw\`border-[theme('colors.electric')]/20\`
 ;({
   '--tw-border-opacity': '1',
   borderColor: 'rgb(136 19 55 / var(--tw-border-opacity))',
-}) // tw\`border-x-inherit\`
-// tw\`border-x-current\`
-// tw\`border-x-transparent\`
-// tw\`border-x-black\`
-// tw\`border-x-white\`
-// tw\`border-x-slate-50\`
-// tw\`border-x-slate-100\`
-// tw\`border-x-slate-200\`
-// tw\`border-x-slate-300\`
-// tw\`border-x-slate-400\`
-// tw\`border-x-slate-500\`
-// tw\`border-x-slate-600\`
-// tw\`border-x-slate-700\`
-// tw\`border-x-slate-800\`
-// tw\`border-x-slate-900\`
-// tw\`border-x-gray-50\`
-// tw\`border-x-gray-100\`
-// tw\`border-x-gray-200\`
-// tw\`border-x-gray-300\`
-// tw\`border-x-gray-400\`
-// tw\`border-x-gray-500\`
-// tw\`border-x-gray-600\`
-// tw\`border-x-gray-700\`
-// tw\`border-x-gray-800\`
-// tw\`border-x-gray-900\`
-// tw\`border-x-zinc-50\`
-// tw\`border-x-zinc-100\`
-// tw\`border-x-zinc-200\`
-// tw\`border-x-zinc-300\`
-// tw\`border-x-zinc-400\`
-// tw\`border-x-zinc-500\`
-// tw\`border-x-zinc-600\`
-// tw\`border-x-zinc-700\`
-// tw\`border-x-zinc-800\`
-// tw\`border-x-zinc-900\`
-// tw\`border-x-neutral-50\`
-// tw\`border-x-neutral-100\`
-// tw\`border-x-neutral-200\`
-// tw\`border-x-neutral-300\`
-// tw\`border-x-neutral-400\`
-// tw\`border-x-neutral-500\`
-// tw\`border-x-neutral-600\`
-// tw\`border-x-neutral-700\`
-// tw\`border-x-neutral-800\`
-// tw\`border-x-neutral-900\`
-// tw\`border-x-stone-50\`
-// tw\`border-x-stone-100\`
-// tw\`border-x-stone-200\`
-// tw\`border-x-stone-300\`
-// tw\`border-x-stone-400\`
-// tw\`border-x-stone-500\`
-// tw\`border-x-stone-600\`
-// tw\`border-x-stone-700\`
-// tw\`border-x-stone-800\`
-// tw\`border-x-stone-900\`
-// tw\`border-x-red-50\`
-// tw\`border-x-red-100\`
-// tw\`border-x-red-200\`
-// tw\`border-x-red-300\`
-// tw\`border-x-red-400\`
-// tw\`border-x-red-500\`
-// tw\`border-x-red-600\`
-// tw\`border-x-red-700\`
-// tw\`border-x-red-800\`
-// tw\`border-x-red-900\`
-// tw\`border-x-orange-50\`
-// tw\`border-x-orange-100\`
-// tw\`border-x-orange-200\`
-// tw\`border-x-orange-300\`
-// tw\`border-x-orange-400\`
-// tw\`border-x-orange-500\`
-// tw\`border-x-orange-600\`
-// tw\`border-x-orange-700\`
-// tw\`border-x-orange-800\`
-// tw\`border-x-orange-900\`
-// tw\`border-x-amber-50\`
-// tw\`border-x-amber-100\`
-// tw\`border-x-amber-200\`
-// tw\`border-x-amber-300\`
-// tw\`border-x-amber-400\`
-// tw\`border-x-amber-500\`
-// tw\`border-x-amber-600\`
-// tw\`border-x-amber-700\`
-// tw\`border-x-amber-800\`
-// tw\`border-x-amber-900\`
-// tw\`border-x-yellow-50\`
-// tw\`border-x-yellow-100\`
-// tw\`border-x-yellow-200\`
-// tw\`border-x-yellow-300\`
-// tw\`border-x-yellow-400\`
-// tw\`border-x-yellow-500\`
-// tw\`border-x-yellow-600\`
-// tw\`border-x-yellow-700\`
-// tw\`border-x-yellow-800\`
-// tw\`border-x-yellow-900\`
-// tw\`border-x-lime-50\`
-// tw\`border-x-lime-100\`
-// tw\`border-x-lime-200\`
-// tw\`border-x-lime-300\`
-// tw\`border-x-lime-400\`
-// tw\`border-x-lime-500\`
-// tw\`border-x-lime-600\`
-// tw\`border-x-lime-700\`
-// tw\`border-x-lime-800\`
-// tw\`border-x-lime-900\`
-// tw\`border-x-green-50\`
-// tw\`border-x-green-100\`
-// tw\`border-x-green-200\`
-// tw\`border-x-green-300\`
-// tw\`border-x-green-400\`
-// tw\`border-x-green-500\`
-// tw\`border-x-green-600\`
-// tw\`border-x-green-700\`
-// tw\`border-x-green-800\`
-// tw\`border-x-green-900\`
-// tw\`border-x-emerald-50\`
-// tw\`border-x-emerald-100\`
-// tw\`border-x-emerald-200\`
-// tw\`border-x-emerald-300\`
-// tw\`border-x-emerald-400\`
-// tw\`border-x-emerald-500\`
-// tw\`border-x-emerald-600\`
-// tw\`border-x-emerald-700\`
-// tw\`border-x-emerald-800\`
-// tw\`border-x-emerald-900\`
-// tw\`border-x-teal-50\`
-// tw\`border-x-teal-100\`
-// tw\`border-x-teal-200\`
-// tw\`border-x-teal-300\`
-// tw\`border-x-teal-400\`
-// tw\`border-x-teal-500\`
-// tw\`border-x-teal-600\`
-// tw\`border-x-teal-700\`
-// tw\`border-x-teal-800\`
-// tw\`border-x-teal-900\`
-// tw\`border-x-cyan-50\`
-// tw\`border-x-cyan-100\`
-// tw\`border-x-cyan-200\`
-// tw\`border-x-cyan-300\`
-// tw\`border-x-cyan-400\`
-// tw\`border-x-cyan-500\`
-// tw\`border-x-cyan-600\`
-// tw\`border-x-cyan-700\`
-// tw\`border-x-cyan-800\`
-// tw\`border-x-cyan-900\`
-// tw\`border-x-sky-50\`
-// tw\`border-x-sky-100\`
-// tw\`border-x-sky-200\`
-// tw\`border-x-sky-300\`
-// tw\`border-x-sky-400\`
-// tw\`border-x-sky-500\`
-// tw\`border-x-sky-600\`
-// tw\`border-x-sky-700\`
-// tw\`border-x-sky-800\`
-// tw\`border-x-sky-900\`
-// tw\`border-x-blue-50\`
-// tw\`border-x-blue-100\`
-// tw\`border-x-blue-200\`
-// tw\`border-x-blue-300\`
-// tw\`border-x-blue-400\`
-// tw\`border-x-blue-500\`
-// tw\`border-x-blue-600\`
-// tw\`border-x-blue-700\`
-// tw\`border-x-blue-800\`
-// tw\`border-x-blue-900\`
-// tw\`border-x-indigo-50\`
-// tw\`border-x-indigo-100\`
-// tw\`border-x-indigo-200\`
-// tw\`border-x-indigo-300\`
-// tw\`border-x-indigo-400\`
-// tw\`border-x-indigo-500\`
-// tw\`border-x-indigo-600\`
-// tw\`border-x-indigo-700\`
-// tw\`border-x-indigo-800\`
-// tw\`border-x-indigo-900\`
-// tw\`border-x-violet-50\`
-// tw\`border-x-violet-100\`
-// tw\`border-x-violet-200\`
-// tw\`border-x-violet-300\`
-// tw\`border-x-violet-400\`
-// tw\`border-x-violet-500\`
-// tw\`border-x-violet-600\`
-// tw\`border-x-violet-700\`
-// tw\`border-x-violet-800\`
-// tw\`border-x-violet-900\`
-// tw\`border-x-purple-50\`
-// tw\`border-x-purple-100\`
-// tw\`border-x-purple-200\`
-// tw\`border-x-purple-300\`
-// tw\`border-x-purple-400\`
-// tw\`border-x-purple-500\`
-// tw\`border-x-purple-600\`
-// tw\`border-x-purple-700\`
-// tw\`border-x-purple-800\`
-// tw\`border-x-purple-900\`
-// tw\`border-x-fuchsia-50\`
-// tw\`border-x-fuchsia-100\`
-// tw\`border-x-fuchsia-200\`
-// tw\`border-x-fuchsia-300\`
-// tw\`border-x-fuchsia-400\`
-// tw\`border-x-fuchsia-500\`
-// tw\`border-x-fuchsia-600\`
-// tw\`border-x-fuchsia-700\`
-// tw\`border-x-fuchsia-800\`
-// tw\`border-x-fuchsia-900\`
-// tw\`border-x-pink-50\`
-// tw\`border-x-pink-100\`
-// tw\`border-x-pink-200\`
-// tw\`border-x-pink-300\`
-// tw\`border-x-pink-400\`
-// tw\`border-x-pink-500\`
-// tw\`border-x-pink-600\`
-// tw\`border-x-pink-700\`
-// tw\`border-x-pink-800\`
-// tw\`border-x-pink-900\`
-// tw\`border-x-rose-50\`
-// tw\`border-x-rose-100\`
-// tw\`border-x-rose-200\`
-// tw\`border-x-rose-300\`
-// tw\`border-x-rose-400\`
-// tw\`border-x-rose-500\`
-// tw\`border-x-rose-600\`
-// tw\`border-x-rose-700\`
-// tw\`border-x-rose-800\`
-// tw\`border-x-rose-900\`
-// tw\`border-y-inherit\`
-// tw\`border-y-current\`
-// tw\`border-y-transparent\`
-// tw\`border-y-black\`
-// tw\`border-y-white\`
-// tw\`border-y-slate-50\`
-// tw\`border-y-slate-100\`
-// tw\`border-y-slate-200\`
-// tw\`border-y-slate-300\`
-// tw\`border-y-slate-400\`
-// tw\`border-y-slate-500\`
-// tw\`border-y-slate-600\`
-// tw\`border-y-slate-700\`
-// tw\`border-y-slate-800\`
-// tw\`border-y-slate-900\`
-// tw\`border-y-gray-50\`
-// tw\`border-y-gray-100\`
-// tw\`border-y-gray-200\`
-// tw\`border-y-gray-300\`
-// tw\`border-y-gray-400\`
-// tw\`border-y-gray-500\`
-// tw\`border-y-gray-600\`
-// tw\`border-y-gray-700\`
-// tw\`border-y-gray-800\`
-// tw\`border-y-gray-900\`
-// tw\`border-y-zinc-50\`
-// tw\`border-y-zinc-100\`
-// tw\`border-y-zinc-200\`
-// tw\`border-y-zinc-300\`
-// tw\`border-y-zinc-400\`
-// tw\`border-y-zinc-500\`
-// tw\`border-y-zinc-600\`
-// tw\`border-y-zinc-700\`
-// tw\`border-y-zinc-800\`
-// tw\`border-y-zinc-900\`
-// tw\`border-y-neutral-50\`
-// tw\`border-y-neutral-100\`
-// tw\`border-y-neutral-200\`
-// tw\`border-y-neutral-300\`
-// tw\`border-y-neutral-400\`
-// tw\`border-y-neutral-500\`
-// tw\`border-y-neutral-600\`
-// tw\`border-y-neutral-700\`
-// tw\`border-y-neutral-800\`
-// tw\`border-y-neutral-900\`
-// tw\`border-y-stone-50\`
-// tw\`border-y-stone-100\`
-// tw\`border-y-stone-200\`
-// tw\`border-y-stone-300\`
-// tw\`border-y-stone-400\`
-// tw\`border-y-stone-500\`
-// tw\`border-y-stone-600\`
-// tw\`border-y-stone-700\`
-// tw\`border-y-stone-800\`
-// tw\`border-y-stone-900\`
-// tw\`border-y-red-50\`
-// tw\`border-y-red-100\`
-// tw\`border-y-red-200\`
-// tw\`border-y-red-300\`
-// tw\`border-y-red-400\`
-// tw\`border-y-red-500\`
-// tw\`border-y-red-600\`
-// tw\`border-y-red-700\`
-// tw\`border-y-red-800\`
-// tw\`border-y-red-900\`
-// tw\`border-y-orange-50\`
-// tw\`border-y-orange-100\`
-// tw\`border-y-orange-200\`
-// tw\`border-y-orange-300\`
-// tw\`border-y-orange-400\`
-// tw\`border-y-orange-500\`
-// tw\`border-y-orange-600\`
-// tw\`border-y-orange-700\`
-// tw\`border-y-orange-800\`
-// tw\`border-y-orange-900\`
-// tw\`border-y-amber-50\`
-// tw\`border-y-amber-100\`
-// tw\`border-y-amber-200\`
-// tw\`border-y-amber-300\`
-// tw\`border-y-amber-400\`
-// tw\`border-y-amber-500\`
-// tw\`border-y-amber-600\`
-// tw\`border-y-amber-700\`
-// tw\`border-y-amber-800\`
-// tw\`border-y-amber-900\`
-// tw\`border-y-yellow-50\`
-// tw\`border-y-yellow-100\`
-// tw\`border-y-yellow-200\`
-// tw\`border-y-yellow-300\`
-// tw\`border-y-yellow-400\`
-// tw\`border-y-yellow-500\`
-// tw\`border-y-yellow-600\`
-// tw\`border-y-yellow-700\`
-// tw\`border-y-yellow-800\`
-// tw\`border-y-yellow-900\`
-// tw\`border-y-lime-50\`
-// tw\`border-y-lime-100\`
-// tw\`border-y-lime-200\`
-// tw\`border-y-lime-300\`
-// tw\`border-y-lime-400\`
-// tw\`border-y-lime-500\`
-// tw\`border-y-lime-600\`
-// tw\`border-y-lime-700\`
-// tw\`border-y-lime-800\`
-// tw\`border-y-lime-900\`
-// tw\`border-y-green-50\`
-// tw\`border-y-green-100\`
-// tw\`border-y-green-200\`
-// tw\`border-y-green-300\`
-// tw\`border-y-green-400\`
-// tw\`border-y-green-500\`
-// tw\`border-y-green-600\`
-// tw\`border-y-green-700\`
-// tw\`border-y-green-800\`
-// tw\`border-y-green-900\`
-// tw\`border-y-emerald-50\`
-// tw\`border-y-emerald-100\`
-// tw\`border-y-emerald-200\`
-// tw\`border-y-emerald-300\`
-// tw\`border-y-emerald-400\`
-// tw\`border-y-emerald-500\`
-// tw\`border-y-emerald-600\`
-// tw\`border-y-emerald-700\`
-// tw\`border-y-emerald-800\`
-// tw\`border-y-emerald-900\`
-// tw\`border-y-teal-50\`
-// tw\`border-y-teal-100\`
-// tw\`border-y-teal-200\`
-// tw\`border-y-teal-300\`
-// tw\`border-y-teal-400\`
-// tw\`border-y-teal-500\`
-// tw\`border-y-teal-600\`
-// tw\`border-y-teal-700\`
-// tw\`border-y-teal-800\`
-// tw\`border-y-teal-900\`
-// tw\`border-y-cyan-50\`
-// tw\`border-y-cyan-100\`
-// tw\`border-y-cyan-200\`
-// tw\`border-y-cyan-300\`
-// tw\`border-y-cyan-400\`
-// tw\`border-y-cyan-500\`
-// tw\`border-y-cyan-600\`
-// tw\`border-y-cyan-700\`
-// tw\`border-y-cyan-800\`
-// tw\`border-y-cyan-900\`
-// tw\`border-y-sky-50\`
-// tw\`border-y-sky-100\`
-// tw\`border-y-sky-200\`
-// tw\`border-y-sky-300\`
-// tw\`border-y-sky-400\`
-// tw\`border-y-sky-500\`
-// tw\`border-y-sky-600\`
-// tw\`border-y-sky-700\`
-// tw\`border-y-sky-800\`
-// tw\`border-y-sky-900\`
-// tw\`border-y-blue-50\`
-// tw\`border-y-blue-100\`
-// tw\`border-y-blue-200\`
-// tw\`border-y-blue-300\`
-// tw\`border-y-blue-400\`
-// tw\`border-y-blue-500\`
-// tw\`border-y-blue-600\`
-// tw\`border-y-blue-700\`
-// tw\`border-y-blue-800\`
-// tw\`border-y-blue-900\`
-// tw\`border-y-indigo-50\`
-// tw\`border-y-indigo-100\`
-// tw\`border-y-indigo-200\`
-// tw\`border-y-indigo-300\`
-// tw\`border-y-indigo-400\`
-// tw\`border-y-indigo-500\`
-// tw\`border-y-indigo-600\`
-// tw\`border-y-indigo-700\`
-// tw\`border-y-indigo-800\`
-// tw\`border-y-indigo-900\`
-// tw\`border-y-violet-50\`
-// tw\`border-y-violet-100\`
-// tw\`border-y-violet-200\`
-// tw\`border-y-violet-300\`
-// tw\`border-y-violet-400\`
-// tw\`border-y-violet-500\`
-// tw\`border-y-violet-600\`
-// tw\`border-y-violet-700\`
-// tw\`border-y-violet-800\`
-// tw\`border-y-violet-900\`
-// tw\`border-y-purple-50\`
-// tw\`border-y-purple-100\`
-// tw\`border-y-purple-200\`
-// tw\`border-y-purple-300\`
-// tw\`border-y-purple-400\`
-// tw\`border-y-purple-500\`
-// tw\`border-y-purple-600\`
-// tw\`border-y-purple-700\`
-// tw\`border-y-purple-800\`
-// tw\`border-y-purple-900\`
-// tw\`border-y-fuchsia-50\`
-// tw\`border-y-fuchsia-100\`
-// tw\`border-y-fuchsia-200\`
-// tw\`border-y-fuchsia-300\`
-// tw\`border-y-fuchsia-400\`
-// tw\`border-y-fuchsia-500\`
-// tw\`border-y-fuchsia-600\`
-// tw\`border-y-fuchsia-700\`
-// tw\`border-y-fuchsia-800\`
-// tw\`border-y-fuchsia-900\`
-// tw\`border-y-pink-50\`
-// tw\`border-y-pink-100\`
-// tw\`border-y-pink-200\`
-// tw\`border-y-pink-300\`
-// tw\`border-y-pink-400\`
-// tw\`border-y-pink-500\`
-// tw\`border-y-pink-600\`
-// tw\`border-y-pink-700\`
-// tw\`border-y-pink-800\`
-// tw\`border-y-pink-900\`
-// tw\`border-y-rose-50\`
-// tw\`border-y-rose-100\`
-// tw\`border-y-rose-200\`
-// tw\`border-y-rose-300\`
-// tw\`border-y-rose-400\`
-// tw\`border-y-rose-500\`
-// tw\`border-y-rose-600\`
-// tw\`border-y-rose-700\`
-// tw\`border-y-rose-800\`
-// tw\`border-y-rose-900\`
-
+})
+;({
+  borderLeftColor: 'inherit',
+  borderRightColor: 'inherit',
+})
+;({
+  borderLeftColor: 'currentColor',
+  borderRightColor: 'currentColor',
+})
+;({
+  borderLeftColor: 'rgb(0 0 0 / 0)',
+  borderRightColor: 'rgb(0 0 0 / 0)',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(0 0 0 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(0 0 0 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 255 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 255 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(248 250 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(248 250 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(241 245 249 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(241 245 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(226 232 240 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(226 232 240 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(203 213 225 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(203 213 225 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(148 163 184 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(148 163 184 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(100 116 139 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(100 116 139 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(71 85 105 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(71 85 105 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(51 65 85 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(51 65 85 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(30 41 59 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(30 41 59 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(15 23 42 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(15 23 42 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(249 250 251 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(249 250 251 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(243 244 246 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(243 244 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(229 231 235 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(229 231 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(209 213 219 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(209 213 219 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(156 163 175 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(156 163 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(107 114 128 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(107 114 128 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(75 85 99 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(75 85 99 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(55 65 81 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(55 65 81 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(31 41 55 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(31 41 55 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(17 24 39 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(17 24 39 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(244 244 245 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(244 244 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(228 228 231 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(228 228 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(212 212 216 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(212 212 216 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(161 161 170 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(161 161 170 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(113 113 122 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(113 113 122 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(82 82 91 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(82 82 91 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(63 63 70 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(63 63 70 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(39 39 42 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(39 39 42 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(24 24 27 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(24 24 27 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(245 245 245 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(245 245 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(229 229 229 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(229 229 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(212 212 212 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(212 212 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(163 163 163 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(163 163 163 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(115 115 115 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(115 115 115 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(82 82 82 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(82 82 82 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(64 64 64 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(64 64 64 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(38 38 38 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(38 38 38 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(23 23 23 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(23 23 23 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 250 249 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 250 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(245 245 244 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(245 245 244 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(231 229 228 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(231 229 228 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(214 211 209 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(214 211 209 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(168 162 158 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(168 162 158 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(120 113 108 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(120 113 108 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(87 83 78 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(87 83 78 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(68 64 60 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(68 64 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(41 37 36 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(41 37 36 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(28 25 23 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(28 25 23 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 242 242 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 242 242 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 226 226 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 226 226 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 202 202 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 202 202 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(252 165 165 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(252 165 165 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(248 113 113 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(248 113 113 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(239 68 68 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(239 68 68 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(220 38 38 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(220 38 38 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(185 28 28 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(185 28 28 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(153 27 27 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(153 27 27 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(127 29 29 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(127 29 29 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 247 237 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 247 237 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 237 213 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 237 213 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 215 170 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 215 170 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 186 116 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 186 116 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(251 146 60 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(251 146 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(249 115 22 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(249 115 22 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(234 88 12 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(234 88 12 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(194 65 12 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(194 65 12 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(154 52 18 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(154 52 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(124 45 18 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(124 45 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 251 235 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 251 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 243 199 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 243 199 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 230 138 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 230 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(252 211 77 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(252 211 77 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(251 191 36 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(251 191 36 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(245 158 11 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(245 158 11 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(217 119 6 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(217 119 6 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(180 83 9 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(180 83 9 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(146 64 14 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(146 64 14 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(120 53 15 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(120 53 15 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 252 232 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 252 232 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 249 195 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 249 195 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 240 138 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 240 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 224 71 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 224 71 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 204 21 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 204 21 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(234 179 8 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(234 179 8 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(202 138 4 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(202 138 4 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(161 98 7 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(161 98 7 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(133 77 14 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(133 77 14 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(113 63 18 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(113 63 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(247 254 231 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(247 254 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(236 252 203 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(236 252 203 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(217 249 157 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(217 249 157 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(190 242 100 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(190 242 100 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(163 230 53 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(163 230 53 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(132 204 22 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(132 204 22 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(101 163 13 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(101 163 13 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(77 124 15 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(77 124 15 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(63 98 18 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(63 98 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(54 83 20 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(54 83 20 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(240 253 244 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(240 253 244 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(220 252 231 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(220 252 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(187 247 208 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(187 247 208 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(134 239 172 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(134 239 172 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(74 222 128 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(74 222 128 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(34 197 94 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(34 197 94 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(22 163 74 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(22 163 74 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(21 128 61 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(21 128 61 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(22 101 52 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(22 101 52 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(20 83 45 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(20 83 45 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(236 253 245 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(236 253 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(209 250 229 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(209 250 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(167 243 208 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(167 243 208 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(110 231 183 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(110 231 183 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(52 211 153 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(52 211 153 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(16 185 129 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(16 185 129 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(5 150 105 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(5 150 105 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(4 120 87 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(4 120 87 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(6 95 70 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(6 95 70 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(6 78 59 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(6 78 59 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(240 253 250 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(240 253 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(204 251 241 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(204 251 241 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(153 246 228 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(153 246 228 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(94 234 212 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(94 234 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(45 212 191 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(45 212 191 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(20 184 166 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(20 184 166 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(13 148 136 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(13 148 136 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(15 118 110 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(15 118 110 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(17 94 89 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(17 94 89 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(19 78 74 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(19 78 74 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(236 254 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(236 254 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(207 250 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(207 250 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(165 243 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(165 243 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(103 232 249 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(103 232 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(34 211 238 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(34 211 238 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(6 182 212 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(6 182 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(8 145 178 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(8 145 178 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(14 116 144 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(14 116 144 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(21 94 117 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(21 94 117 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(22 78 99 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(22 78 99 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(240 249 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(240 249 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(224 242 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(224 242 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(186 230 253 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(186 230 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(125 211 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(125 211 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(56 189 248 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(56 189 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(14 165 233 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(14 165 233 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(2 132 199 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(2 132 199 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(3 105 161 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(3 105 161 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(7 89 133 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(7 89 133 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(12 74 110 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(12 74 110 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(239 246 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(239 246 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(219 234 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(219 234 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(191 219 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(191 219 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(147 197 253 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(147 197 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(96 165 250 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(96 165 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(59 130 246 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(59 130 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(37 99 235 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(37 99 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(29 78 216 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(29 78 216 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(30 64 175 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(30 64 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(30 58 138 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(30 58 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(238 242 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(238 242 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(224 231 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(224 231 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(199 210 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(199 210 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(165 180 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(165 180 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(129 140 248 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(129 140 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(99 102 241 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(99 102 241 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(79 70 229 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(79 70 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(67 56 202 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(67 56 202 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(55 48 163 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(55 48 163 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(49 46 129 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(49 46 129 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(245 243 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(245 243 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(237 233 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(237 233 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(221 214 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(221 214 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(196 181 253 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(196 181 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(167 139 250 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(167 139 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(139 92 246 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(139 92 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(124 58 237 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(124 58 237 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(109 40 217 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(109 40 217 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(91 33 182 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(91 33 182 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(76 29 149 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(76 29 149 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 245 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 245 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(243 232 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(243 232 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(233 213 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(233 213 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(216 180 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(216 180 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(192 132 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(192 132 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(168 85 247 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(168 85 247 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(147 51 234 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(147 51 234 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(126 34 206 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(126 34 206 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(107 33 168 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(107 33 168 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(88 28 135 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(88 28 135 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 244 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 244 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(250 232 255 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(250 232 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(245 208 254 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(245 208 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(240 171 252 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(240 171 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(232 121 249 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(232 121 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(217 70 239 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(217 70 239 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(192 38 211 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(192 38 211 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(162 28 175 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(162 28 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(134 25 143 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(134 25 143 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(112 26 117 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(112 26 117 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 242 248 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 242 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(252 231 243 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(252 231 243 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(251 207 232 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(251 207 232 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(249 168 212 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(249 168 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(244 114 182 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(244 114 182 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(236 72 153 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(236 72 153 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(219 39 119 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(219 39 119 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(190 24 93 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(190 24 93 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(157 23 77 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(157 23 77 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(131 24 67 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(131 24 67 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 241 242 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 241 242 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(255 228 230 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(255 228 230 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(254 205 211 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(254 205 211 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(253 164 175 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(253 164 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(251 113 133 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(251 113 133 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(244 63 94 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(244 63 94 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(225 29 72 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(225 29 72 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(190 18 60 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(190 18 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(159 18 57 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(159 18 57 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderLeftColor: 'rgb(136 19 55 / var(--tw-border-opacity))',
+  borderRightColor: 'rgb(136 19 55 / var(--tw-border-opacity))',
+})
+;({
+  borderTopColor: 'inherit',
+  borderBottomColor: 'inherit',
+})
+;({
+  borderTopColor: 'currentColor',
+  borderBottomColor: 'currentColor',
+})
+;({
+  borderTopColor: 'rgb(0 0 0 / 0)',
+  borderBottomColor: 'rgb(0 0 0 / 0)',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(0 0 0 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(0 0 0 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 255 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 255 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(248 250 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(248 250 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(241 245 249 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(241 245 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(226 232 240 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(226 232 240 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(203 213 225 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(203 213 225 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(148 163 184 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(148 163 184 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(100 116 139 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(100 116 139 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(71 85 105 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(71 85 105 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(51 65 85 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(51 65 85 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(30 41 59 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(30 41 59 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(15 23 42 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(15 23 42 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(249 250 251 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(249 250 251 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(243 244 246 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(243 244 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(229 231 235 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(229 231 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(209 213 219 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(209 213 219 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(156 163 175 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(156 163 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(107 114 128 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(107 114 128 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(75 85 99 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(75 85 99 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(55 65 81 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(55 65 81 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(31 41 55 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(31 41 55 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(17 24 39 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(17 24 39 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(244 244 245 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(244 244 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(228 228 231 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(228 228 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(212 212 216 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(212 212 216 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(161 161 170 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(161 161 170 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(113 113 122 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(113 113 122 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(82 82 91 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(82 82 91 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(63 63 70 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(63 63 70 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(39 39 42 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(39 39 42 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(24 24 27 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(24 24 27 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 250 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(245 245 245 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(245 245 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(229 229 229 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(229 229 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(212 212 212 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(212 212 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(163 163 163 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(163 163 163 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(115 115 115 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(115 115 115 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(82 82 82 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(82 82 82 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(64 64 64 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(64 64 64 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(38 38 38 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(38 38 38 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(23 23 23 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(23 23 23 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 250 249 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 250 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(245 245 244 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(245 245 244 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(231 229 228 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(231 229 228 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(214 211 209 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(214 211 209 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(168 162 158 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(168 162 158 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(120 113 108 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(120 113 108 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(87 83 78 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(87 83 78 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(68 64 60 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(68 64 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(41 37 36 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(41 37 36 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(28 25 23 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(28 25 23 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 242 242 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 242 242 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 226 226 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 226 226 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 202 202 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 202 202 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(252 165 165 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(252 165 165 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(248 113 113 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(248 113 113 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(239 68 68 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(239 68 68 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(220 38 38 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(220 38 38 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(185 28 28 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(185 28 28 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(153 27 27 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(153 27 27 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(127 29 29 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(127 29 29 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 247 237 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 247 237 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 237 213 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 237 213 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 215 170 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 215 170 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 186 116 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 186 116 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(251 146 60 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(251 146 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(249 115 22 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(249 115 22 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(234 88 12 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(234 88 12 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(194 65 12 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(194 65 12 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(154 52 18 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(154 52 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(124 45 18 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(124 45 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 251 235 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 251 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 243 199 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 243 199 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 230 138 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 230 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(252 211 77 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(252 211 77 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(251 191 36 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(251 191 36 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(245 158 11 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(245 158 11 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(217 119 6 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(217 119 6 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(180 83 9 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(180 83 9 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(146 64 14 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(146 64 14 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(120 53 15 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(120 53 15 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 252 232 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 252 232 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 249 195 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 249 195 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 240 138 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 240 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 224 71 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 224 71 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 204 21 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 204 21 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(234 179 8 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(234 179 8 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(202 138 4 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(202 138 4 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(161 98 7 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(161 98 7 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(133 77 14 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(133 77 14 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(113 63 18 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(113 63 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(247 254 231 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(247 254 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(236 252 203 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(236 252 203 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(217 249 157 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(217 249 157 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(190 242 100 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(190 242 100 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(163 230 53 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(163 230 53 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(132 204 22 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(132 204 22 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(101 163 13 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(101 163 13 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(77 124 15 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(77 124 15 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(63 98 18 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(63 98 18 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(54 83 20 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(54 83 20 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(240 253 244 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(240 253 244 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(220 252 231 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(220 252 231 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(187 247 208 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(187 247 208 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(134 239 172 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(134 239 172 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(74 222 128 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(74 222 128 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(34 197 94 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(34 197 94 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(22 163 74 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(22 163 74 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(21 128 61 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(21 128 61 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(22 101 52 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(22 101 52 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(20 83 45 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(20 83 45 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(236 253 245 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(236 253 245 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(209 250 229 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(209 250 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(167 243 208 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(167 243 208 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(110 231 183 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(110 231 183 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(52 211 153 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(52 211 153 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(16 185 129 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(16 185 129 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(5 150 105 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(5 150 105 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(4 120 87 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(4 120 87 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(6 95 70 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(6 95 70 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(6 78 59 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(6 78 59 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(240 253 250 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(240 253 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(204 251 241 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(204 251 241 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(153 246 228 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(153 246 228 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(94 234 212 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(94 234 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(45 212 191 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(45 212 191 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(20 184 166 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(20 184 166 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(13 148 136 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(13 148 136 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(15 118 110 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(15 118 110 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(17 94 89 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(17 94 89 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(19 78 74 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(19 78 74 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(236 254 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(236 254 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(207 250 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(207 250 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(165 243 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(165 243 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(103 232 249 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(103 232 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(34 211 238 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(34 211 238 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(6 182 212 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(6 182 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(8 145 178 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(8 145 178 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(14 116 144 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(14 116 144 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(21 94 117 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(21 94 117 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(22 78 99 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(22 78 99 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(240 249 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(240 249 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(224 242 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(224 242 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(186 230 253 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(186 230 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(125 211 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(125 211 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(56 189 248 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(56 189 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(14 165 233 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(14 165 233 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(2 132 199 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(2 132 199 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(3 105 161 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(3 105 161 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(7 89 133 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(7 89 133 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(12 74 110 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(12 74 110 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(239 246 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(239 246 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(219 234 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(219 234 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(191 219 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(191 219 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(147 197 253 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(147 197 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(96 165 250 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(96 165 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(59 130 246 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(59 130 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(37 99 235 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(37 99 235 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(29 78 216 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(29 78 216 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(30 64 175 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(30 64 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(30 58 138 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(30 58 138 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(238 242 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(238 242 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(224 231 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(224 231 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(199 210 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(199 210 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(165 180 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(165 180 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(129 140 248 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(129 140 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(99 102 241 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(99 102 241 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(79 70 229 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(79 70 229 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(67 56 202 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(67 56 202 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(55 48 163 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(55 48 163 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(49 46 129 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(49 46 129 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(245 243 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(245 243 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(237 233 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(237 233 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(221 214 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(221 214 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(196 181 253 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(196 181 253 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(167 139 250 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(167 139 250 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(139 92 246 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(139 92 246 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(124 58 237 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(124 58 237 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(109 40 217 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(109 40 217 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(91 33 182 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(91 33 182 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(76 29 149 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(76 29 149 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 245 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 245 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(243 232 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(243 232 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(233 213 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(233 213 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(216 180 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(216 180 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(192 132 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(192 132 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(168 85 247 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(168 85 247 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(147 51 234 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(147 51 234 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(126 34 206 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(126 34 206 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(107 33 168 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(107 33 168 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(88 28 135 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(88 28 135 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 244 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 244 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(250 232 255 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(250 232 255 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(245 208 254 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(245 208 254 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(240 171 252 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(240 171 252 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(232 121 249 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(232 121 249 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(217 70 239 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(217 70 239 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(192 38 211 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(192 38 211 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(162 28 175 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(162 28 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(134 25 143 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(134 25 143 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(112 26 117 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(112 26 117 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 242 248 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 242 248 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(252 231 243 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(252 231 243 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(251 207 232 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(251 207 232 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(249 168 212 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(249 168 212 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(244 114 182 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(244 114 182 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(236 72 153 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(236 72 153 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(219 39 119 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(219 39 119 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(190 24 93 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(190 24 93 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(157 23 77 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(157 23 77 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(131 24 67 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(131 24 67 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 241 242 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 241 242 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(255 228 230 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(255 228 230 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(254 205 211 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(254 205 211 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(253 164 175 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(253 164 175 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(251 113 133 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(251 113 133 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(244 63 94 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(244 63 94 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(225 29 72 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(225 29 72 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(190 18 60 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(190 18 60 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(159 18 57 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(159 18 57 / var(--tw-border-opacity))',
+})
+;({
+  '--tw-border-opacity': '1',
+  borderTopColor: 'rgb(136 19 55 / var(--tw-border-opacity))',
+  borderBottomColor: 'rgb(136 19 55 / var(--tw-border-opacity))',
+})
 ;({
   borderTopColor: 'inherit',
 })
@@ -14433,16 +16227,16 @@ tw\`border-2\`
 tw\`border-4\`
 tw\`border-8\`
 tw\`border\`
-// tw\`border-x-0\`
-// tw\`border-x-2\`
-// tw\`border-x-4\`
-// tw\`border-x-8\`
-// tw\`border-x\`
-// tw\`border-y-0\`
-// tw\`border-y-2\`
-// tw\`border-y-4\`
-// tw\`border-y-8\`
-// tw\`border-y\`
+tw\`border-x-0\`
+tw\`border-x-2\`
+tw\`border-x-4\`
+tw\`border-x-8\`
+tw\`border-x\`
+tw\`border-y-0\`
+tw\`border-y-2\`
+tw\`border-y-4\`
+tw\`border-y-8\`
+tw\`border-y\`
 tw\`border-t-0\`
 tw\`border-t-2\`
 tw\`border-t-4\`
@@ -14485,17 +16279,47 @@ tw\`border-t-[2.5px]\`
 })
 ;({
   borderWidth: '1px',
-}) // tw\`border-x-0\`
-// tw\`border-x-2\`
-// tw\`border-x-4\`
-// tw\`border-x-8\`
-// tw\`border-x\`
-// tw\`border-y-0\`
-// tw\`border-y-2\`
-// tw\`border-y-4\`
-// tw\`border-y-8\`
-// tw\`border-y\`
-
+})
+;({
+  borderLeftWidth: '0px',
+  borderRightWidth: '0px',
+})
+;({
+  borderLeftWidth: '2px',
+  borderRightWidth: '2px',
+})
+;({
+  borderLeftWidth: '4px',
+  borderRightWidth: '4px',
+})
+;({
+  borderLeftWidth: '8px',
+  borderRightWidth: '8px',
+})
+;({
+  borderLeftWidth: '1px',
+  borderRightWidth: '1px',
+})
+;({
+  borderTopColor: '0px',
+  borderBottomColor: '0px',
+})
+;({
+  borderTopColor: '2px',
+  borderBottomColor: '2px',
+})
+;({
+  borderTopColor: '4px',
+  borderBottomColor: '4px',
+})
+;({
+  borderTopColor: '8px',
+  borderBottomColor: '8px',
+})
+;({
+  borderTopColor: '1px',
+  borderBottomColor: '1px',
+})
 ;({
   borderTopWidth: '0px',
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -256,9 +256,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-      "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
+      "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw=="
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.2.1",
@@ -455,49 +455,44 @@
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.14.6",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
-          "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ=="
-        },
         "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   },
   "homepage": "https://github.com/ben-rogerson/twin.macro#readme",
   "dependencies": {
-    "@babel/parser": "^7.12.5",
-    "@babel/template": "^7.14.5",
+    "@babel/parser": "^7.17.0",
+    "@babel/template": "^7.16.7",
     "autoprefixer": "^10.2.5",
     "babel-plugin-macros": "^3.1.0",
     "chalk": "^4.1.0",

--- a/src/coerced.js
+++ b/src/coerced.js
@@ -1,0 +1,124 @@
+import deepMerge from 'lodash.merge'
+import { throwIf, withAlpha, splitOnFirst, getTheme, isLength } from './utils'
+import { opacityErrorNotFound, logBadGood } from './logging'
+
+const coercedTypeMap = {
+  all: ({ config, value, theme }) => config(value, theme),
+  color: ({ config, value, pieces, theme, hasFallback }) => {
+    if (typeof config === 'function') return config(value, theme)
+    const { property, variable, wrapWith } = config
+    if (!property) return
+
+    const values = Array.isArray(property) ? property : [property]
+    const result = values
+      .map(p => {
+        const colorOutput = withAlpha({
+          color: value,
+          property: p,
+          pieces,
+          hasFallback,
+          ...(variable && { variable }),
+        })
+
+        if (colorOutput && wrapWith) return { [wrapWith]: colorOutput }
+
+        return colorOutput
+      })
+      .filter(Boolean)
+    if (result.length === 0) return
+
+    return deepMerge(...result)
+  },
+  length: ({ config, value, theme }) => {
+    if (!isLength(value) && !value.startsWith('var(')) return
+
+    if (typeof config === 'function') return config(value, theme)
+    const { property, variable, wrapWith } = config
+    if (!property) return
+
+    const values = Array.isArray(property) ? property : [property]
+    const result = Object.fromEntries(
+      values.map(p => [
+        p,
+        variable ? `calc(${value} * var(${variable}))` : value,
+      ])
+    )
+
+    const out = { ...(variable && { [variable]: '0' }), ...result }
+    if (wrapWith) return { [wrapWith]: out }
+
+    return out
+  },
+  url: ({ value }) => {
+    if (!value.startsWith('url(')) return
+    return { backgroundImage: value } // TODO: Get correct property
+  },
+  lookup: ({ config, value, theme }) => config(value, theme),
+}
+
+const getCoercedValue = (customValue, context) => {
+  const [explicitType, value] = splitOnFirst(customValue, ':')
+  if (value.length === 0) return
+
+  const coercedConfig = context.config.coerced
+  if (!coercedConfig) return
+
+  const coercedOptions = Object.keys(coercedConfig)
+  throwIf(!coercedOptions.includes(explicitType), () =>
+    logBadGood(
+      `The coerced value of “${explicitType}” isn’t available`,
+      `Try one of these coerced classes:\n\n${coercedOptions
+        .map(o => `${context.property}-[${o}:${value}]`)
+        .join(', ')}`
+    )
+  )
+
+  const result = coercedTypeMap[explicitType]({
+    config: coercedConfig[explicitType],
+    value,
+    pieces: context.pieces,
+    theme: getTheme(context.state.config.theme),
+  })
+  return result
+}
+
+const getCoercedColor = ({
+  pieces,
+  theme,
+  config,
+  matchConfig,
+}) => configKey => {
+  if (!config) return
+
+  // Match config including a custom slash alpha, eg: bg-black/[.5]
+  const keys = Array.isArray(configKey) ? configKey : [configKey]
+  let value
+  keys.find(k => {
+    const match = matchConfig(k)
+    if (match) value = match
+    return match
+  })
+  if (!value) return
+
+  return coercedTypeMap.color({ value, config, pieces, theme })
+}
+
+const getCoercedLength = ({
+  pieces,
+  theme,
+  config,
+  matchConfig,
+}) => configKey => {
+  const value = matchConfig(configKey)
+  if (!value) return
+
+  throwIf(pieces.hasAlpha, () =>
+    opacityErrorNotFound({
+      className: pieces.classNameRaw,
+    })
+  )
+
+  return coercedTypeMap.length({ value, config, pieces, theme })
+}
+
+export { coercedTypeMap, getCoercedValue, getCoercedColor, getCoercedLength }

--- a/src/config/dynamicStyles.js
+++ b/src/config/dynamicStyles.js
@@ -83,21 +83,29 @@ export default {
   'divide-opacity': { prop: '--tw-divide-opacity', plugin: 'divide' },
   'divide-y': {
     plugin: 'divide',
-    value: ({ value }) => ({
-      '> :not([hidden]) ~ :not([hidden])': {
-        '--tw-divide-y-reverse': '0',
-        borderTopWidth: `calc(${value} * calc(1 - var(--tw-divide-y-reverse)))`,
-        borderBottomWidth: `calc(${value} * var(--tw-divide-y-reverse))`,
-      },
-    }),
+    value: ['length'],
+    coerced: {
+      length: value => ({
+        '> :not([hidden]) ~ :not([hidden])': {
+          '--tw-divide-y-reverse': '0',
+          borderTopWidth: `calc(${value} * calc(1 - var(--tw-divide-y-reverse)))`,
+          borderBottomWidth: `calc(${value} * var(--tw-divide-y-reverse))`,
+        },
+      }),
+    },
   },
   'divide-x': {
     plugin: 'divide',
-    value: ({ value }) => ({
-      '--tw-divide-x-reverse': '0',
-      borderRightWidth: `calc(${value} * var(--tw-divide-x-reverse))`,
-      borderLeftWidth: `calc(${value} * calc(1 - var(--tw-divide-x-reverse)))`,
-    }),
+    value: ['length'],
+    coerced: {
+      length: value => ({
+        '> :not([hidden]) ~ :not([hidden])': {
+          '--tw-divide-x-reverse': '0',
+          borderRightWidth: `calc(${value} * var(--tw-divide-x-reverse))`,
+          borderLeftWidth: `calc(${value} * calc(1 - var(--tw-divide-x-reverse)))`,
+        },
+      }),
+    },
   },
   divide: {
     plugin: 'divide',
@@ -106,7 +114,7 @@ export default {
       color: {
         property: 'borderColor',
         variable: '--tw-divide-opacity',
-        useSlashAlpha: false,
+        wrapWith: '> :not([hidden]) ~ :not([hidden])',
       },
     },
   },
@@ -261,13 +269,14 @@ export default {
   // https://tailwindcss.com/docs/placeholder-color
   placeholder: {
     plugin: 'placeholder',
-    value: ({ color }) => ({
-      '::placeholder': color({
+    value: ['color'],
+    coerced: {
+      color: {
         property: 'color',
         variable: '--tw-placeholder-opacity',
-        useSlashAlpha: false,
-      }),
-    }),
+        wrapWith: '::placeholder',
+      },
+    },
   },
 
   // https://tailwindcss.com/docs/text-align
@@ -317,11 +326,7 @@ export default {
     value: ['color', 'url'],
     plugin: 'bg',
     coerced: {
-      color: {
-        property: 'backgroundColor',
-        variable: '--tw-bg-opacity',
-        useSlashAlpha: false,
-      },
+      color: { property: 'backgroundColor', variable: '--tw-bg-opacity' },
       lookup: value => ({
         backgroundImage: value,
         backgroundSize: value,
@@ -332,21 +337,21 @@ export default {
 
   // https://tailwindcss.com/docs/gradient-color-stops
   from: {
+    plugin: 'gradient',
     value: ({ value, transparentTo }) => ({
       '--tw-gradient-from': value,
       '--tw-gradient-stops': `var(--tw-gradient-from), var(--tw-gradient-to, ${transparentTo(
         value
       )})`,
     }),
-    plugin: 'gradient',
   },
   via: {
+    plugin: 'gradient',
     value: ({ value, transparentTo }) => ({
       '--tw-gradient-stops': `var(--tw-gradient-from), ${value}, var(--tw-gradient-to, ${transparentTo(
         value
       )})`,
     }),
-    plugin: 'gradient',
   },
   to: { prop: '--tw-gradient-to', plugin: 'gradient' },
 
@@ -363,24 +368,25 @@ export default {
     value: ['color', 'length'],
     plugin: 'border',
     coerced: {
-      color: { property: 'borderTopColor', variable: '--tw-border-opacity' },
       length: { property: 'borderTopWidth' },
+      color: { property: 'borderTopColor', variable: '--tw-border-opacity' },
     },
   },
   'border-b': {
-    value: ['color', 'length'],
+    value: ['length', 'color'],
     plugin: 'border',
+    config: ['borderWidth', 'borderColor'],
     coerced: {
-      color: { property: 'borderBottomColor', variable: '--tw-border-opacity' },
       length: { property: 'borderBottomWidth' },
+      color: { property: 'borderBottomColor', variable: '--tw-border-opacity' },
     },
   },
   'border-l': {
     value: ['color', 'length'],
     plugin: 'border',
     coerced: {
-      color: { property: 'borderLeftColor', variable: '--tw-border-opacity' },
       length: { property: 'borderLeftWidth' },
+      color: { property: 'borderLeftColor', variable: '--tw-border-opacity' },
     },
   },
   'border-r': {
@@ -389,6 +395,29 @@ export default {
     coerced: {
       color: { property: 'borderRightColor', variable: '--tw-border-opacity' },
       length: { property: 'borderRightWidth' },
+    },
+  },
+  'border-x': {
+    value: ['color', 'length'],
+    plugin: 'border',
+    prop: '--tw-border-opacity',
+    coerced: {
+      color: {
+        property: ['borderLeftColor', 'borderRightColor'],
+        variable: '--tw-border-opacity',
+      },
+      length: { property: ['borderLeftWidth', 'borderRightWidth'] },
+    },
+  },
+  'border-y': {
+    value: ['color', 'length'],
+    plugin: 'border',
+    coerced: {
+      color: {
+        property: ['borderTopColor', 'borderBottomColor'],
+        variable: '--tw-border-opacity',
+      },
+      length: { property: ['borderTopColor', 'borderBottomColor'] },
     },
   },
   'border-opacity': {
@@ -442,7 +471,7 @@ export default {
     value: ['length', 'color'],
     plugin: 'ringOffset',
     coerced: {
-      color: value => ({ '--tw-ring-offset-color': value }),
+      color: { property: '--tw-ring-offset-color' },
       length: { property: '--tw-ring-offset-width' },
     },
   },
@@ -819,20 +848,17 @@ export default {
 
   // https://tailwindcss.com/docs/fill
   fill: {
-    prop: 'fill',
     plugin: 'fill',
-    coerced: {
-      color: { property: 'fill' },
-    },
+    value: ['color'],
+    coerced: { color: { property: 'fill' } },
   },
 
   // https://tailwindcss.com/docs/stroke
   stroke: {
-    prop: 'stroke',
     value: ['length', 'color'],
     plugin: 'stroke',
     coerced: {
-      color: value => ({ stroke: value }),
+      color: { property: 'stroke' },
       length: { property: 'strokeWidth' },
     },
   },

--- a/src/contants.js
+++ b/src/contants.js
@@ -1,3 +1,23 @@
 const SPACE_ID = '__SPACE_ID__'
 
-export { SPACE_ID }
+const LENGTH_UNITS = [
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pc',
+  'pt',
+  'px',
+  'em',
+  'ex',
+  'ch',
+  'rem',
+  'lh',
+  'vw',
+  'vh',
+  'vmin',
+  'vmax',
+  '%',
+]
+
+export { SPACE_ID, LENGTH_UNITS }

--- a/src/getProperties.js
+++ b/src/getProperties.js
@@ -26,11 +26,10 @@ const getDynamicProperties = className => {
   const dynamicConfig = dynamicStyles[dynamicKey] || {}
 
   // See if the config property is defined
-  const isDynamicClass = Boolean(
-    Array.isArray(dynamicConfig)
-      ? dynamicConfig.map(item => get(item, 'config'))
-      : get(dynamicStyles, [dynamicKey, 'config'])
-  )
+  const isDynamicClass = Array.isArray(dynamicConfig)
+    ? dynamicConfig.map(item => get(item, 'config') && !get(item, 'coerced'))
+    : get(dynamicStyles, [dynamicKey, 'config']) &&
+      !get(dynamicConfig, 'coerced')
 
   return { isDynamicClass, dynamicConfig, dynamicKey }
 }

--- a/src/logging.js
+++ b/src/logging.js
@@ -216,21 +216,11 @@ const themeErrorNotFound = ({ theme, input, trimInput }) => {
   return spaced(`${textNotFound}\n\n${suggestionText}`)
 }
 
-const opacityErrorNotFound = ({ className, opacity, theme }) => {
+const opacityErrorNotFound = ({ className }) => {
   const textNotFound = warning(
-    `The opacity ${color.errorLight(
-      opacity
-    )} was not found in your tailwind config`
+    `The class ${color.errorLight(className)} doesn’t support an opacity`
   )
-
-  const suggestionText = `Try one of these values:\n${formatSuggestions(
-    Object.entries(theme).map(([k, v]) => ({
-      target: [className, k].join('/'),
-      value: typeof v === 'string' ? v : '...',
-    }))
-  )}`
-
-  return spaced(`${textNotFound}\n\n${suggestionText}`)
+  return spaced(textNotFound)
 }
 
 const logNotFoundVariant = ({ classNameRaw }) =>

--- a/src/plugins/bg.js
+++ b/src/plugins/bg.js
@@ -1,12 +1,3 @@
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'bg',
-    property: 'backgroundColor',
-    configSearch: 'backgroundColor',
-  }
-  return toColor([{ ...common, opacityVariable: '--tw-bg-opacity' }, common])
-}
-
 const handleSize = ({ configValue, important }) => {
   const value = configValue('backgroundSize')
   if (!value) return
@@ -32,14 +23,14 @@ export default properties => {
   const {
     theme,
     match,
-    toColor,
     getConfigValue,
+    getCoercedColor,
     errors: { errorSuggestions },
     pieces: { important },
   } = properties
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor('backgroundColor')
+  if (coercedColor) return coercedColor
 
   const classValue = match(/(?<=(bg)-)([^]*)/)
   const configValue = config => getConfigValue(theme(config), classValue)

--- a/src/plugins/border.js
+++ b/src/plugins/border.js
@@ -1,62 +1,15 @@
-const borderWidthConfig = [
-  {
-    property: 'borderTopWidth',
-    value: regex => regex(/(?<=(border-t(-|$)))([^]*)/),
-  },
-  {
-    property: 'borderRightWidth',
-    value: regex => regex(/(?<=(border-r(-|$)))([^]*)/),
-  },
-  {
-    property: 'borderBottomWidth',
-    value: regex => regex(/(?<=(border-b(-|$)))([^]*)/),
-  },
-  {
-    property: 'borderLeftWidth',
-    value: regex => regex(/(?<=(border-l(-|$)))([^]*)/),
-  },
-  {
-    property: 'borderWidth',
-    value: regex => regex(/(?<=(border(-|$)))([^]*)/),
-  },
-]
-
-const borderColorConfig = [
-  { matchStart: 'border-t', property: 'borderTopColor' },
-  { matchStart: 'border-r', property: 'borderRightColor' },
-  { matchStart: 'border-b', property: 'borderBottomColor' },
-  { matchStart: 'border-l', property: 'borderLeftColor' },
-  { matchStart: 'border', property: 'borderColor' },
-]
-
-const getCommonColorConfig = ({ matchStart, property }) => ({
-  matchStart,
-  property,
-  configSearch: 'borderColor',
-})
-
 export default properties => {
   const {
-    matchConfigValue,
-    toColor,
-    pieces: { important },
+    getCoercedLength,
+    getCoercedColor,
     errors: { errorSuggestions },
   } = properties
 
-  const getBorderWidthByRegex = regex => matchConfigValue('borderWidth', regex)
-  for (const task of borderWidthConfig) {
-    const value = task.value(getBorderWidthByRegex)
-    if (value) return { [task.property]: `${value}${important}` }
-  }
+  const coercedLength = getCoercedLength('borderWidth')
+  if (coercedLength) return coercedLength
 
-  for (const task of borderColorConfig) {
-    const common = getCommonColorConfig(task)
-    const value = toColor([
-      { ...common, opacityVariable: '--tw-border-opacity' },
-      common,
-    ])
-    if (value) return value
-  }
+  const coercedColor = getCoercedColor('borderColor')
+  if (coercedColor) return coercedColor
 
   errorSuggestions({ config: ['borderColor', 'borderWidth'] })
 }

--- a/src/plugins/caretColor.js
+++ b/src/plugins/caretColor.js
@@ -1,14 +1,7 @@
 export default properties => {
-  const common = {
-    matchStart: 'caret',
-    property: 'caretColor',
-    configSearch: 'caretColor',
-  }
-  const color = properties.toColor([
-    { ...common, useSlashAlpha: false },
-    common,
-  ])
-  if (!color) properties.errors.errorSuggestions({ config: 'caretColor' })
+  const coercedColor = properties.getCoercedColor('caretColor')
+  if (!coercedColor)
+    properties.errors.errorSuggestions({ config: 'caretColor' })
 
-  return color
+  return coercedColor
 }

--- a/src/plugins/divide.js
+++ b/src/plugins/divide.js
@@ -1,20 +1,5 @@
 import { addPxTo0, stripNegative } from './../utils'
 
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'divide',
-    property: 'borderColor',
-    configSearch: ['divideColor', 'borderColor', 'colors'],
-  }
-  const borderColor = toColor([
-    { ...common, opacityVariable: '--tw-divide-opacity' },
-    common,
-  ])
-  if (!borderColor) return
-
-  return { '> :not([hidden]) ~ :not([hidden])': borderColor }
-}
-
 const handleOpacity = ({ configValue }) => {
   const opacity = configValue('divideOpacity') || configValue('opacity')
   if (!opacity) return
@@ -46,7 +31,7 @@ const handleWidth = ({
     ? { borderRightWidth: borderFirst, borderLeftWidth: borderSecond }
     : { borderTopWidth: borderSecond, borderBottomWidth: borderFirst }
 
-  const innerStyles = { [cssVariableKey]: 0, ...styleKey }
+  const innerStyles = { [cssVariableKey]: '0', ...styleKey }
 
   return { '> :not([hidden]) ~ :not([hidden])': innerStyles }
 }
@@ -55,13 +40,13 @@ export default properties => {
   const {
     errors: { errorSuggestions },
     getConfigValue,
-    toColor,
+    getCoercedColor,
     theme,
     match,
   } = properties
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor(['divideColor', 'borderColor', 'colors'])
+  if (coercedColor) return coercedColor
 
   const opacityMatch =
     match(/(?<=(divide)-(opacity))([^]*)/) ||
@@ -91,9 +76,7 @@ export default properties => {
     const width = handleWidth(widthProperties)
     if (width) return width
 
-    errorSuggestions({
-      config: 'divideWidth',
-    })
+    errorSuggestions({ config: 'divideWidth' })
   }
 
   errorSuggestions()

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -1,10 +1,6 @@
 export default properties => {
-  const common = { matchStart: 'fill', property: 'fill', configSearch: 'fill' }
-  const color = properties.toColor([
-    { ...common, useSlashAlpha: false },
-    common,
-  ])
-  if (!color) properties.errors.errorSuggestions({ config: 'fill' })
+  const coercedColor = properties.getCoercedColor('fill')
+  if (!coercedColor) properties.errors.errorSuggestions({ config: 'fill' })
 
-  return color
+  return coercedColor
 }

--- a/src/plugins/gradient.js
+++ b/src/plugins/gradient.js
@@ -24,7 +24,6 @@ export default properties => {
           pieces,
           color: value,
           property: '--tw-gradient-from',
-          useSlashAlpha: false,
         }),
         '--tw-gradient-stops': [
           'var(--tw-gradient-from)',
@@ -34,7 +33,7 @@ export default properties => {
       via: {
         '--tw-gradient-stops': [
           'var(--tw-gradient-from)',
-          withAlpha({ pieces, color: value, useSlashAlpha: false }),
+          withAlpha({ pieces, color: value }),
           `var(--tw-gradient-to, ${transparentTo(value)})`,
         ].join(', '),
       },
@@ -42,7 +41,6 @@ export default properties => {
         pieces,
         color: value,
         property: '--tw-gradient-to',
-        useSlashAlpha: false,
       }),
     }) ||
     (slashAlphaValue && {

--- a/src/plugins/placeholder.js
+++ b/src/plugins/placeholder.js
@@ -1,28 +1,16 @@
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'placeholder',
-    property: 'color',
-    configSearch: 'placeholderColor',
-  }
-  return toColor([
-    { ...common, opacityVariable: '--tw-placeholder-opacity' },
-    common,
-  ])
-}
-
 const handleOpacity = ({ configValue }) => {
   const value = configValue('placeholderOpacity') || configValue('opacity')
   if (!value) return
 
-  return { '--tw-placeholder-opacity': `${value}` }
+  return { '::placeholder': { '--tw-placeholder-opacity': `${value}` } }
 }
 
 export default properties => {
   const {
     match,
     theme,
-    toColor,
     getConfigValue,
+    getCoercedColor,
     errors: { errorSuggestions },
   } = properties
 
@@ -31,10 +19,10 @@ export default properties => {
   const opacity = handleOpacity({
     configValue: config => getConfigValue(theme(config), opacityMatch),
   })
-  if (opacity) return { '::placeholder': opacity }
+  if (opacity) return opacity
 
-  const color = handleColor({ toColor })
-  if (color) return { '::placeholder': color }
+  const coercedColor = getCoercedColor('placeholderColor')
+  if (coercedColor) return coercedColor
 
   errorSuggestions({
     config: [

--- a/src/plugins/ring.js
+++ b/src/plugins/ring.js
@@ -32,20 +32,11 @@ const handleWidth = ({ configValue, important }) => {
   }
 }
 
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'ring',
-    property: '--tw-ring-color',
-    configSearch: 'ringColor',
-  }
-  return toColor([{ ...common, opacityVariable: '--tw-ring-opacity' }, common])
-}
-
 export default properties => {
   const {
     theme,
     match,
-    toColor,
+    getCoercedColor,
     getConfigValue,
     errors: { errorSuggestions },
     pieces: { important },
@@ -61,8 +52,8 @@ export default properties => {
   })
   if (width) return width
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor('ringColor')
+  if (coercedColor) return coercedColor
 
   errorSuggestions({
     config: ['ringWidth', 'ringColor'],

--- a/src/plugins/ringOffset.js
+++ b/src/plugins/ringOffset.js
@@ -1,15 +1,6 @@
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'ring-offset',
-    property: '--tw-ring-offset-color',
-    configSearch: 'ringOffsetColor',
-  }
-  return toColor([{ ...common, useSlashAlpha: false }, common])
-}
-
 export default properties => {
   const {
-    toColor,
+    getCoercedColor,
     matchConfigValue,
     errors: { errorSuggestions },
     pieces: { negative },
@@ -18,8 +9,8 @@ export default properties => {
   const width = matchConfigValue('ringOffsetWidth', /(?<=(ring-offset)-)([^]*)/)
   if (width) return { '--tw-ring-offset-width': `${negative}${width}` }
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor('ringOffsetColor')
+  if (coercedColor) return coercedColor
 
   errorSuggestions({
     config: ['ringOffsetWidth', 'ringOffsetColor'],

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -1,12 +1,3 @@
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'stroke',
-    property: 'stroke',
-    configSearch: 'stroke',
-  }
-  return toColor([{ ...common, useSlashAlpha: false }, common])
-}
-
 const handleWidth = ({ configValue, important }) => {
   const value = configValue('strokeWidth')
   if (!value) return
@@ -28,14 +19,14 @@ export default properties => {
   const {
     theme,
     match,
-    toColor,
+    getCoercedColor,
     getConfigValue,
     errors: { errorSuggestions },
     pieces: { important },
   } = properties
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor('stroke')
+  if (coercedColor) return coercedColor
 
   const classValue = match(/(?<=(stroke)-)([^]*)/)
   const configValue = config => getConfigValue(theme(config), classValue)

--- a/src/plugins/text.js
+++ b/src/plugins/text.js
@@ -1,12 +1,3 @@
-const handleColor = ({ toColor }) => {
-  const common = {
-    matchStart: 'text',
-    property: 'color',
-    configSearch: 'textColor',
-  }
-  return toColor([{ ...common, opacityVariable: '--tw-text-opacity' }, common])
-}
-
 const handleSize = ({ configValue, important }) => {
   const value = configValue('fontSize')
   if (!value) return
@@ -31,7 +22,7 @@ export default properties => {
   const {
     match,
     theme,
-    toColor,
+    getCoercedColor,
     getConfigValue,
     pieces: { important, hasNegative },
     errors: { errorSuggestions, errorNoNegatives },
@@ -39,8 +30,8 @@ export default properties => {
 
   hasNegative && errorNoNegatives()
 
-  const color = handleColor({ toColor })
-  if (color) return color
+  const coercedColor = getCoercedColor('textColor')
+  if (coercedColor) return coercedColor
 
   const classValue = match(/(?<=(text-))([^]*)/)
   const configValue = config => getConfigValue(theme(config), classValue)

--- a/src/utils/alpha.js
+++ b/src/utils/alpha.js
@@ -1,5 +1,4 @@
 import createColor from 'color'
-import { throwIf } from './misc'
 
 function hasAlpha(color) {
   return (
@@ -69,16 +68,22 @@ const withAlpha = ({
 }) => {
   if (!color) return
 
-  // Validate the slash opacity and show an error that was generated earlier
-  throwIf(useSlashAlpha && pieces.alphaError, pieces.alphaError)
-
   if (typeof color === 'function') {
     if (variable && property) {
-      const value = color({
-        opacityVariable: variable,
-        opacityValue: `var(${variable})`,
-      })
-      return { [variable]: '1', [property]: value }
+      if (pieces.hasAlpha)
+        return {
+          [property]: `${color({ opacityValue: pieces.alpha })}${
+            pieces.important
+          }`,
+        }
+
+      return {
+        [variable]: '1',
+        [property]: `${color({
+          opacityVariable: variable,
+          opacityValue: `var(${variable})`,
+        })}${pieces.important}`,
+      }
     }
 
     color = color({ opacityVariable: variable })

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,3 +1,4 @@
+import deepMerge from 'lodash.merge'
 import { withAlpha } from './../utils'
 
 const getColor = ({ matchConfigValue, pieces }) => colors => {
@@ -22,15 +23,23 @@ const getColor = ({ matchConfigValue, pieces }) => colors => {
       )
       if (!color) return false
 
-      const newColor = withAlpha({
-        pieces,
-        property,
-        variable: opacityVariable,
-        useSlashAlpha,
-        color,
-      })
-      if (newColor) result = newColor
-      return newColor
+      const values = Array.isArray(property) ? property : [property]
+      const res = values
+        .map(p =>
+          withAlpha({
+            color,
+            property: p,
+            pieces,
+            useSlashAlpha,
+            variable: opacityVariable,
+          })
+        )
+        .filter(Boolean)
+
+      if (res.length === 0) return false
+
+      result = deepMerge(...res)
+      return true
     }
   )
   return result

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,5 +12,6 @@ export {
   isShortCss,
   isArbitraryCss,
   splitOnFirst,
+  isLength,
 } from './misc'
 export { toRgba, withAlpha, transparentTo } from './alpha'

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,6 +1,7 @@
 import deepMerge from 'lodash.merge'
 import { MacroError } from 'babel-plugin-macros'
 import get from 'lodash.get'
+import { LENGTH_UNITS } from './../contants'
 
 const throwIf = (expression, callBack) => {
   if (!expression) return
@@ -99,6 +100,14 @@ function splitOnFirst(input, delim) {
   return (([first, ...rest]) => [first, rest.join(delim)])(input.split(delim))
 }
 
+const isLength = value => {
+  const unitsPattern = `(?:${LENGTH_UNITS.join('|')})`
+  return (
+    new RegExp(`${unitsPattern}$`).test(value) ||
+    new RegExp(`^calc\\(.+?${unitsPattern}`).test(value)
+  )
+}
+
 export {
   throwIf,
   isEmpty,
@@ -113,4 +122,5 @@ export {
   isShortCss,
   isArbitraryCss,
   splitOnFirst,
+  isLength,
 }


### PR DESCRIPTION
This PR adds new `border-x-{width}`, `border-y-{width}`, `border-x-{color}`, and `border-y-{color}` classes to style the border on two sides of an element at the same time.

I also updated the way colors are added in core plugins, so updated the codebase to use those instead.