### PR TITLE
Rename overflow-clip to text-clip and overflow-ellipsis to text-ellipsis

### DIFF
--- a/__fixtures__/utilitiesLayout/overflow.js
+++ b/__fixtures__/utilitiesLayout/overflow.js
@@ -4,6 +4,8 @@ import tw from './macro'
 tw`overflow-auto`
 tw`overflow-hidden`
 tw`overflow-clip`
+tw`overflow-x-clip`
+tw`overflow-y-clip`
 tw`overflow-visible`
 tw`overflow-scroll`
 tw`overflow-x-auto`

--- a/__fixtures__/utiltiesTypography/textOverflow.js
+++ b/__fixtures__/utiltiesTypography/textOverflow.js
@@ -2,5 +2,5 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/text-overflow
 tw`truncate`
-tw`overflow-ellipsis`
-tw`overflow-clip`
+tw`text-ellipsis`
+tw`text-clip`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -35160,6 +35160,8 @@ import tw from './macro'
 tw\`overflow-auto\`
 tw\`overflow-hidden\`
 tw\`overflow-clip\`
+tw\`overflow-x-clip\`
+tw\`overflow-y-clip\`
 tw\`overflow-visible\`
 tw\`overflow-scroll\`
 tw\`overflow-x-auto\`
@@ -35181,7 +35183,13 @@ tw\`overflow-y-scroll\`
   overflow: 'hidden',
 })
 ;({
-  textOverflow: 'clip',
+  overflow: 'clip',
+})
+;({
+  overflowX: 'clip',
+})
+;({
+  overflowY: 'clip',
 })
 ;({
   overflow: 'visible',
@@ -51336,8 +51344,8 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/text-overflow
 tw\`truncate\`
-tw\`overflow-ellipsis\`
-tw\`overflow-clip\`
+tw\`text-ellipsis\`
+tw\`text-clip\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -96,6 +96,9 @@ export default {
   },
   'overflow-x-scroll': { output: { overflowX: 'scroll' }, config: 'overflow' },
   'overflow-y-scroll': { output: { overflowY: 'scroll' }, config: 'overflow' },
+  'overflow-clip': { output: { overflow: 'clip' } },
+  'overflow-x-clip': { output: { overflowX: 'clip' } },
+  'overflow-y-clip': { output: { overflowY: 'clip' } },
 
   // https://tailwindcss.com/docs/position
   static: { output: { position: 'static' } },
@@ -455,8 +458,8 @@ export default {
       whiteSpace: 'nowrap',
     },
   },
-  'overflow-ellipsis': { output: { textOverflow: 'ellipsis' } },
-  'overflow-clip': { output: { textOverflow: 'clip' } },
+  'text-ellipsis': { output: { textOverflow: 'ellipsis' } },
+  'text-clip': { output: { textOverflow: 'clip' } },
 
   /**
    * ===========================================

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -96,9 +96,9 @@ export default {
   },
   'overflow-x-scroll': { output: { overflowX: 'scroll' }, config: 'overflow' },
   'overflow-y-scroll': { output: { overflowY: 'scroll' }, config: 'overflow' },
-  'overflow-clip': { output: { overflow: 'clip' } },
-  'overflow-x-clip': { output: { overflowX: 'clip' } },
-  'overflow-y-clip': { output: { overflowY: 'clip' } },
+  'overflow-clip': { output: { overflow: 'clip' }, config: 'overflow' },
+  'overflow-x-clip': { output: { overflowX: 'clip' }, config: 'overflow' },
+  'overflow-y-clip': { output: { overflowY: 'clip' }, config: 'overflow' },
 
   // https://tailwindcss.com/docs/position
   static: { output: { position: 'static' } },

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -13,7 +13,7 @@ const getCustomSuggestions = className => {
     'flex-column-reverse': 'flex-col-reverse',
     'text-italic': 'italic',
     'text-normal': 'font-normal / not-italic',
-    ellipsis: 'overflow-ellipsis',
+    ellipsis: 'text-ellipsis',
     'flex-no-wrap': 'flex-nowrap',
   }[className]
   if (suggestions) return suggestions


### PR DESCRIPTION
This PR renames `overflow-clip` to `text-clip` and `overflow-ellipsis` to `text-ellipsis`.

In addition the new `overflow-clip`, `overflow-x-clip`, `overflow-y-clip` properties are added to twin.macro

Part of #589.