### PR TITLE
Use `text-decoration-line` instead of `text-decoration`

### DIFF
--- a/__fixtures__/utiltiesTypography/textDecoration.js
+++ b/__fixtures__/utiltiesTypography/textDecoration.js
@@ -2,6 +2,6 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/text-decoration
 tw`underline`
-// tw`overline`
+tw`overline`
 tw`line-through`
 tw`no-underline`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -1089,7 +1089,7 @@ const multipleClasses = {
     backgroundColor: 'rgb(0 0 0 / var(--tw-bg-opacity))',
     '--tw-text-opacity': '1',
     color: 'rgb(255 255 255 / var(--tw-text-opacity))',
-    textDecoration: 'underline',
+    textDecorationLine: 'underline',
   },
 }
 const pseudoElement = {
@@ -51867,7 +51867,7 @@ import tw from './macro'
 
 // https://tailwindcss.com/docs/text-decoration
 tw\`underline\`
-// tw\`overline\`
+tw\`overline\`
 tw\`line-through\`
 tw\`no-underline\`
 
@@ -51875,14 +51875,16 @@ tw\`no-underline\`
 
 // https://tailwindcss.com/docs/text-decoration
 ;({
-  textDecoration: 'underline',
-}) // tw\`overline\`
-
-;({
-  textDecoration: 'line-through',
+  textDecorationLine: 'underline',
 })
 ;({
-  textDecoration: 'none',
+  textDecorationLine: 'overline',
+})
+;({
+  textDecorationLine: 'line-through',
+})
+;({
+  textDecorationLine: 'none',
 })
 
 

--- a/src/config/staticStyles.js
+++ b/src/config/staticStyles.js
@@ -441,9 +441,10 @@ export default {
   // See dynamicStyles.js
 
   // https://tailwindcss.com/docs/text-decoration
-  underline: { output: { textDecoration: 'underline' } },
-  'line-through': { output: { textDecoration: 'line-through' } },
-  'no-underline': { output: { textDecoration: 'none' } },
+  underline: { output: { textDecorationLine: 'underline' } },
+  overline: { output: { textDecorationLine: 'overline' } },
+  'line-through': { output: { textDecorationLine: 'line-through' } },
+  'no-underline': { output: { textDecorationLine: 'none' } },
 
   // https://tailwindcss.com/docs/text-transform
   uppercase: { output: { textTransform: 'uppercase' } },


### PR DESCRIPTION
From [tailwindcss#6378](https://github.com/tailwindlabs/tailwindcss/pull/6378):

> Currently the following code would not lead to the underline being green, which is a bug imo: class="decoration-green-700 hover:underline hover:underline-offset-4"
> This is because text-decoration is a shorthand for text-decoration-line, text-decoration-color, text-decoration-style, and text-decoration-thickness so overrides any of those values (if they have been set) to initial.

Also added is the missing `overline` class which adds a line above the text.