### PR TITLE
Add TwComponent to list of valid imports

### DIFF
--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -244,6 +244,7 @@ const validImports = new Set([
   'theme',
   'screen',
   'TwStyle',
+  'TwComponent',
   'ThemeStyle',
   'GlobalStyles',
   'globalStyles',


### PR DESCRIPTION
Fix issue [#653](https://github.com/ben-rogerson/twin.macro/issues/653)