### PR TITLE
Add `tailwind.config.cjs` fallback

### DIFF
--- a/src/configHelpers.js
+++ b/src/configHelpers.js
@@ -30,8 +30,15 @@ const getConfigTailwindProperties = (state, config) => {
   const sourceRoot = state.file.opts.sourceRoot || '.'
   const configFile = config && config.config
 
-  const configPath = resolve(sourceRoot, configFile || `./tailwind.config.js`)
+  const configPath = resolve(sourceRoot, configFile || './tailwind.config.js')
   const configExists = existsSync(configPath)
+
+  // Look for a commonjs file as a fallback
+  if (!configExists && !configFile)
+    return getConfigTailwindProperties(state, {
+      ...config,
+      config: './tailwind.config.cjs',
+    })
 
   const configSelected = configExists
     ? require(configPath)


### PR DESCRIPTION
This PR adds a fallback config lookup of `tailwind.config.cjs` when `tailwind.config.js` is not found.

Closes #567 