### PR TITLE
Add touch action classes

### DIFF
--- a/__fixtures__/utiltiesInteractivity/touchAction.js
+++ b/__fixtures__/utiltiesInteractivity/touchAction.js
@@ -1,13 +1,13 @@
 import tw from './macro'
 
 // https://tailwindcss.com/docs/touch-action
-// tw`touch-auto`
-// tw`touch-none`
-// tw`touch-pan-x`
-// tw`touch-pan-left`
-// tw`touch-pan-right`
-// tw`touch-pan-y`
-// tw`touch-pan-up`
-// tw`touch-pan-down`
-// tw`touch-pinch-zoom`
-// tw`touch-manipulation`
+tw`touch-auto`
+tw`touch-none`
+tw`touch-pan-x`
+tw`touch-pan-left`
+tw`touch-pan-right`
+tw`touch-pan-y`
+tw`touch-pan-up`
+tw`touch-pan-down`
+tw`touch-pinch-zoom`
+tw`touch-manipulation`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -59005,19 +59005,57 @@ exports[`twin.macro touchAction.js: touchAction.js 1`] = `
 import tw from './macro'
 
 // https://tailwindcss.com/docs/touch-action
-// tw\`touch-auto\`
-// tw\`touch-none\`
-// tw\`touch-pan-x\`
-// tw\`touch-pan-left\`
-// tw\`touch-pan-right\`
-// tw\`touch-pan-y\`
-// tw\`touch-pan-up\`
-// tw\`touch-pan-down\`
-// tw\`touch-pinch-zoom\`
-// tw\`touch-manipulation\`
+tw\`touch-auto\`
+tw\`touch-none\`
+tw\`touch-pan-x\`
+tw\`touch-pan-left\`
+tw\`touch-pan-right\`
+tw\`touch-pan-y\`
+tw\`touch-pan-up\`
+tw\`touch-pan-down\`
+tw\`touch-pinch-zoom\`
+tw\`touch-manipulation\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
+// https://tailwindcss.com/docs/touch-action
+;({
+  touchAction: 'auto',
+})
+;({
+  touchAction: 'none',
+})
+;({
+  '--tw-pan-x': 'pan-x',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pan-x': 'pan-left',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pan-x': 'pan-right',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pan-y': 'pan-y',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pan-y': 'pan-up',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pan-y': 'pan-down',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  '--tw-pinch-zoom': 'pinch-zoom',
+  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
+})
+;({
+  touchAction: 'manipulation',
+})
 
 
 `;

--- a/src/config/corePlugins.js
+++ b/src/config/corePlugins.js
@@ -23,6 +23,9 @@ const cssFilterValue = [
   'var(--tw-drop-shadow)',
 ].join(' ')
 
+const cssTouchActionValue =
+  'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)'
+
 export default {
   // https://tailwindcss.com/docs/container
   container: {
@@ -419,7 +422,33 @@ export default {
   cursor: { property: 'cursor', config: 'cursor' },
 
   // https://tailwindcss.com/docs/touch-action
-  // TODO...
+  'touch-auto': { output: { touchAction: 'auto' } },
+  'touch-none': { output: { touchAction: 'none' } },
+  'touch-pan-x': {
+    output: { '--tw-pan-x': 'pan-x', touchAction: cssTouchActionValue },
+  },
+  'touch-pan-left': {
+    output: { '--tw-pan-x': 'pan-left', touchAction: cssTouchActionValue },
+  },
+  'touch-pan-right': {
+    output: { '--tw-pan-x': 'pan-right', touchAction: cssTouchActionValue },
+  },
+  'touch-pan-y': {
+    output: { '--tw-pan-y': 'pan-y', touchAction: cssTouchActionValue },
+  },
+  'touch-pan-up': {
+    output: { '--tw-pan-y': 'pan-up', touchAction: cssTouchActionValue },
+  },
+  'touch-pan-down': {
+    output: { '--tw-pan-y': 'pan-down', touchAction: cssTouchActionValue },
+  },
+  'touch-pinch-zoom': {
+    output: {
+      '--tw-pinch-zoom': 'pinch-zoom',
+      touchAction: cssTouchActionValue,
+    },
+  },
+  'touch-manipulation': { output: { touchAction: 'manipulation' } },
 
   // https://tailwindcss.com/docs/user-select
   'select-none': { output: { userSelect: 'none' } },


### PR DESCRIPTION
This PR adds the following touch action classes:

```js
tw`touch-auto`
tw`touch-none`
tw`touch-pan-x`
tw`touch-pan-left`
tw`touch-pan-right`
tw`touch-pan-y`
tw`touch-pan-up`
tw`touch-pan-down`
tw`touch-pinch-zoom`
tw`touch-manipulation`

// ↓ ↓ ↓ ↓ ↓ ↓

;({
  touchAction: 'auto',
})
;({
  touchAction: 'none',
})
;({
  '--tw-pan-x': 'pan-x',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pan-x': 'pan-left',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pan-x': 'pan-right',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pan-y': 'pan-y',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pan-y': 'pan-up',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pan-y': 'pan-down',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  '--tw-pinch-zoom': 'pinch-zoom',
  touchAction: 'var(--tw-pan-x) var(--tw-pan-y) var(--tw-pinch-zoom)',
})
;({
  touchAction: 'manipulation',
})
```

There's also [some global styles](https://github.com/ben-rogerson/twin.macro/blob/7fc20f60e4b863bc3abf40ef9cb660f1098d8990/src/config/globalStyles.js#L137) that are attached to this change but they were updated in a past commit.