### PR TITLE
Add dev sandbox

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "plugins": ["@babel/plugin-syntax-jsx"]
+  "plugins": [
+    "@babel/plugin-syntax-jsx",
+    "babel-plugin-macros"
+  ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
     'types',
     '__fixtures__',
     'tailwind.config.js',
+    'sandbox',
   ],
   globals: { JSX: true, AriaAttributes: true },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ yarn.lock
 *.tsbuildinfo
 types/build
 .eslintcache
+macro.d.ts
+
+sandbox/out.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "timsort": "^0.3.0"
       },
       "devDependencies": {
+        "@babel/cli": "^7.17.6",
         "@babel/plugin-syntax-jsx": "^7.16.7",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -73,6 +74,45 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/cli": {
+      "version": "7.17.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.6.tgz",
+      "integrity": "sha512-l4w608nsDNlxZhiJ5tE3DbNmr61fIKMZ6fTBo171VEFuFMIYuJ3mHRhTLEkKKyvx2Mizkkv/0a8OJOnZqkKYNA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.4",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2463,6 +2503,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4310,6 +4357,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6104,6 +6160,12 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8547,6 +8609,28 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9421,6 +9505,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pirates": {
@@ -12526,6 +12619,32 @@
         "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
+    "@babel/cli": {
+      "version": "7.17.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.6.tgz",
+      "integrity": "sha512-l4w608nsDNlxZhiJ5tE3DbNmr61fIKMZ6fTBo171VEFuFMIYuJ3mHRhTLEkKKyvx2Mizkkv/0a8OJOnZqkKYNA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.4",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -14252,6 +14371,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -15637,6 +15763,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -16986,6 +17118,12 @@
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -18838,6 +18976,24 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -19481,6 +19637,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.5.0.tgz",
       "integrity": "sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
     "pirates": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,16 @@
   "main": "macro.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "dev": "nodemon --watch src -x \"npm run build:macro\" --delay .02",
+    "dev": "npm run dev:macro:sandbox",
+    "dev:macro": "NODE_ENV=dev nodemon --watch src --watch package.json -x \"npm run build:macro\" --delay .01",
+    "dev:sandbox": "NODE_ENV=dev nodemon --watch sandbox/in.js --watch tailwind.config.js --watch package.json -x \"npm run build:sandbox\" --delay .01",
+    "dev:macro:sandbox": "NODE_ENV=dev nodemon --watch src --watch sandbox/in.js --watch tailwind.config.js --watch package.json -x \"npm run build:macro && npm run build:sandbox\" --delay .01",
     "build": "npm run build:macro",
     "build:macro": "microbundle -i src/macro.js -f cjs -o ./macro.js --target node",
-    "test:types": "tsc -b ./types/tsconfig.json",
+    "build:sandbox": "babel sandbox/in.js --out-file sandbox/out.js",
     "test": "npm run build && jest && npm run test:types",
-    "fixup": "npm run build && jest --u",
+    "test:types": "tsc -b ./types/tsconfig.json",
+    "test:accept": "npm run build && jest --u",
     "prepublishOnly": "npm run build"
   },
   "husky": {
@@ -72,6 +76,7 @@
     "timsort": "^0.3.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.17.6",
     "@babel/plugin-syntax-jsx": "^7.16.7",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/sandbox/in.js
+++ b/sandbox/in.js
@@ -1,0 +1,22 @@
+/**
+ * Twin Sandbox
+ * A place to test the output twin creates.
+ * Good for general testing or for development of new features.
+ *
+ * Getting started
+ * 1. Run the script: "npm run dev:demo" (or "npm run dev:demo:macro" if deving)
+ * 2. Make a change to this file
+ * 3. Check 'out.js' for the macro output
+ */
+
+// @ts-nocheck
+import tw, { globalStyles, css, styled, theme } from '../macro'
+
+// Tw block
+tw`bg-black/25`
+
+// Styled component
+tw.div`bg-black/25`
+
+// Inline tw
+;<div tw="bg-black/25" />

--- a/sandbox/in.js
+++ b/sandbox/in.js
@@ -4,7 +4,7 @@
  * Good for general testing or for development of new features.
  *
  * Getting started
- * 1. Run the script: "npm run dev:demo" (or "npm run dev:demo:macro" if deving)
+ * 1. Run the script: "npm run dev:sandbox" (or "npm run dev:macro:sandbox" if deving)
  * 2. Make a change to this file
  * 3. Check 'out.js' for the macro output
  */


### PR DESCRIPTION
This PR adds a file for testing the output of twin within the repo.
This avoids the need to clone twin-output-tester and makes it easier to contribute features to twin! 🎉 

**Using the test environment**

1. Run the script: `npm run dev:sandbox` (or `npm run dev:macro:sandbox` if deving)
2. Make a change within `sandbox/in.js`
3. Check `sandbox/out.js` for the macro output