### PR TITLE
Add border-hidden

### DIFF
--- a/__fixtures__/utilitiesBorders/borderStyle.js
+++ b/__fixtures__/utilitiesBorders/borderStyle.js
@@ -5,5 +5,5 @@ tw`border-solid`
 tw`border-dashed`
 tw`border-dotted`
 tw`border-double`
-// tw`border-hidden`
+tw`border-hidden`
 tw`border-none`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -16552,7 +16552,7 @@ tw\`border-solid\`
 tw\`border-dashed\`
 tw\`border-dotted\`
 tw\`border-double\`
-// tw\`border-hidden\`
+tw\`border-hidden\`
 tw\`border-none\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -16569,8 +16569,10 @@ tw\`border-none\`
 })
 ;({
   borderStyle: 'double',
-}) // tw\`border-hidden\`
-
+})
+;({
+  borderStyle: 'hidden',
+})
 ;({
   borderStyle: 'none',
 })

--- a/src/config/corePlugins.js
+++ b/src/config/corePlugins.js
@@ -927,6 +927,7 @@ export default {
   'border-dashed': { output: { borderStyle: 'dashed' } },
   'border-dotted': { output: { borderStyle: 'dotted' } },
   'border-double': { output: { borderStyle: 'double' } },
+  'border-hidden': { output: { borderStyle: 'hidden' } },
   'border-none': { output: { borderStyle: 'none' } },
 
   border: [


### PR DESCRIPTION
This PR adds the missing border hidden class:

```js
tw`border-hidden`

// ↓ ↓ ↓ ↓ ↓ ↓

({  borderStyle: 'hidden' })
```