### PR TITLE
Add unsupported plugin feedback

### DIFF
--- a/src/config/twinConfig.js
+++ b/src/config/twinConfig.js
@@ -9,12 +9,14 @@ const configDefaultsStitches = {
 }
 
 const configDefaultsTwin = ({ isGoober, isStitches, isDev }) => ({
+  allowUnsupportedPlugins: false, // Allow plugins to use an unsupported API function, eg: addVariant()
   allowStyleProp: false, // Allows styles within style="blah" without throwing an error
   autoCssProp: false, // Deprecated since v2.8.2
   dataTwProp: isDev, // During development, add a data-tw="" prop containing your tailwind classes for backtracing
   hasSuggestions: true, // Switch suggestions on/off when you use a tailwind class that's not found
   sassyPseudo: false, // Sets selectors like hover to &:hover
   debug: false, // Show the output of the classes twin converts
+  debugPlugins: false, // Display generated class information from your plugins
   includeClassNames: false, // Look in the className props for tailwind classes to convert
   dataCsProp: isDev, // During development, add a data-cs="" prop containing your short css classes for backtracing
   disableCsProp: false, // Disable converting css styles in the cs prop

--- a/src/logging.js
+++ b/src/logging.js
@@ -74,7 +74,7 @@ const logBadGood = (bad, good) =>
     : logGeneralError(bad)
 
 const logErrorFix = (error, good) =>
-  `${color.error(error)}\n${color.success('Fix:')} ${good}`
+  spaced(`${color.error(error)}\n${color.success('Fix:')} ${good}`)
 
 const logGeneralError = error => spaced(warning(error))
 
@@ -245,11 +245,9 @@ const logNotFoundVariant = ({ classNameRaw }) =>
 
 const logNotFoundClass = logGeneralError('That class was not found')
 
-const logStylePropertyError = spaced(
-  logErrorFix(
-    'Styles shouldn’t be added within a `style={...}` prop',
-    'Use the tw or css prop instead: <div tw="" /> or <div css={tw``} />\n\nDisable this error by adding this in your twin config: `{ "allowStyleProp": true }`\nRead more at https://twinredirect.page.link/style-prop'
-  )
+const logStylePropertyError = logErrorFix(
+  'Styles shouldn’t be added within a `style={...}` prop',
+  'Use the tw or css prop instead: <div tw="" /> or <div css={tw``} />\n\nDisable this error by adding this in your twin config: `{ "allowStyleProp": true }`\nRead more at https://twinredirect.page.link/style-prop'
 )
 
 const debug = state => message => {
@@ -453,6 +451,12 @@ const getSuggestions = args => {
   return matches.slice(0, 5)
 }
 
+const getUnsupportedError = feature =>
+  logErrorFix(
+    `A plugin is trying to use the unsupported “${feature}” function`,
+    `Either remove the plugin or add this in your twin config: \`{ "allowUnsupportedPlugins": true }\``
+  )
+
 export {
   logNoVariant,
   logNotAllowed,
@@ -467,4 +471,5 @@ export {
   errorSuggestions,
   opacityErrorNotFound,
   themeErrorNotFound,
+  getUnsupportedError,
 }

--- a/src/macro.js
+++ b/src/macro.js
@@ -105,7 +105,7 @@ const twinMacro = args => {
   state.tailwindConfigIdentifier = generateUid('tailwindConfig', program)
   state.tailwindUtilsIdentifier = generateUid('tailwindUtils', program)
 
-  state.userPluginData = getUserPluginData({ config: state.config })
+  state.userPluginData = getUserPluginData({ config: state.config, configTwin })
   isDev &&
     Boolean(config.debugPlugins) &&
     state.userPluginData &&

--- a/src/utils/getUserPluginData.js
+++ b/src/utils/getUserPluginData.js
@@ -185,7 +185,7 @@ const getUserPluginRules = (rules, screens, isBase) =>
     })
   }, {})
 
-const getUserPluginData = ({ config }) => {
+const getUserPluginData = ({ config, configTwin }) => {
   if (!config.plugins || config.plugins.length === 0) {
     return
   }
@@ -193,6 +193,7 @@ const getUserPluginData = ({ config }) => {
   const context = {
     candidateRuleMap: new Map(),
     tailwindConfig: config,
+    configTwin,
   }
 
   const pluginApi = buildPluginApi(config, context)

--- a/src/utils/pluginApi.js
+++ b/src/utils/pluginApi.js
@@ -6,6 +6,8 @@ import transformThemeValue from 'tailwindcss/lib/util/transformThemeValue'
 import parseObjectStyles from 'tailwindcss/lib/util/parseObjectStyles'
 import isPlainObject from 'tailwindcss/lib/util/isPlainObject'
 import { toPath } from 'tailwindcss/lib/util/toPath'
+import { throwIf } from './index'
+import { getUnsupportedError } from '../logging'
 
 export default function buildPluginApi(tailwindConfig, context) {
   function getConfigValue(path, defaultValue) {
@@ -24,9 +26,13 @@ export default function buildPluginApi(tailwindConfig, context) {
     return context.tailwindConfig.prefix + identifier
   }
 
+  const { allowUnsupportedPlugins } = context.configTwin
+
   return {
     addVariant() {
-      // Unavailable in twin
+      throwIf(!allowUnsupportedPlugins, () =>
+        getUnsupportedError('addVariant()')
+      )
       return null
     },
     postcss,
@@ -41,13 +47,20 @@ export default function buildPluginApi(tailwindConfig, context) {
       )
       return transformThemeValue(pathRoot)(value)
     },
-    corePlugins: () => null, // Unavailable in twin
+    corePlugins() {
+      throwIf(!allowUnsupportedPlugins, () =>
+        getUnsupportedError('corePlugins()')
+      )
+      return null
+    },
     variants() {
       // Preserved for backwards compatibility but not used in v3.0+
       return []
     },
     addUserCss() {
-      // Unavailable in twin
+      throwIf(!allowUnsupportedPlugins, () =>
+        getUnsupportedError('addUserCss()')
+      )
       return null
     },
     addBase(base) {
@@ -64,7 +77,9 @@ export default function buildPluginApi(tailwindConfig, context) {
       }
     },
     addDefaults() {
-      // Unavailable in twin
+      throwIf(!allowUnsupportedPlugins, () =>
+        getUnsupportedError('addDefaults()')
+      )
       return null
     },
     addComponents(components, options) {


### PR DESCRIPTION
This PR adds errors when a plugin tries to use an unsupported API function.
I decided it's best to alert the user immediately to avoid them finding out the plugin isn't working later on.

Here's the error that displays: 

```shell
A plugin is trying to use the unsupported “addVariant()” function
Fix: Either remove the plugin or add this in your twin config: `{ "allowUnsupportedPlugins": true }`
```