### PR TITLE
Replace theme values in short css

### DIFF
--- a/__fixtures__/shortCss.js
+++ b/__fixtures__/shortCss.js
@@ -56,3 +56,6 @@ tw`padding[
     calc((2em * -1) +
     var(--myVar))
 ]`
+
+// Theme value
+tw`--color[theme(colors.red.500)]`

--- a/__fixtures__/shortCss.js
+++ b/__fixtures__/shortCss.js
@@ -59,3 +59,4 @@ tw`padding[
 
 // Theme value
 tw`--color[theme(colors.red.500)]`
+tw`--color[this theme(colors.red.500) that]`

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -49720,6 +49720,7 @@ tw\`padding[
 
 // Theme value
 tw\`--color[theme(colors.red.500)]\`
+tw\`--color[this theme(colors.red.500) that]\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -49939,6 +49940,9 @@ tw\`--color[theme(colors.red.500)]\`
 
 ;({
   '--color': '#ef4444',
+})
+;({
+  '--color': 'this #ef4444 that',
 })
 
 

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -49718,6 +49718,9 @@ tw\`padding[
     var(--myVar))
 ]\`
 
+// Theme value
+tw\`--color[theme(colors.red.500)]\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 ;<div
@@ -49932,6 +49935,10 @@ tw\`padding[
 })
 ;({
   padding: 'calc((2em * -1) + var(--myVar))',
+}) // Theme value
+
+;({
+  '--color': '#ef4444',
 })
 
 

--- a/src/handlers/shortCss.js
+++ b/src/handlers/shortCss.js
@@ -1,7 +1,8 @@
 import { throwIf, camelize, splitOnFirst } from '../utils'
 import { logBadGood } from '../logging'
+import { replaceThemeValue } from './helpers'
 
-export default ({ className }) => {
+export default ({ className, theme }) => {
   let [property, value] = splitOnFirst(className, '[')
 
   property =
@@ -18,5 +19,7 @@ export default ({ className }) => {
     )
   )
 
-  return { [property]: value }
+  const themeReplacedValue = replaceThemeValue(value, { theme })
+
+  return { [property]: themeReplacedValue }
 }


### PR DESCRIPTION
This PR adds the ability to use a value from our `tailwind.config.js` within short css.

This feature can be used to quickly set css variables:

```js
tw`--color-primary[theme('colors.red.500')]`

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "--color-primary": "#ef4444"
});
```

Worth mentioning is that in `twin.macro@rc.1+` we can also use the theme value with normal tailwind classes:

```js
tw`text-[theme('colors.red.500')]`

// Works with slash opacity too:
tw`bg-[theme('colors.red.500')]/25`
tw`bg-[theme('colors.red.500')]/[.25]`
```