### PR TITLE
Negative config key match fix

### DIFF
--- a/__fixtures__/negative/negative.js
+++ b/__fixtures__/negative/negative.js
@@ -1,0 +1,5 @@
+import tw from './macro'
+
+tw`-z-1`
+tw`-z-10`
+tw`-inset-10`

--- a/__fixtures__/negative/tailwind.config.js
+++ b/__fixtures__/negative/tailwind.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  theme: { extend: { zIndex: { '-1': '-1' } } },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -35576,6 +35576,32 @@ tw\`mix-blend-luminosity\`
 
 `;
 
+exports[`twin.macro negative.js: negative.js 1`] = `
+
+import tw from './macro'
+
+tw\`-z-1\`
+tw\`-z-10\`
+tw\`-inset-10\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  zIndex: '1',
+})
+;({
+  zIndex: '-10',
+})
+;({
+  top: '-2.5rem',
+  right: '-2.5rem',
+  bottom: '-2.5rem',
+  left: '-2.5rem',
+})
+
+
+`;
+
 exports[`twin.macro objectFit.js: objectFit.js 1`] = `
 
 import tw from './macro'

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -37,11 +37,13 @@ export default props => {
   const { theme, pieces, state, corePluginName, coreConfig } = props
   const { classNameRaw, className, classNameNoSlashAlpha } = pieces
 
+  const configSearch = []
   const classNameValue = className.slice(Number(corePluginName.length) + 1)
-  const configSearch = [classNameValue]
 
   // Search config for a negative valued key, eg: `zIndex: { "-1": "-1" }`
   if (pieces.hasNegative) configSearch.push(`-${classNameValue}`)
+
+  configSearch.push(classNameValue)
 
   // Search config for a slash, eg: `h-1/5`
   if (className !== classNameNoSlashAlpha)

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -37,9 +37,13 @@ export default props => {
   const { theme, pieces, state, corePluginName, coreConfig } = props
   const { classNameRaw, className, classNameNoSlashAlpha } = pieces
 
-  const configSearch = [className.slice(Number(corePluginName.length) + 1)]
+  const classNameValue = className.slice(Number(corePluginName.length) + 1)
+  const configSearch = [classNameValue]
 
-  // eg: names including a slash, eg: h-1/5
+  // Search config for a negative valued key, eg: `zIndex: { "-1": "-1" }`
+  if (pieces.hasNegative) configSearch.push(`-${classNameValue}`)
+
+  // Search config for a slash, eg: `h-1/5`
   if (className !== classNameNoSlashAlpha)
     configSearch.push(
       classNameNoSlashAlpha.slice(Number(corePluginName.length) + 1)


### PR DESCRIPTION
This PR fixes a regression matching keys with a negative value.

A config like this will now match correctly:

```js
// tailwind.config.js
module.exports = {
  theme: {
    zIndex: {
      '-1': '-1',
    },
  },
};
``` 

```js
tw`-z-1` // 👍
```


Fixes #680 