### PR TITLE
Fix `border-y` property

### DIFF
--- a/__fixtures__/negative/negative.js
+++ b/__fixtures__/negative/negative.js
@@ -1,0 +1,5 @@
+import tw from './macro'
+
+tw`-z-1`
+tw`-z-10`
+tw`-inset-10`

--- a/__fixtures__/negative/tailwind.config.js
+++ b/__fixtures__/negative/tailwind.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  theme: { extend: { zIndex: { '-1': '-1' } } },
+}

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -35576,6 +35576,32 @@ tw\`mix-blend-luminosity\`
 
 `;
 
+exports[`twin.macro negative.js: negative.js 1`] = `
+
+import tw from './macro'
+
+tw\`-z-1\`
+tw\`-z-10\`
+tw\`-inset-10\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+;({
+  zIndex: '1',
+})
+;({
+  zIndex: '-10',
+})
+;({
+  top: '-2.5rem',
+  right: '-2.5rem',
+  bottom: '-2.5rem',
+  left: '-2.5rem',
+})
+
+
+`;
+
 exports[`twin.macro objectFit.js: objectFit.js 1`] = `
 
 import tw from './macro'

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -16681,24 +16681,24 @@ tw\`border-[length:10px]\`
   borderRightWidth: '1px',
 })
 ;({
-  borderTopColor: '0px',
-  borderBottomColor: '0px',
+  borderTopWidth: '0px',
+  borderBottomWidth: '0px',
 })
 ;({
-  borderTopColor: '2px',
-  borderBottomColor: '2px',
+  borderTopWidth: '2px',
+  borderBottomWidth: '2px',
 })
 ;({
-  borderTopColor: '4px',
-  borderBottomColor: '4px',
+  borderTopWidth: '4px',
+  borderBottomWidth: '4px',
 })
 ;({
-  borderTopColor: '8px',
-  borderBottomColor: '8px',
+  borderTopWidth: '8px',
+  borderBottomWidth: '8px',
 })
 ;({
-  borderTopColor: '1px',
-  borderBottomColor: '1px',
+  borderTopWidth: '1px',
+  borderBottomWidth: '1px',
 })
 ;({
   borderTopWidth: '0px',
@@ -16786,8 +16786,8 @@ tw\`border-[length:10px]\`
   borderRightWidth: '10px',
 })
 ;({
-  borderTopColor: '10px',
-  borderBottomColor: '10px',
+  borderTopWidth: '10px',
+  borderBottomWidth: '10px',
 })
 ;({
   borderWidth: '10px',

--- a/src/config/corePlugins.js
+++ b/src/config/corePlugins.js
@@ -978,10 +978,10 @@ export default {
       config: 'borderWidth',
       coerced: {
         'line-width': {
-          property: ['borderTopColor', 'borderBottomColor'],
+          property: ['borderTopWidth', 'borderBottomWidth'],
         },
         length: {
-          property: ['borderTopColor', 'borderBottomColor'],
+          property: ['borderTopWidth', 'borderBottomWidth'],
         },
       },
     },

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -37,11 +37,13 @@ export default props => {
   const { theme, pieces, state, corePluginName, coreConfig } = props
   const { classNameRaw, className, classNameNoSlashAlpha } = pieces
 
+  const configSearch = []
   const classNameValue = className.slice(Number(corePluginName.length) + 1)
-  const configSearch = [classNameValue]
 
   // Search config for a negative valued key, eg: `zIndex: { "-1": "-1" }`
   if (pieces.hasNegative) configSearch.push(`-${classNameValue}`)
+
+  configSearch.push(classNameValue)
 
   // Search config for a slash, eg: `h-1/5`
   if (className !== classNameNoSlashAlpha)

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -37,9 +37,13 @@ export default props => {
   const { theme, pieces, state, corePluginName, coreConfig } = props
   const { classNameRaw, className, classNameNoSlashAlpha } = pieces
 
-  const configSearch = [className.slice(Number(corePluginName.length) + 1)]
+  const classNameValue = className.slice(Number(corePluginName.length) + 1)
+  const configSearch = [classNameValue]
 
-  // eg: names including a slash, eg: h-1/5
+  // Search config for a negative valued key, eg: `zIndex: { "-1": "-1" }`
+  if (pieces.hasNegative) configSearch.push(`-${classNameValue}`)
+
+  // Search config for a slash, eg: `h-1/5`
   if (className !== classNameNoSlashAlpha)
     configSearch.push(
       classNameNoSlashAlpha.slice(Number(corePluginName.length) + 1)


### PR DESCRIPTION
This PR fixes this incorrect output when using `border-y`.

It incorrectly was doing this:

```js
tw`border-y`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "borderTopColor": "1px",
  "borderBottomColor": "1px"
});
```

When it should have been doing this:

```js
tw`border-y`;

// ↓ ↓ ↓ ↓ ↓ ↓

({
  "borderTopWidth": "1px",
  "borderBottomWidth": "1px"
});
```

thanks for the pickup @lukesmurray