### PR TITLE
Add opacity errors/suggestions

### DIFF
--- a/src/coerced.js
+++ b/src/coerced.js
@@ -56,7 +56,6 @@ const coercedTypeMap = {
     if (result.length === 0)
       result = properties.map(p => ({ [p]: `${value}${pieces.important}` }))
 
-    // @ts-expect-error TODO: Investigate TS error
     return deepMerge(...result)
   },
   'line-width'({ config, value, theme, output, forceReturn }) {

--- a/src/getStyleData.js
+++ b/src/getStyleData.js
@@ -1,5 +1,5 @@
 import deepMerge from 'lodash.merge'
-import { throwIf, isEmpty, getTheme } from './utils'
+import { throwIf, isEmpty, getTheme, formatProp } from './utils'
 import { getProperties } from './getProperties'
 import { astify } from './macroHelpers'
 import * as precheckExports from './prechecks'
@@ -181,7 +181,7 @@ export default (classes, args) => {
       addVariants({ results, style, pieces, state })
     )
 
-    state.debug(debugSuccess(classNameRaw, style))
+    state.debug(debugSuccess(formatProp(classNameRaw), style))
 
     classesMatched.push(classNameRaw)
     return result

--- a/src/macro/debug.js
+++ b/src/macro/debug.js
@@ -91,4 +91,4 @@ const addDataPropToExistingPath = ({
   )
 }
 
-export { formatProp, addDataTwPropToPath, addDataPropToExistingPath }
+export { addDataTwPropToPath, addDataPropToExistingPath }

--- a/src/utils/alpha.js
+++ b/src/utils/alpha.js
@@ -8,15 +8,23 @@ const buildStyleSet = (property, color, pieces) => {
   return { [property]: value }
 }
 
-const maybeAddAlpha = (value, { pieces, variable = '' }) =>
-  typeof value === 'function' ||
-  (pieces.alpha && typeof value === 'string' && color(value))
-    ? toAlpha({ pieces, variable, property: undefined })(
-        value,
-        pieces.alpha,
-        value
-      )
-    : value
+const maybeAddAlpha = (value, { matchedConfig, pieces, variable = '' }) => {
+  const isAlphable =
+    typeof value === 'function' ||
+    (pieces.alpha && typeof value === 'string' && color(value))
+
+  if (!isAlphable) {
+    const hasIssue = pieces.hasAlpha && !matchedConfig.includes('/')
+    if (hasIssue) return
+    return value
+  }
+
+  return toAlpha({ pieces, variable, property: undefined })(
+    value,
+    pieces.alpha,
+    value
+  )
+}
 
 const toAlpha =
   ({ pieces, property, variable }) =>

--- a/src/utils/getConfigValue.js
+++ b/src/utils/getConfigValue.js
@@ -30,7 +30,7 @@ const splitAtDash = (twClass, fromEnd = 1) => {
  */
 const getConfigValue = (from, matcher) => {
   const matchArray = toArray(matcher)
-  const [result] = getFirstValue(matchArray, match =>
+  const result = getFirstValue(matchArray, match =>
     getValueFromConfig(from, match)
   )
   return result
@@ -62,8 +62,11 @@ const getValueFromConfig = (from, matcher) => {
   const [result] = getFirstValue(matcher.split('-'), (_, { index }) => {
     const { firstPart, lastPart } = splitAtDash(matcher, Number(index) + 1)
     const objectMatch = from[firstPart]
-    if (objectMatch && typeof objectMatch === 'object')
-      return getConfigValue(objectMatch, lastPart)
+
+    if (objectMatch && typeof objectMatch === 'object') {
+      const [value] = getConfigValue(objectMatch, lastPart) || []
+      return value
+    }
   })
 
   return result


### PR DESCRIPTION
This PR adds some helpful errors when:

- An opacity is used on a non-color class 
- An opacity is used that doesn't exist in your opacity config