### PR TITLE
Fix spreadVariantGroups regex

### DIFF
--- a/src/variants.js
+++ b/src/variants.js
@@ -102,7 +102,7 @@ function spreadVariantGroups(
   classes = classes.slice(start, end).trim()
 
   // variant / class / group
-  const reg = /(\[.*?]:|[\w-<>]+:)|([\w-./[\]]+!?)|\(|(\S+)/g
+  const reg = /(\[.*?]:|[\w-<>]+:)|(!?[\w-./[\]]+!?)|\(|(\S+)/g
 
   let match
   const baseContext = context


### PR DESCRIPTION
Typically Tailwind detects '!' before class name and after all variants.

> The ! always goes at the beginning of the utility name, after any variants, but before any prefix:

> ``` html
> <div class="sm:hover:!tw-font-bold">
> ```

But twin just detect '!' at the end of class name.So lets compare the output of two same twin classes:

input:

```javascript
tw`sm:block! sm:hover:block`
```

output:

```javascript
({
  "@media (min-width: 640px)": {
    "display": "block !important",
    ":hover": {
      "display": "block"
    }
  }
});
```

and 

input:

```javascript
tw`sm:!block sm:hover:block`
```

output:
```javascript
({
  "@media (min-width: 640px)": {
    "display": "block !important",
    "@media (min-width: 640px)": {
      ":hover": {
        "display": "block"
      }
    }
  }
});
```

so in order to twin works in both situation we must change regex at `spreadVariantGroups  ` a little bit!