### PR TITLE
Support arrays for fontSize values

### DIFF
--- a/__fixtures__/utiltiesTypography/fontSize.js
+++ b/__fixtures__/utiltiesTypography/fontSize.js
@@ -19,3 +19,6 @@ tw`text-9xl`
 
 tw`text-[2.23rem]`
 tw`text-[length:var(--font-size)]`
+
+tw`text-arraystring`
+tw`text-arrayobject`

--- a/__fixtures__/utiltiesTypography/tailwind.config.js
+++ b/__fixtures__/utiltiesTypography/tailwind.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   theme: {
     extend: {
+      // https://tailwindcss.com/docs/font-size#providing-a-default-line-height
+      fontSize: {
+        arraystring: ['0.875rem', '1.5'],
+        arrayobject: ['0.875rem', { lineHeight: '2rem', color: 'red' }],
+      },
       colors: {
         'red-500/fromConfig': '#000',
         electric: ({ opacityVariable, opacityValue }) => {

--- a/__snapshots__/plugin.test.js.snap
+++ b/__snapshots__/plugin.test.js.snap
@@ -20586,7 +20586,7 @@ tw\`font-customFontWeightAsNumber\`
   color: '0',
 })
 ;({
-  color: 'blue, purple, orange',
+  color: 'blue,purple,orange',
 })
 ;({
   '--tw-text-opacity': '1',
@@ -20621,7 +20621,7 @@ tw\`font-customFontWeightAsNumber\`
   backgroundColor: '0',
 })
 ;({
-  backgroundColor: 'blue, purple, orange',
+  backgroundColor: 'blue,purple,orange',
 })
 ;({
   '--tw-bg-opacity': '1',
@@ -25616,6 +25616,9 @@ tw\`text-9xl\`
 tw\`text-[2.23rem]\`
 tw\`text-[length:var(--font-size)]\`
 
+tw\`text-arraystring\`
+tw\`text-arrayobject\`
+
       ↓ ↓ ↓ ↓ ↓ ↓
 
 // https://tailwindcss.com/docs/font-size
@@ -25698,6 +25701,14 @@ tw\`text-[length:var(--font-size)]\`
       lineHeight: '1',
     },
   ],
+  arraystring: ['0.875rem', '1.5'],
+  arrayobject: [
+    '0.875rem',
+    {
+      lineHeight: '2rem',
+      color: 'red',
+    },
+  ],
 })
 ;({
   fontSize: '0.75rem',
@@ -25756,6 +25767,15 @@ tw\`text-[length:var(--font-size)]\`
 })
 ;({
   fontSize: 'var(--font-size)',
+})
+;({
+  fontSize: '0.875rem',
+  lineHeight: '1.5',
+})
+;({
+  fontSize: '0.875rem',
+  lineHeight: '2rem',
+  color: 'red',
 })
 
 

--- a/src/coerced.js
+++ b/src/coerced.js
@@ -204,13 +204,24 @@ const getCoercedValueFromTypeMap = (type, context) => {
   }
 
   let extraStyles
-  if (Array.isArray(context.value)) {
+
+  if (type === 'family-name' && Array.isArray(context.value)) {
+    context.value = context.value.join(', ')
+  }
+
+  if (
+    context.configKey &&
+    context.configKey === 'fontSize' &&
+    Array.isArray(context.value)
+  ) {
     const [value, ...rest] = context.value
-    if (rest.length === 1 && isObject(rest[0])) {
-      extraStyles = rest[0]
+    if (rest.length === 1) {
       context.value = value
-    } else {
-      context.value = context.value.join(', ')
+      // fontSize: { base: ['0.875rem', { lineHeight: '2em' }]}
+      extraStyles =
+        (isObject(rest[0]) && rest[0]) ||
+        // fontSize: { base: ['0.875rem', '1.5']}
+        (typeof value === 'string' && { lineHeight: rest[0] })
     }
   }
 

--- a/src/handlers/dynamic.js
+++ b/src/handlers/dynamic.js
@@ -9,22 +9,20 @@ import { supportsArbitraryValues } from './../configHelpers'
 import { getCoercedValueFromTypeMap } from './../coerced'
 import { maybeAddNegative } from './helpers'
 
-const getDynamicStyle = (
-  config,
-  { matchedConfig, classValue, theme, pieces }
-) => {
+const getDynamicStyle = (c, { matchedConfig, classValue, theme, pieces }) => {
   // Array values loop over cooerced object - { coerced: { color: () => {}, length () => {} } }
-  if (config.coerced) {
+  if (c.coerced) {
     const coerced = ([type, config], forceReturn) =>
       getCoercedValueFromTypeMap(type, {
         value: classValue,
+        configKey: c.config,
         config,
         pieces,
         theme,
         forceReturn,
       })
     const [result] = getFirstValue(
-      Object.entries(config.coerced),
+      Object.entries(c.coerced),
       (type, { isLast }) => coerced(type, isLast)
     )
     return result
@@ -41,11 +39,11 @@ const getDynamicStyle = (
     opacityErrorNotFound({ className: pieces.classNameRaw })
   )
 
-  return Array.isArray(config.property)
+  return Array.isArray(c.property)
     ? // FIXME: Remove comment and fix next line
       // eslint-disable-next-line unicorn/prefer-object-from-entries
-      config.property.reduce((result, p) => ({ ...result, [p]: value }), {})
-    : { [config.property]: value }
+      c.property.reduce((result, p) => ({ ...result, [p]: value }), {})
+    : { [c.property]: value }
 }
 
 export default props => {


### PR DESCRIPTION
This PR adds support for arrays used for fontSize values:

```js
module.exports = {
  theme: {
    fontSize: {
      sm: ['14px', '20px'], // if second value is a string then it will be used as the lineHeight
      base: ['16px', {
        lineHeight: '24px', // if second value is a object it will be merged
      }],
    }
  }
}
```

This behaviour is now synced with [tailwind font size values](https://tailwindcss.com/docs/font-size#providing-a-default-line-height).