### PR TITLE
allow omitting DEFAULT when using theme

### DIFF
--- a/src/core/lib/util/replaceThemeValue.ts
+++ b/src/core/lib/util/replaceThemeValue.ts
@@ -17,7 +17,7 @@ function replaceThemeValue(
   const themeParameters = match[1].replace(MATCH_QUOTES, '').trim()
 
   const [main, second] = themeParameters.split(',')
-  const themeValue = theme(main, second)
+  let themeValue = theme(main, second)
 
   assert(Boolean(themeValue), ({ color }: AssertContext) =>
     color(
@@ -28,7 +28,13 @@ function replaceThemeValue(
     )
   )
 
+  // Account for the 'DEFAULT' key
+  if (typeof themeValue === 'object' && 'DEFAULT' in themeValue) {
+    themeValue = themeValue.DEFAULT as typeof themeValue
+  }
+
   const replacedValue = value.replace(themeFunction, String(themeValue))
+
   return replacedValue
 }
 

--- a/tests/arbitraryValues.test.ts
+++ b/tests/arbitraryValues.test.ts
@@ -194,6 +194,38 @@ it('reads theme values in arbitrary values (with quotes) when inside calc or sim
   })
 })
 
+it('should allow omitting the DEFAULT key when using theme', async () => {
+  const input = 'tw`bg-[theme(colors.black)]`'
+  const config = {
+    theme: { colors: { black: { DEFAULT: '#111111', pure: '#000000 ' } } },
+  }
+
+  return run(input, config).then(result => {
+    expect(result).toMatchFormattedJavaScript(`
+      ({
+        "--tw-bg-opacity": "1",
+        backgroundColor: "rgb(17 17 17 / var(--tw-bg-opacity))"
+      });
+    `)
+  })
+})
+
+it('should allow using the DEFAULT key when using theme', async () => {
+  const input = 'tw`bg-[theme(colors.black.DEFAULT)]`'
+  const config = {
+    theme: { colors: { black: { DEFAULT: '#111111', pure: '#000000 ' } } },
+  }
+
+  return run(input, config).then(result => {
+    expect(result).toMatchFormattedJavaScript(`
+      ({
+        "--tw-bg-opacity": "1",
+        backgroundColor: "rgb(17 17 17 / var(--tw-bg-opacity))"
+      });
+    `)
+  })
+})
+
 it('should not output unparsable arbitrary CSS values', async () => {
   // eslint-disable-next-line no-template-curly-in-string
   const input = 'tw`w-[${sizes.width}]`'


### PR DESCRIPTION
Fixes https://github.com/ben-rogerson/twin.macro/discussions/679#discussioncomment-3998674

@ben-rogerson I wanted to prevent modifying the theme parsing function, in order to align with your comment 
> so the theme function is more predictable when it's used to grab objects from the config

That's why I added the check right before replacing the correct value to prevent it being replaced as `bg-[Object object]` instead of `bg-[#whatever]`.

Let me know if that works!