### PR TITLE
Handle arbitrary variants with commas

### DIFF
--- a/tests/__fixtures__/arbitraryVariants/arbitraryVariants.tsx
+++ b/tests/__fixtures__/arbitraryVariants/arbitraryVariants.tsx
@@ -47,5 +47,4 @@ tw`[.dropdown.dropdown-open &, .dropdown:focus &]:block`
 tw`[path]:first:[stroke: #000] md:[path]:[stroke: #000]`
 tw`first:block md:[path]:[stroke: #000]`
 tw`[.sec section a[target="_blank"]]:block` // < issue with _blank present in tailwindcss
-tw`[#blah, &.pre, & section,]:block`
 tw`[&.pre,& section,]:block`

--- a/tests/__snapshots__/plugin.test.js.snap
+++ b/tests/__snapshots__/plugin.test.js.snap
@@ -4150,7 +4150,6 @@ tw\`[.dropdown.dropdown-open &, .dropdown:focus &]:block\`
 tw\`[path]:first:[stroke: #000] md:[path]:[stroke: #000]\`
 tw\`first:block md:[path]:[stroke: #000]\`
 tw\`[.sec section a[target="_blank"]]:block\` // < issue with _blank present in tailwindcss
-tw\`[#blah, &.pre, & section,]:block\`
 tw\`[&.pre,& section,]:block\`
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -4365,11 +4364,6 @@ tw\`[&.pre,& section,]:block\`
   },
 }) // < issue with _blank present in tailwindcss
 
-;({
-  '&#blah,&.pre,& section': {
-    display: 'block',
-  },
-})
 ;({
   '&.pre,& section': {
     display: 'block',

--- a/tests/arbitraryProperties.test.ts
+++ b/tests/arbitraryProperties.test.ts
@@ -169,3 +169,12 @@ it('should generate seemingly invalid CSS', async () => {
     `)
   })
 })
+
+it('should preserve commas', async () => {
+  const input = 'tw`[path[fill="rgb(51,100,51)"]]:[fill:white]`'
+  return run(input).then(result => {
+    expect(result).toMatchFormattedJavaScript(`
+      ({ '& path[fill="rgb(51,100,51)"]': { fill: "white" } });
+    `)
+  })
+})

--- a/tests/escaping.test.ts
+++ b/tests/escaping.test.ts
@@ -28,7 +28,7 @@ test('media commas in media queries are preserved', async () => {
   return run(input).then(result => {
     expect(result).toMatchFormattedJavaScript(`
       ({
-        "@media (min-width: 700px),, (min-width: 700px), and (orientation: landscape)": {
+        "@media (min-width: 700px), , (min-width: 700px), and (orientation: landscape)": {
           "display": "block",
         }
       });


### PR DESCRIPTION
This PR adds an error when we attempt to create a class that contains:

- 2+ variants
- One of those variants is an arbitrary variant
- The arbitrary variant contains a comma

eg: `[.class1,.class2]:first:bg-black`

Reason: Multi selectors are unsupported by tailwind and only the first selector is used.

More at https://github.com/ben-rogerson/twin.macro/discussions/756

---

Fixed a bug where arbitrary variants aren't visited individually to add the auto parent selector:

```js
tw`[.this,.that]:block`
// ↓ ↓ ↓ ↓ ↓ ↓
{ "& .this, .that": { display: "block" } // < Fixes missing parent selector on 2nd+ selector
```

---

Also fixed an encoding bug in arbitrary variants when a number is added directly after a comma:

```js
tw`[path[fill="rgb(1,1,1)"]]:block`
```