### PR TITLE
Add option to move keyframes to global styles

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
   ],
   ignorePatterns: [
     '/tests/plugin.test.js',
+    '/tests/stitches.config.js',
     '/tests/__fixtures__',
     '/types/macro.d.ts',
     '/types',

--- a/docs/options.md
+++ b/docs/options.md
@@ -4,19 +4,20 @@
 
 These options are available in your [twin config](#twin-config-location):
 
-| Name              | Default                | Description                                                                                                                                                                                                                                   |
-| ----------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| config            | `"tailwind.config.js"` | The path to your Tailwind config. Also takes a config object.                                                                                                                                                                                 |
-| preset            | `"emotion"`            | The css-in-js library behind the scenes.<br>Also supported: `"styled-components"` `"goober"` `"stitches"`                                                                                                                                     |
-| dataTwProp        | `true`                 | Add a prop to jsx components in development showing the original tailwind classes.<br/> Use `"all"` to keep the prop in production.                                                                                                           |
-| debug             | `false`                | Display information in your terminal about the Tailwind class conversions.                                                                                                                                                                    |
-| disableShortCss   | `true`                 | Disable converting short css within the tw import/prop.                                                                                                                                                                                       |
-| hasLogColors      | `true`                 | Disable log colors to remove the glyphs when the color display is not supported                                                                                                                                                               |
-| includeClassNames | `false`                | Look in className props for tailwind classes to convert.                                                                                                                                                                                      |
-| dataCsProp        | `true`                 | Add a prop to your elements in development so you can see the original cs prop classes, eg: `<div data-cs="maxWidth[1em]" />`.                                                                                                                |
-| disableCsProp     | `true`                 | Disable twin from reading values specified in the cs prop.                                                                                                                                                                                    |
-| sassyPseudo       | `false`                | Some css-in-js frameworks require the `&` in selectors like `&:hover`, this option ensures it’s added.                                                                                                                                        |
-| autoCssProp       | _deprecated in v2.8.2_ | `styled-components` only: Used to add an import of 'styled-components/macro' which automatically adds the styled-components css prop. Here’s how to [setup the new styled-components css prop](https://twinredirect.page.link/auto-css-prop). |
+| Name                        | Default                | Description                                                                                                                                                                                                                                   |
+| --------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config                      | `"tailwind.config.js"` | The path to your Tailwind config. Also takes a config object.                                                                                                                                                                                 |
+| preset                      | `"emotion"`            | The css-in-js library behind the scenes.<br>Also supported: `"styled-components"` `"goober"` `"stitches"`                                                                                                                                     |
+| dataTwProp                  | `true`                 | Add a prop to jsx components in development showing the original tailwind classes.<br/> Use `"all"` to keep the prop in production.                                                                                                           |
+| debug                       | `false`                | Display information in your terminal about the Tailwind class conversions.                                                                                                                                                                    |
+| disableShortCss             | `true`                 | Disable converting short css within the tw import/prop.                                                                                                                                                                                       |
+| hasLogColors                | `true`                 | Disable log colors to remove the glyphs when the color display is not supported                                                                                                                                                               |
+| includeClassNames           | `false`                | Look in className props for tailwind classes to convert.                                                                                                                                                                                      |
+| dataCsProp                  | `true`                 | Add a prop to your elements in development so you can see the original cs prop classes, eg: `<div data-cs="maxWidth[1em]" />`.                                                                                                                |
+| disableCsProp               | `true`                 | Disable twin from reading values specified in the cs prop.                                                                                                                                                                                    |
+| sassyPseudo                 | `false`                | Some css-in-js frameworks require the `&` in selectors like `&:hover`, this option ensures it’s added.                                                                                                                                        |
+| moveKeyframesToGlobalStyles | `false`                | `@keyframes` are added next to the `animation-x` classes - this option can move them to global styles instead.                                                                                                                                |
+| autoCssProp                 | _deprecated in v2.8.2_ | `styled-components` only: Used to add an import of 'styled-components/macro' which automatically adds the styled-components css prop. Here’s how to [setup the new styled-components css prop](https://twinredirect.page.link/auto-css-prop). |
 
 ### Options
 
@@ -232,6 +233,23 @@ sassyPseudo: true, // Prefix pseudo selectors with a `&`
 ```
 
 Some css-in-js frameworks require the `&` in selectors like `&:hover`, this option ensures it’s added.
+
+</details>
+
+---
+
+<details>
+
+  <summary><strong>moveKeyframesToGlobalStyles</strong></summary>
+
+<br />
+
+```js
+moveKeyframesToGlobalStyles: true, // Avoid @keyframes next to animation-x classes
+```
+
+Add `@keyframes` matching an `animation-x` class to global styles instead of alongside the `animation-x` class.<br/>
+In stitches this gets set to `true` to make animations work.
 
 </details>
 

--- a/src/core/extractRuleStyles.ts
+++ b/src/core/extractRuleStyles.ts
@@ -209,6 +209,14 @@ const ruleTypes = {
       return
     }
 
+    // Strip keyframes from animate-* classes
+    if (
+      selector.startsWith('@keyframes') &&
+      !params.passChecks &&
+      params.twinConfig.moveKeyframesToGlobalStyles
+    )
+      return
+
     if (PRESERVED_ATRULE_TYPES.has(atrule.name)) {
       params.debug(`${atrule.name} pass given`, selector)
       // Rules that pass checks have no further style transformations

--- a/src/core/getGlobalStyles.ts
+++ b/src/core/getGlobalStyles.ts
@@ -29,8 +29,26 @@ function getGlobalStyles(params: CoreContext): CssObject | undefined {
     extractRuleStyles([rule], { ...params, passChecks: true })
   )
 
-  // @ts-expect-error TOFIX: Fix tuple type error
-  return deepMerge(...preflightStyles, ...globalPluginStyles)
+  return deepMerge(
+    // @ts-expect-error TOFIX: Fix tuple type error
+    ...preflightStyles,
+    ...globalPluginStyles,
+    ...globalKeyframeStyles(params)
+  )
+}
+
+function globalKeyframeStyles(
+  params: CoreContext
+): Array<Record<string, unknown>> {
+  if (params.twinConfig.moveKeyframesToGlobalStyles === false) return []
+  const keyframes = params.theme('keyframes')
+  if (!keyframes) return []
+
+  return Object.entries(keyframes).map(
+    ([name, frames]: [string, Record<string, unknown>]) => ({
+      [`@keyframes ${name}`]: frames,
+    })
+  )
 }
 
 export default getGlobalStyles

--- a/src/core/getStyles.ts
+++ b/src/core/getStyles.ts
@@ -237,6 +237,7 @@ function getStyles(
   const commonMatchContext = {
     ...commonContext,
     includeUniversalStyles: false,
+    twinConfig: params.twinConfig,
     tailwindConfig: params.tailwindConfig,
     tailwindContext: params.tailwindContext,
     sassyPseudo: params.twinConfig.sassyPseudo,

--- a/src/core/lib/twinConfig.ts
+++ b/src/core/lib/twinConfig.ts
@@ -16,6 +16,7 @@ const TWIN_CONFIG_DEFAULTS = {
   hasLogColors: true,
   includeClassNames: false,
   moveTwPropToStyled: false,
+  moveKeyframesToGlobalStyles: false,
   preset: undefined,
   sassyPseudo: false,
   stitchesConfig: undefined,
@@ -30,6 +31,7 @@ const configDefaultsStitches = {
   moveTwPropToStyled: true, // Move the tw prop to a styled definition
   convertHtmlElementToStyled: true, // For packages like stitches, add a styled definition on css prop elements
   stitchesConfig: undefined, // Set the path to the stitches config
+  moveKeyframesToGlobalStyles: true, // Stitches doesn't support inline @keyframes
 }
 
 function configDefaultsTwin({

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -46,6 +46,7 @@ export type TwinConfigAll = {
   config?: string | Partial<TailwindConfig>
   convertStyledDot?: boolean
   moveTwPropToStyled?: boolean
+  moveKeyframesToGlobalStyles?: boolean
   convertHtmlElementToStyled?: boolean
   hasLogColors?: boolean
   stitchesConfig?: undefined
@@ -107,6 +108,7 @@ export type ExtractRuleStyles = {
   | 'tailwindConfig'
   | 'tailwindContext'
   | 'options'
+  | 'twinConfig'
 >
 
 export type TransformDecl = {

--- a/tests/__fixtures__/stitches/stitchesProps.tsx
+++ b/tests/__fixtures__/stitches/stitchesProps.tsx
@@ -18,4 +18,4 @@ const styles = {
 // Dot syntax
 const Component = { Sub: () => [] }
 ;<Component.Sub css={tw`fixed`} />
-;<Component.Sub tw="fixed" />
+;<Component.Sub tw="animate-spin" />

--- a/tests/__snapshots__/plugin.test.js.snap
+++ b/tests/__snapshots__/plugin.test.js.snap
@@ -67615,6 +67615,32 @@ const globals = global({
     '--tw-backdrop-saturate': 'var(--tw-empty,/*!*/ /*!*/)',
     '--tw-backdrop-sepia': 'var(--tw-empty,/*!*/ /*!*/)',
   },
+  '@keyframes spin': {
+    to: {
+      transform: 'rotate(360deg)',
+    },
+  },
+  '@keyframes ping': {
+    '75%, 100%': {
+      transform: 'scale(2)',
+      opacity: '0',
+    },
+  },
+  '@keyframes pulse': {
+    '50%': {
+      opacity: '.5',
+    },
+  },
+  '@keyframes bounce': {
+    '0%, 100%': {
+      transform: 'translateY(-25%)',
+      animationTimingFunction: 'cubic-bezier(0.8,0,1,1)',
+    },
+    '50%': {
+      transform: 'none',
+      animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
+    },
+  },
 })
 export function App() {
   globals() // ...
@@ -67674,7 +67700,7 @@ const styles = {
 // Dot syntax
 const Component = { Sub: () => [] }
 ;<Component.Sub css={tw\`fixed\`} />
-;<Component.Sub tw="fixed" />
+;<Component.Sub tw="animate-spin" />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -67768,7 +67794,7 @@ const _TwComponent11 = _styled(Component.Sub, {})
 />
 
 const _TwComponent12 = _styled(Component.Sub, {
-  position: 'fixed',
+  animation: 'spin 1s linear infinite',
 })
 
 ;<_TwComponent12 />

--- a/tests/stitches.config.js
+++ b/tests/stitches.config.js
@@ -1,0 +1,1 @@
+// just for show


### PR DESCRIPTION
This option moves the `@keyframes` created from `animate-x` classes to global styles.
It was added to provide support for Stitches that doesn't support inline `@keyframes`. 

Here's what global styles looks like with `{ moveKeyframesToGlobalStyles: true }` in your twin config:

```js
import { globalStyles } from "twin.macro"
globalStyles

// ↓ ↓ ↓ ↓ ↓ ↓

({
  // ...rest of global styles
  "@keyframes spin": {
    "to": {
      "transform": "rotate(360deg)"
    }
  },
  "@keyframes ping": {
    "75%, 100%": {
      "transform": "scale(2)",
      "opacity": "0"
    }
  },
  "@keyframes pulse": {
    "50%": {
      "opacity": ".5"
    }
  },
  "@keyframes bounce": {
    "0%, 100%": {
      "transform": "translateY(-25%)",
      "animationTimingFunction": "cubic-bezier(0.8,0,1,1)"
    },
    "50%": {
      "transform": "none",
      "animationTimingFunction": "cubic-bezier(0,0,0.2,1)"
    }
  }
});
```

and on the `animate-x` classes:

```js
tw`animate-bounce`

// ↓ ↓ ↓ ↓ ↓ ↓

// moveKeyframesToGlobalStyles: true
({
  "animation": "bounce 1s infinite"
});

// moveKeyframesToGlobalStyles: false (default)
({
  "@keyframes bounce": {
    "0%, 100%": {
      "transform": "translateY(-25%)",
      "animationTimingFunction": "cubic-bezier(0.8,0,1,1)"
    },
    "50%": {
      "transform": "none",
      "animationTimingFunction": "cubic-bezier(0,0,0.2,1)"
    }
  },
  "animation": "bounce 1s infinite"
});
```

closes #753 