### PR TITLE
Improved variant ordering

### DIFF
--- a/src/core/lib/convertClassName.ts
+++ b/src/core/lib/convertClassName.ts
@@ -10,6 +10,7 @@ const ALL_COMMAS = /,/g
 const ALL_AMPERSANDS = /&/g
 const ENDING_AMP_THEN_WHITESPACE = /&[\s_]*$/
 const ALL_CLASS_DOTS = /(?<!\\)(\.)(?=\w)/g
+const ALL_CLASS_ATS = /(?<!\\)(@)(?=\w)(?!media)/g
 const ALL_WRAPPABLE_PARENT_SELECTORS = /&(?=([^ $)*+,.:>[_~])[\w-])/g
 const BASIC_SELECTOR_TYPES = /^#|^\\.|[^\W_]/
 
@@ -253,6 +254,8 @@ function sassifyArbitraryVariants(
       // Unescaped dots incorrectly add the prefix within arbitrary variants (only when`prefix` is set in tailwind config)
       // eg: tw`[.a]:first:tw-block` -> `.tw-a &:first-child`
       .replace(ALL_CLASS_DOTS, '\\.')
+      // Unescaped ats will throw a conversion error
+      .replace(ALL_CLASS_ATS, '\\@')
 
     const variantList = unwrappedVariant.startsWith('@')
       ? [unwrappedVariant]

--- a/src/core/lib/convertClassName.ts
+++ b/src/core/lib/convertClassName.ts
@@ -2,12 +2,7 @@ import replaceThemeValue from './util/replaceThemeValue'
 import isShortCss from './util/isShortCss'
 import splitOnFirst from './util/splitOnFirst'
 import { splitAtTopLevelOnly } from './util/twImports'
-import type {
-  Assert,
-  AssertContext,
-  CoreContext,
-  TailwindConfig,
-} from 'core/types'
+import type { AssertContext, CoreContext, TailwindConfig } from 'core/types'
 // eslint-disable-next-line import/no-relative-parent-imports
 import { SPACE_ID, SPACES } from '../constants'
 
@@ -16,7 +11,7 @@ const ALL_AMPERSANDS = /&/g
 const ENDING_AMP_THEN_WHITESPACE = /&[\s_]*$/
 const ALL_CLASS_DOTS = /(?<!\\)(\.)(?=\w)/g
 const ALL_WRAPPABLE_PARENT_SELECTORS = /&(?=([^ $)*+,.:>[_~])[\w-])/g
-const BASIC_SELECTOR_TYPES = /^#|^\\./
+const BASIC_SELECTOR_TYPES = /^#|^\\.|[^\W_]/
 
 type ConvertShortCssToArbitraryPropertyParameters = {
   disableShortCss: CoreContext['twinConfig']['disableShortCss']
@@ -166,7 +161,7 @@ function convertClassName(
   className = replaceThemeValue(className, { assert, theme })
 
   // Add missing parent selectors and collapse arbitrary variants
-  className = sassifyArbitraryVariants(className, { assert, tailwindConfig })
+  className = sassifyArbitraryVariants(className, { tailwindConfig })
 
   debug('class after format', className)
 
@@ -183,7 +178,7 @@ function unbracket(variant: string): string {
 
 function sassifyArbitraryVariants(
   fullClassName: string,
-  { assert, tailwindConfig }: { assert: Assert; tailwindConfig: TailwindConfig }
+  { tailwindConfig }: { tailwindConfig: TailwindConfig }
 ): string {
   const splitArray = [
     ...splitAtTopLevelOnly(fullClassName, tailwindConfig.separator ?? ':'),
@@ -249,34 +244,13 @@ function sassifyArbitraryVariants(
     collapsed[collapsed.length - 1] = mergedWithPrev
   })
 
-  // Use that list to add the parent selector
-  let hasArbitraryVariant = false
-  let hasNormalVariant = false
-  const variantsWithParentSelectors = collapsed.map((v, idx) => {
-    if (!isArbitraryVariant(v)) {
-      if (idx > 0 && hasArbitraryVariant) hasNormalVariant = true
-      return v
-    }
-
-    // The ordering gets screwy in the selector when using a mix of arbitrary variants, normal variants and the auto parent feature - so notify in that case
-    const isMissingParentSelectorOkay =
-      hasArbitraryVariant && hasNormalVariant && !v.includes('&')
-    assert(
-      !isMissingParentSelectorOkay,
-      ({ color }: AssertContext) =>
-        `${color(
-          `✕ ${String(
-            color(fullClassName, 'errorLight')
-          )} had trouble with the auto parent selector feature`
-        )}\n\nYou’ll need to add the parent selector manually within the arbitrary variant(s), eg: ${String(
-          color(`[section &]:block`, 'success')
-        )}`
-    )
-
-    hasArbitraryVariant = true
+  // The supplied class requires the reversal of it's variants as resolveMatches adds them in reverse order
+  const reversedVariantList = [...collapsed].slice().reverse()
+  const allVariants = reversedVariantList.map((v, idx) => {
+    if (!isArbitraryVariant(v)) return v
 
     const unwrappedVariant = unbracket(v)
-      // Escape class dots in the selector - otherwise tailwindcss adds the prefix within arbitrary variants (only when `prefix` is set in tailwind config)
+      // Unescaped dots incorrectly add the prefix within arbitrary variants (only when`prefix` is set in tailwind config)
       // eg: tw`[.a]:first:tw-block` -> `.tw-a &:first-child`
       .replace(ALL_CLASS_DOTS, '\\.')
 
@@ -297,9 +271,7 @@ function sassifyArbitraryVariants(
     return `[${out}]`
   })
 
-  return [...variantsWithParentSelectors, className].join(
-    tailwindConfig.separator ?? ':'
-  )
+  return [...allVariants, className].join(tailwindConfig.separator ?? ':')
 }
 
 function addParentSelector(
@@ -311,18 +283,14 @@ function addParentSelector(
   if (selector.includes('&') || selector.startsWith('@')) return selector
 
   // Arbitrary variants
-  // Variants that start with a class/id get treated as a child
-  if (BASIC_SELECTOR_TYPES.test(selector) && !prev) return `& ${selector}`
   // Pseudo elements get an auto parent selector prefixed
   if (selector.startsWith(':')) return `&${selector}`
+  // Variants that start with a class/id get treated as a child
+  if (BASIC_SELECTOR_TYPES.test(selector) && !prev) return `& ${selector}`
   // When there's more than one variant and it's at the end then prefix it
   if (!next && prev) return `&${selector}`
-  // When a non arbitrary variant follows then we combine it with the current
-  // selector by adding the parent selector at the end
-  // eg: `[input&]:focus:...` -> `input:focus:...`
-  if (next && !isArbitraryVariant(next)) return `${selector}&`
 
-  return `&_${selector}`
+  return `& ${selector}`
 }
 
 export default convertClassName

--- a/src/core/lib/util/sassifySelector.ts
+++ b/src/core/lib/util/sassifySelector.ts
@@ -1,6 +1,7 @@
 import type { ExtractRuleStyles } from 'core/types'
 
 const SELECTOR_PARENT_CANDIDATE = /^[ #.[]/
+const SELECTOR_SPECIAL_STARTS = /^ [>@]/
 const SELECTOR_ROOT = /(^| ):root(?!\w)/g
 const UNDERSCORE_ESCAPING = /\\+(_)/g
 const WRAPPED_PARENT_SELECTORS = /(\({3}&(.*?)\){3})/g
@@ -62,7 +63,7 @@ const sassifySelectorTasks: SassifySelectorTasks = [
 
     // Fix: ` > :not([hidden]) ~ :not([hidden])` / ` > *`
     // Fix: `[@page]:x`
-    if (/^ [>@]/.test(selector)) return selector
+    if (SELECTOR_SPECIAL_STARTS.test(selector)) return selector
 
     return `&${selector}`
   },

--- a/src/core/lib/util/sassifySelector.ts
+++ b/src/core/lib/util/sassifySelector.ts
@@ -58,11 +58,11 @@ const sassifySelectorTasks: SassifySelectorTasks = [
     if (selector.includes('&')) return selector
 
     const addParentSelector = SELECTOR_PARENT_CANDIDATE.test(selector)
-
     if (!addParentSelector) return selector
 
-    // ` > :not([hidden]) ~ :not([hidden])` / ` > *`
-    if (selector.startsWith(' >')) return selector
+    // Fix: ` > :not([hidden]) ~ :not([hidden])` / ` > *`
+    // Fix: `[@page]:x`
+    if (/^ [>@]/.test(selector)) return selector
 
     return `&${selector}`
   },

--- a/tests/__snapshots__/plugin.test.js.snap
+++ b/tests/__snapshots__/plugin.test.js.snap
@@ -177,7 +177,7 @@ const StatePlaceholderImportant = _styled.input({
 })
 
 const StateStatePlaceholderImportant = _styled.input({
-  ':hover:active::placeholder': {
+  ':active:hover::placeholder': {
     '--tw-placeholder-opacity': '1 !important',
     color: 'rgb(239 68 68 / var(--tw-placeholder-opacity)) !important',
   },
@@ -264,7 +264,7 @@ const StatePlaceholderImportantPrefix = _styled.input({
 })
 
 const StateStatePlaceholderImportantPrefix = _styled.input({
-  ':hover:active::placeholder': {
+  ':active:hover::placeholder': {
     '--tw-placeholder-opacity': '1 !important',
     color: 'rgb(239 68 68 / var(--tw-placeholder-opacity)) !important',
   },
@@ -1222,7 +1222,7 @@ const nestedGroups = {
     display: 'inline',
     backgroundColor: 'rgb(0 0 0 / .20)',
   },
-  ':last-child:first-child': {
+  ':first-child:last-child': {
     display: 'block',
     backgroundColor: 'rgb(0 0 0 / .20)',
   },
@@ -1236,13 +1236,13 @@ const nestedGroups = {
 ;({
   '@media (min-width: 768px)': {
     marginLeft: '1rem !important',
-    one: {
+    '& one': {
       marginTop: '1.25rem !important',
     },
-    'one two': {
+    '& one two': {
       display: 'inline !important',
     },
-    'one two three': {
+    '& one two three': {
       display: 'inline !important',
     },
   },
@@ -1935,22 +1935,22 @@ tw\`xl:placeholder-red-500! first:md:block sm:disabled:flex\`
   },
 })
 ;({
-  '@media (prefers-color-scheme: dark)': {
-    '@media (min-width: 640px)': {
+  '@media (min-width: 640px)': {
+    '@media (prefers-color-scheme: dark)': {
       display: 'block',
     },
   },
 })
 ;({
-  '@media (prefers-color-scheme: light)': {
-    '@media (min-width: 640px)': {
+  '@media (min-width: 640px)': {
+    '@media (prefers-color-scheme: light)': {
       display: 'block',
     },
   },
 })
 ;({
-  '@media (prefers-color-scheme: dark)': {
-    '@media (min-width: 640px)': {
+  '@media (min-width: 640px)': {
+    '@media (prefers-color-scheme: dark)': {
       '.group:hover &': {
         display: 'block',
       },
@@ -1958,8 +1958,8 @@ tw\`xl:placeholder-red-500! first:md:block sm:disabled:flex\`
   },
 })
 ;({
-  '@media (prefers-color-scheme: light)': {
-    '@media (min-width: 640px)': {
+  '@media (min-width: 640px)': {
+    '@media (prefers-color-scheme: light)': {
       '.group:hover &': {
         display: 'block',
       },
@@ -4171,7 +4171,7 @@ tw\`[&.pre,& section,]:block\`
   },
 })
 ;({
-  'p:hover': {
+  ':hover p': {
     display: 'block',
   },
 })
@@ -4268,7 +4268,7 @@ tw\`[&.pre,& section,]:block\`
 })
 ;({
   '@media (min-width: 768px)': {
-    section: {
+    '& section': {
       display: 'block',
     },
   },
@@ -4289,32 +4289,32 @@ tw\`[&.pre,& section,]:block\`
   },
 })
 ;({
-  'section pre &:first-child': {
+  'pre section &:first-child': {
     display: 'block',
   },
 })
 ;({
-  'section & pre:first-child': {
+  'section &:first-child pre': {
     display: 'block',
   },
 })
 ;({
-  'pre section:first-child': {
+  ':first-child pre section': {
     display: 'block',
   },
 })
 ;({
-  'section pre:first-child': {
+  ':first-child section pre': {
     display: 'block',
   },
 })
 ;({
-  'section pre:first-child': {
+  ':first-child section pre': {
     marginTop: '2px',
   },
 })
 ;({
-  'section pre:first-child': {
+  ':first-child section pre': {
     display: 'inline',
   },
 })
@@ -4343,7 +4343,7 @@ tw\`[&.pre,& section,]:block\`
     stroke: '#000',
   },
   '@media (min-width: 768px)': {
-    path: {
+    '& path': {
       stroke: '#000',
     },
   },
@@ -4353,7 +4353,7 @@ tw\`[&.pre,& section,]:block\`
     display: 'block',
   },
   '@media (min-width: 768px)': {
-    path: {
+    '& path': {
       stroke: '#000',
     },
   },
@@ -58450,10 +58450,10 @@ const addUtilitiesTest2Media = {
   },
 }
 const addUtilitiesTest2Variants = {
-  ':visited:nth-child(even)': {
+  ':nth-child(even):visited': {
     transform: 'skewY(-15deg)',
   },
-  ':active:hover': {
+  ':hover:active': {
     transform: 'skewY(-15deg)',
   },
 }
@@ -58489,14 +58489,14 @@ const addComponentsTestMedia = {
   },
 }
 const addComponentsTestVariants = {
-  ':visited:nth-child(even)': {
+  ':nth-child(even):visited': {
     backgroundColor: '#e3342f',
     color: '#fff',
   },
-  ':visited:nth-child(even):hover': {
+  ':nth-child(even):visited:hover': {
     backgroundColor: '#cc1f1a',
   },
-  ':active:hover': {
+  ':hover:active': {
     padding: '.5rem 1rem',
     borderRadius: '.25rem',
     fontWeight: '600',
@@ -78440,12 +78440,12 @@ tw\`any-pointer-fine:portrait:print:dark:contrast-more:motion-safe:rtl:valid:bef
 
 // @ts-nocheck
 ;({
-  '@media (prefers-reduced-motion: no-preference)': {
-    '@media (prefers-contrast: more)': {
-      '@media (prefers-color-scheme: dark)': {
-        '@media print': {
-          '@media (orientation: portrait)': {
-            '@media (any-pointer: fine)': {
+  '@media (any-pointer: fine)': {
+    '@media (orientation: portrait)': {
+      '@media print': {
+        '@media (prefers-color-scheme: dark)': {
+          '@media (prefers-contrast: more)': {
+            '@media (prefers-reduced-motion: no-preference)': {
               '[dir="rtl"] &:valid::before': {
                 content: 'var(--tw-content)',
                 display: 'block',
@@ -78458,12 +78458,12 @@ tw\`any-pointer-fine:portrait:print:dark:contrast-more:motion-safe:rtl:valid:bef
   },
 })
 ;({
-  '@media (any-pointer: fine)': {
-    '@media (orientation: portrait)': {
-      '@media print': {
-        '@media (prefers-color-scheme: dark)': {
-          '@media (prefers-contrast: more)': {
-            '@media (prefers-reduced-motion: no-preference)': {
+  '@media (prefers-reduced-motion: no-preference)': {
+    '@media (prefers-contrast: more)': {
+      '@media (prefers-color-scheme: dark)': {
+        '@media print': {
+          '@media (orientation: portrait)': {
+            '@media (any-pointer: fine)': {
               '[dir="rtl"] &:valid::before': {
                 content: 'var(--tw-content)',
                 marginTop: '1.25rem',

--- a/tests/arbitraryProperties.test.ts
+++ b/tests/arbitraryProperties.test.ts
@@ -12,8 +12,8 @@ test('arbitrary properties with modifiers', async () => {
   return run(input).then(result => {
     expect(result).toMatchFormattedJavaScript(`
       ({
-        '@media (prefers-color-scheme: dark)': {
-          '@media (min-width: 1024px)': { ':hover': { paintOrder: 'markers' } },
+        '@media (min-width: 1024px)': {
+          '@media (prefers-color-scheme: dark)': { ':hover': { paintOrder: 'markers' } },
         },
       })  
     `)

--- a/tests/arbitraryVariants.test.ts
+++ b/tests/arbitraryVariants.test.ts
@@ -857,6 +857,15 @@ test('nested at-rules', async () => {
   })
 })
 
+test('nested at-rules 2', async () => {
+  const input = 'tw`print:[@page]:underline`'
+  return run(input).then(result => {
+    expect(result).toMatchFormattedJavaScript(`
+      ({ '@media print': { '@page': { textDecorationLine: 'underline' } } });
+    `)
+  })
+})
+
 test('multiple variants containing commas throw unsupported error', async () => {
   const input = 'tw`[.this,.that]:first:block`'
   return run(input)

--- a/tests/arbitraryVariants.test.ts
+++ b/tests/arbitraryVariants.test.ts
@@ -32,8 +32,8 @@ test('arbitrary variants with modifiers', async () => {
   return run(input).then(result => {
     expect(result).toMatchFormattedJavaScript(`
       ({
-        '@media (prefers-color-scheme: dark)': {
-          "@media (min-width: 1024px)": { "> *:hover": { textDecorationLine: "underline" } },
+        '@media (min-width: 1024px)': {
+          "@media (prefers-color-scheme: dark)": { ":hover > *": { textDecorationLine: "underline" } },
         }
       })
     `)
@@ -199,8 +199,8 @@ test('keeps escaped underscores in arbitrary variants mixed with normal variants
   ].join('; ')
   return run(input).then(result => {
     expect(result).toMatchFormattedJavaScript(`
-      ({ ':hover .foo_bar': { textDecorationLine: 'underline' } });
       ({ "& .foo_bar:hover": { textDecorationLine: "underline" } });
+      ({ ':hover .foo_bar': { textDecorationLine: 'underline' } });
     `)
   })
 })
@@ -779,9 +779,9 @@ describe('auto parent selector', () => {
     return run(input).then(result => {
       expect(result).toMatchFormattedJavaScript(`
         ({
-          "@media (min-width: 768px)": {
-            "@media (min-width: 640px)": {
-              "one": { margin: "0.25rem" },
+          "@media (min-width: 640px)": {
+            "@media (min-width: 768px)": {
+              "& one": { margin: "0.25rem" },
             }
           },
         });
@@ -820,34 +820,22 @@ describe('auto parent selector', () => {
     })
   })
 
-  test('mixed variants without parent selectors throw error', async () => {
+  test('mixed variants without parent selectors are handled', async () => {
     const input = 'tw`[one]:not-link:[two]:m-4`'
-    return run(input)
-      .then(result => {
-        expect(result).toMatchFormattedJavaScript(``)
-      })
-      .catch(error => {
-        expect(error).toMatchFormattedError(`
-          MacroError: unknown:
-
-          ✕ [one]:not-link:[two]:m-4 had trouble with the auto parent selector feature
-        `)
-      })
+    return run(input).then(result => {
+      expect(result).toMatchFormattedJavaScript(`
+        ({ "one:not(:link) two": { margin: "1rem" } });
+      `)
+    })
   })
 
-  test('mixed variants without parent selectors throw error 2', async () => {
+  test('mixed variants without parent selectors are handled 2', async () => {
     const input = 'tw`not-link:[one]:last:[two]:m-4`'
-    return run(input)
-      .then(result => {
-        expect(result).toMatchFormattedJavaScript(``)
-      })
-      .catch(error => {
-        expect(error).toMatchFormattedError(`
-          MacroError: unknown:
-
-          ✕ not-link:[one]:last:[two]:m-4 had trouble with the auto parent selector feature
-        `)
-      })
+    return run(input).then(result => {
+      expect(result).toMatchFormattedJavaScript(`
+        ({ ":not(:link) one:last-child two": { "margin": "1rem" } });
+      `)
+    })
   })
 })
 


### PR DESCRIPTION
This PR fixes the ordering of variants on multi-variant classes:

```js
tw`hover:[svg]:block`

// ↓ ↓ ↓ ↓ ↓ ↓

// Before
({ "svg:hover": { "display": "block" } });

// Now
({ ":hover svg": { "display": "block" } });
```

Thanks @u3u for the report which led me to look into this issue again - turned out an easy fix this time 🎉 

The auto-parent selector then needed a couple tweaks:
- Removed an error that asked us to add parent selectors
- Included elements as a qualifier for a `& ` (amp+space) prefix

I also fixed an error when non-media at-rules were used in arbitrary variants. (eg: `[@page]:m-0`)