### PR TITLE
fix bug of media query with object type screen and support array style screen

### DIFF
--- a/src/macro/screen.ts
+++ b/src/macro/screen.ts
@@ -101,7 +101,12 @@ function getMediaQuery({
   assert,
 }: {
   input: string
-  screens: Record<string, any>
+  screens: Record<
+    string,
+    | string
+    | { raw?: string; min?: string; max?: string }
+    | Array<{ raw?: string; min?: string; max?: string }>
+  >
   assert: CoreContext['assert']
 }): string {
   const screen = screens[input]
@@ -126,18 +131,25 @@ function getMediaQuery({
         .join('\n')}`
   )
 
-  var mediaQuery;
+  let mediaQuery
 
-  if (typeof screen === 'string') { mediaQuery= ("@media (min-width: " + screen + ")"); }
-
-  if (typeof screen.raw === 'string') {
-    mediaQuery= ("@media " + (screen.raw));
+  if (typeof screen === 'string') {
+    mediaQuery = '@media (min-width: ' + screen + ')'
+  } else if (!Array.isArray(screen) && typeof screen.raw === 'string') {
+    mediaQuery = '@media ' + screen.raw
+  } else {
+    const string = (Array.isArray(screen) ? screen : [screen])
+      .map(range =>
+        [
+          typeof range.min === 'string' ? `(min-width: ${range.min} )` : null,
+          typeof range.max === 'string' ? `(max-width: ${range.max}) ` : null,
+        ]
+          .filter(Boolean)
+          .join(' and ')
+      )
+      .join(', ')
+    mediaQuery = string ? '@media ' + string : ''
   }
-
-  var string = (Array.isArray(screen) ? screen : [screen]).map(function (range) {
-    return [typeof range.min === 'string' ? ("(min-width: " + (range.min) + ")") : null, typeof range.max === 'string' ? ("(max-width: " + (range.max) + ")") : null].filter(Boolean).join(' and ');
-  }).join(', ');
-  mediaQuery= string ? ("@media " + string) : '';
 
   // const mediaQuery = `@media (min-width: ${String(screen)})`
   return mediaQuery

--- a/src/macro/screen.ts
+++ b/src/macro/screen.ts
@@ -101,7 +101,7 @@ function getMediaQuery({
   assert,
 }: {
   input: string
-  screens: Record<string, string>
+  screens: Record<string, any>
   assert: CoreContext['assert']
 }): string {
   const screen = screens[input]
@@ -126,7 +126,20 @@ function getMediaQuery({
         .join('\n')}`
   )
 
-  const mediaQuery = `@media (min-width: ${String(screen)})`
+  var mediaQuery;
+
+  if (typeof screen === 'string') { mediaQuery= ("@media (min-width: " + screen + ")"); }
+
+  if (typeof screen.raw === 'string') {
+    mediaQuery= ("@media " + (screen.raw));
+  }
+
+  var string = (Array.isArray(screen) ? screen : [screen]).map(function (range) {
+    return [typeof range.min === 'string' ? ("(min-width: " + (range.min) + ")") : null, typeof range.max === 'string' ? ("(max-width: " + (range.max) + ")") : null].filter(Boolean).join(' and ');
+  }).join(', ');
+  mediaQuery= string ? ("@media " + string) : '';
+
+  // const mediaQuery = `@media (min-width: ${String(screen)})`
   return mediaQuery
 }
 


### PR DESCRIPTION
**Minimum Reproducible Example**
[`https://github.com/minzojian/cra-emotion`](https://github.com/minzojian/cra-emotion)
base
[`https://github.com/ben-rogerson/twin.examples/tree/master/cra-emotion`](https://github.com/ben-rogerson/twin.examples/tree/master/cra-emotion)

**Issue Details**
if i set a custom screen define like this
```
screens: {
      mobile: { max: '767px' },
      tablet: {
        min: '768px',
        max: '991px'
      },
      laptop: {
        min: '992px',
        max: '1599px'
      },
      desktop: { min: '1600px' },
    },
```
and then define css like this
```
 background: ${theme`colors.blue.500`};
    ${screen`mobile`}{
      background: ${theme`colors.red.500`}!important
    }
```
but after compiled, i got 
```
@media (min-width [object object]){
```
the correct result should be
```
@media (max-width: 767px){
```

this bug mentioned form here too
https://github.com/ben-rogerson/twin.macro/issues/433
https://github.com/ben-rogerson/twin.macro/issues/432