### PR TITLE
Add usable types for twin config

### DIFF
--- a/src/macro/twin.ts
+++ b/src/macro/twin.ts
@@ -51,7 +51,7 @@ function twinMacro(params: MacroParams): void {
 
   const coreContext = createCoreContext({
     isDev,
-    config: params.config as undefined,
+    config: params.config,
     filename: params.state.filename ?? '',
     sourceRoot: params.state.file.opts.sourceRoot ?? '',
     CustomError: MacroError as typeof Error,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,24 +60,81 @@ declare global {
 
 // Docs: https://github.com/ben-rogerson/twin.macro/blob/master/docs/options.md
 export type Config = {
+  /**
+   * The css-in-js library behind the scenes, default is `emotion`.
+   */
   preset?: 'styled-components' | 'emotion' | 'goober' | 'stitches'
+  /**
+   * Visit `style={...}` props/attributes for classes.
+   */
   allowStyleProp?: boolean
+  /**
+   * The path to your Tailwind config. Also takes a TailwindConfig object.
+   */
   config?: string | Partial<TailwindConfig>
+  /**
+   * For packages like stitches, add a styled definition on css prop elements.
+   */
   convertHtmlElementToStyled?: boolean
+  /**
+   * Convert styled.[element] to a default syntax.
+   */
   convertStyledDot?: boolean
+  /**
+   * Add a prop to your elements in development so you can see the original cs prop classes, eg: `<div data-cs="maxWidth[1em]" />`.
+   */
   dataCsProp?: boolean | 'all'
+  /**
+   * Add a prop to jsx components in development showing the original tailwind classes. Use `"all"` to keep the prop in production.
+   */
   dataTwProp?: boolean | 'all'
+  /**
+   * Display information in your terminal about the Tailwind class conversions.
+   */
   debug?: boolean
+  /**
+   * Disable twin from reading values specified in the cs prop.
+   */
   disableCsProp?: boolean
+  /**
+   * Disable converting short css within the tw import/prop.
+   */
   disableShortCss?: boolean
+  /**
+   * Disable log colors to remove the glyphs when the color display is not supported.
+   */
   hasLogColors?: boolean
+  /**
+   * Look in className props for tailwind classes to convert.
+   */
   includeClassNames?: boolean
+  /**
+   * `@keyframes` are added next to the `animation-x` classes - this option can move them to global styles instead.
+   */
   moveKeyframesToGlobalStyles?: boolean
+  /**
+   * Move the tw prop to a styled definition.
+   */
   moveTwPropToStyled?: boolean
+  /**
+   * Some css-in-js frameworks require the `&` in selectors like `&:hover`, this option ensures it’s added.
+   */
   sassyPseudo?: boolean
+  /**
+   * This is the path to your config (stitches only).
+   */
   stitchesConfig?: string
+  /**
+   * Overwrite the css prop based import, eg: `import: 'css', from: '@emotion/react'`.
+   */
   css?: { import: string; from: string }
+  /**
+   * Overwrite the css prop based import, eg: `import: 'default', from: '@emotion/styled'`.
+   */
   styled?: { import: string; from: string }
+  /**
+   * Overwrite the css prop based import, eg: `import: 'Global', from: '@emotion/react'`.
+   */
   global?: { import: string; from: string }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,7 +77,7 @@ export type Config = {
    */
   convertHtmlElementToStyled?: boolean
   /**
-   * Convert styled.[element] to a default syntax.
+   * Convert `styled.[element]` to a default syntax.
    */
   convertStyledDot?: boolean
   /**
@@ -129,11 +129,11 @@ export type Config = {
    */
   css?: { import: string; from: string }
   /**
-   * Overwrite the css prop based import, eg: `import: 'default', from: '@emotion/styled'`.
+   * Overwrite the styled import, eg: `import: 'default', from: '@emotion/styled'`.
    */
   styled?: { import: string; from: string }
   /**
-   * Overwrite the css prop based import, eg: `import: 'Global', from: '@emotion/react'`.
+   * Overwrite the import used for global styles, eg: `import: 'Global', from: '@emotion/react'`.
    */
   global?: { import: string; from: string }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import { ComponentType } from 'react'
+import { Config as TailwindConfig } from 'tailwindcss'
 
 export interface TwStyle {
   [key: string]: string | number | TwStyle
@@ -57,9 +58,31 @@ declare global {
   }
 }
 
+// Docs: https://github.com/ben-rogerson/twin.macro/blob/master/docs/options.md
+export type Config = {
+  preset?: 'styled-components' | 'emotion' | 'goober' | 'stitches'
+  allowStyleProp?: boolean
+  config?: string | Partial<TailwindConfig>
+  convertHtmlElementToStyled?: boolean
+  convertStyledDot?: boolean
+  dataCsProp?: boolean | 'all'
+  dataTwProp?: boolean | 'all'
+  debug?: boolean
+  disableCsProp?: boolean
+  disableShortCss?: boolean
+  hasLogColors?: boolean
+  includeClassNames?: boolean
+  moveKeyframesToGlobalStyles?: boolean
+  moveTwPropToStyled?: boolean
+  sassyPseudo?: boolean
+  stitchesConfig?: string
+  css?: { import: string; from: string }
+  styled?: { import: string; from: string }
+  global?: { import: string; from: string }
+}
+
 declare const theme: ThemeFn
 declare const screen: ScreenFn
-
 declare const globalStyles: Record<string, unknown>
 
 export { theme, screen, globalStyles }


### PR DESCRIPTION
This PR adds config types for us to use within `babel-plugin-macros.config.js`:

```js
// babel-plugin-macros.config.js

// @ts-check
module.exports = {
  /** @type {import('twin.macro').Config} */
  twin: {
    preset: "styled-components",
  },
}
```