### PR TITLE
Fix `pieces.some is not a function` error

### DIFF
--- a/src/core/lib/convertClassName.ts
+++ b/src/core/lib/convertClassName.ts
@@ -87,12 +87,13 @@ function checkForVariantSupport({
   CoreContext,
   'tailwindConfig' | 'assert'
 >): void {
-  const pieces = splitAtTopLevelOnly(className, tailwindConfig.separator ?? ':')
-  const hasMultipleVariants = pieces.length > 2
-  const hasACommaInVariants = pieces.some(p => {
-    const splits = splitAtTopLevelOnly(p.slice(1, -1), ',')
-    return splits.length > 1
-  })
+  const pieces = [
+    ...splitAtTopLevelOnly(className, tailwindConfig.separator ?? ':'),
+  ]
+  const hasMultipleVariants = pieces.length > 2 // One is the class name
+  const hasACommaInVariants = pieces.some(
+    p => splitAtTopLevelOnly(p.slice(1, -1), ',').length > 1
+  )
   const hasIssue = hasMultipleVariants && hasACommaInVariants
   assert(
     !hasIssue,

--- a/src/core/lib/util/isShortCss.ts
+++ b/src/core/lib/util/isShortCss.ts
@@ -22,7 +22,7 @@ export default function isShortCss(
   // Normal class
   if (splitAtArbitrary[0].endsWith('-')) return false
 
-  // Important prefix
+  // Important suffix
   if (splitAtArbitrary[0].endsWith('!')) return false
 
   // Arbitrary property


### PR DESCRIPTION
This PR fixes an error when running an older version of tailwindcss alongside `twin.macro@3.0.1`.

Closes #761 