### PR TITLE
Add 'as' prop to types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "twin.macro",
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react'
+import { ComponentType, ElementType } from 'react'
 import { Config as TailwindConfig } from 'tailwindcss'
 
 export interface TwStyle {
@@ -26,7 +26,7 @@ export type ScreenFn = <T = string>(
 ) => (styles?: string | TemplateStringsArray | TwStyle | TwStyle[]) => T
 
 export type TwComponent<K extends keyof JSX.IntrinsicElements> = (
-  props: JSX.IntrinsicElements[K]
+  props: JSX.IntrinsicElements[K] & { as?: ElementType }
 ) => JSX.Element
 
 export type TwComponentMap = {

--- a/types/tests/basic/index.tsx
+++ b/types/tests/basic/index.tsx
@@ -52,3 +52,7 @@ const twProperty = (
 )
 
 const csProperty = <div cs="maxWidth[100%] height[calc(100vh - 1em)]" />
+const asProperty = <Button as="div" />
+
+// @ts-expect-error basic element doesn't provide as prop
+const asPropertyError = <p as="div" />

--- a/types/tests/emotion/index.tsx
+++ b/types/tests/emotion/index.tsx
@@ -26,3 +26,6 @@ export const ComposedLink2 = styled(Link)``
 
 export const cssProperty = <div css={tw`bg-red-100`} />
 export const csProperty = <div cs="maxWidth[100%] height[calc(100vh - 1em)]" />
+
+export const asProperty = <Link as="button" />
+export const asProperty2 = <Container as="button" />

--- a/types/tests/styled-components/index.tsx
+++ b/types/tests/styled-components/index.tsx
@@ -22,3 +22,6 @@ export const ComposedLink2 = styled(Link)``
 
 export const cssProperty = <div css={tw`bg-red-100`} />
 export const csProperty = <div cs="maxWidth[100%] height[calc(100vh - 1em)]" />
+
+export const asProperty = <Link as="button" />
+export const asProperty2 = <Container as="button" />


### PR DESCRIPTION
Add missing type for prop `as`. 

This removes the need for the workaround proposed here:
- https://github.com/ben-rogerson/twin.macro/issues/180

Also, it works better because the `as` prop is only available for styled components.

